### PR TITLE
Documentation for output section limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ and compiles it to an equivalent workflow on the DNAnexus platform.
 It provides a reasonably complete set of WDL features.
 WDL draft-2 is supported, with a few exceptions:
 * Calls with missing arguments have limited support
-* The ouput section:
-1. does not support expressions
-2. requires full definitions. For example:
+* The output section does not allow expressions, and requires full definitions. For example:
 ```wdl
 workflow foo {
   output {
@@ -17,7 +15,7 @@ workflow foo {
 }
 ```
 
-Instead of
+instead of:
 ```wdl
 workflow foo {
   output {

--- a/README.md
+++ b/README.md
@@ -5,13 +5,32 @@ dxWDL takes a bioinformatics pipeline written in the
 and compiles it to an equivalent workflow on the DNAnexus platform.
 It provides a reasonably complete set of WDL features.
 WDL draft-2 is supported, with a few exceptions:
-* Expressions in the output section are not allowed
 * Calls with missing arguments have limited support
+* The ouput section:
+1. does not support expressions
+2. requires full definitions. For example:
+```wdl
+workflow foo {
+  output {
+     String result = bar
+  }
+}
+```
+
+Instead of
+```wdl
+workflow foo {
+  output {
+     bar
+  }
+}
+```
 
 # Ongoing
 Work has started on supporting WDL version 1.0 using the WOM scala library,
 that is part of [Cromwell](https://github.com/broadinstitute/cromwell). A high level
 list of changes between draft-2 and version 1.0 is provided [here](doc/WdlVersionChanges.md).
+We plan to remove the limitations on the output section.
 
 ## Setup
 Prerequisites: DNAnexus platform account, dx-toolkit, java 8+, python 2.7.
@@ -43,8 +62,8 @@ workflow bam_chrom_counter {
         }
     }
     output {
-        slice_bam.bai
-        count_bam.count
+        File bai = slice_bam.bai
+        Int count = count_bam.count
     }
 }
 


### PR DESCRIPTION
The output section has to have full definitions. This has been documented at the beginning of the README.md file.