### PR TITLE
Allow version to be specified in docker script

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.79.1
+
+- Version [docker-based runner script](https://github.com/dnanexus/dxWDL/tree/master/scripts/compiler_image/dxwdl)
+- Do not call sudo in runner script, in case system is set up not to require
+  sudo to run Docker.
+- Rename run script to `dxwdl` for elegance
+
+```
+$ export DXWDL_VERSION=0.79.1
+$ sudo dxwdl compile /path/to/foo.wdl -project project-xxx
+```
+
 ## 0.79
 - Support [per task dx-attributes](./doc/ExpertOptions.md#Setting-dnanexus-specific-attributes-for-tasks).
 - Report a warning for a non-empty runtime section in a native applet, instead of throwing an error. Note
@@ -11,7 +23,7 @@ which is important in volume workflows.
 - A [docker image](https://hub.docker.com/r/dnanexus/dxwdl) for
 running the compiler without needing to install dependencies. You can
 use the
-[runc.sh](https://github.com/dnanexus/dxWDL/blob/native_docker/scripts/compiler_image/runc.sh)
+[dxwdl](https://github.com/dnanexus/dxWDL/tree/master/scripts/compiler_image/dxwdl)
 script to compile file `foo.wdl` like this:
 
 ```bash

--- a/scripts/compiler_image/dxwdl
+++ b/scripts/compiler_image/dxwdl
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 eval "$(dx env --bash)"
-sudo docker run \
+DXWDL_VERSION=${DXWDL_VERSION:-latest}  # stamped to specific current version on deploys
+echo $DXWDL_VERSION
+docker run \
      --rm \
      -e DX_SECURITY_CONTEXT="$DX_SECURITY_CONTEXT" \
      -e DX_APISERVER_PROTOCOL="$DX_APISERVER_PROTOCOL" \
@@ -9,4 +11,4 @@ sudo docker run \
      -e DX_PROJECT_CONTEXT_ID="$DX_PROJECT_CONTEXT_ID" \
      --volume "$PWD":/workdir \
      --workdir /workdir \
-     dnanexus/dxwdl "$@"
+     dnanexus/dxwdl:${DXWDL_VERSION} "$@"


### PR DESCRIPTION
Really excited about new docker changes! Took a quick glance and a had a small suggestion about dxwdl script.

- Version [docker-based runner script](https://github.com/dnanexus/dxWDL/blob/master/scripts/compiler_image/runc.sh)
- Do not call sudo in runner script, in case system is set up not to require
  sudo to run Docker.
- Rename run script to `dxwdl` for elegance

```
$ export DXWDL_VERSION=0.79.1
$ sudo dxwdl.sh compile /path/to/foo.wdl -project project-xxx
```