### PR TITLE
Quote workflow-level meta and parameter_meta values

### DIFF
--- a/src/main/scala/dxWDL/WdlPrettyPrinter.scala
+++ b/src/main/scala/dxWDL/WdlPrettyPrinter.scala
@@ -264,8 +264,8 @@ case class WdlPrettyPrinter(fqnFlag: Boolean,
             case Some(outputs) => outputs
         }
         val outputs = wos.map(apply(_, level + 2)).flatten.toVector
-        val paramMeta = wf.parameterMeta.map{ case (x,y) =>  s"${x}: ${y}" }.toVector
-        val meta = wf.meta.map{ case (x,y) =>  s"${x}: ${y}" }.toVector
+        val paramMeta = wf.parameterMeta.map{ case (x,y) =>  s"""${x}: "${y}" """ }.toVector
+        val meta = wf.meta.map{ case (x,y) =>  s"""${x}: "${y}" """ }.toVector
 
         val lines = children ++
             buildBlock("output", outputs, level + 1, force=true) ++


### PR DESCRIPTION
The WDL spec says you can put `meta` and `parameter_meta` blocks in a `workflow`. But the WdlPrettyPrinter currently strips the quotes from the value. Then wdl4s is unhappy.

Here is a test WDL that this fixes:

```
task CountLines {
  File input_file

  command <<<
    wc -l ${input_file} | awk '{print $1}' > line.count
  >>>

  output {
    Int line_count = read_int("line.count")
  }
}

workflow CountLinesWorkflow {
  File input_file

  call CountLines {
    input: input_file=input_file
  }

  output {
    Int line_count=CountLines.line_count
  }

  parameter_meta {
      input_file: "a file that is input"
  }

  meta {
      this: "is allowed"
      even_some: "emoji should work  🌕 🌖 🌗 🌘 🌑 🌒 🌓 🌔"
  }
}
```