### PR TITLE
Allow SSD in disk specification.

### DIFF
--- a/src/main/scala/dxWDL/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/InstanceTypeDB.scala
@@ -280,7 +280,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
             case None => None
             case Some(WomString(buf)) =>
                 val components = buf.split("\\s+")
-                val ignoreWords = Set("local-disk", "hdd", "sdd")
+                val ignoreWords = Set("local-disk", "hdd", "sdd", "ssd")
                 val l = components.filter(x => !(ignoreWords contains x.toLowerCase))
                 if (l.length != 1)
                     throw new Exception(s"Can't parse disk space specification ${buf}")


### PR DESCRIPTION
I think SDD might have been a typo? At a minimum, it's somewhat intuitive that you'd say `local-disk 1000 SSD` in a runtime block :)