### PR TITLE
update dx-toolkit version

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -4,8 +4,8 @@ FROM ubuntu:16.04
 
 # 1. DNANexus SDK (dx-toolkit)
 RUN apt-get update && apt-get install -y wget git openssl python python-dev g++ default-jdk
-RUN wget https://wiki.dnanexus.com/images/files/dx-toolkit-v0.255.0-ubuntu-14.04-amd64.tar.gz && \
-    tar -xzvf dx-toolkit-v0.255.0-ubuntu-14.04-amd64.tar.gz && \
+RUN wget https://wiki.dnanexus.com/images/files/dx-toolkit-v0.275.0-ubuntu-16.04-amd64.tar.gz && \
+    tar -xzvf dx-toolkit-v0.275.0-ubuntu-16.04-amd64.tar.gz && \
     /bin/bash -c "source /dx-toolkit/environment"  
 ENV PATH /dx-toolkit/bin:$PATH
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH $PATH:/dnanexus-upload-agent-1.5.30-linux
 
 # dxWDL
 WORKDIR /
-ARG DXWDL_VERSION=0.78
+ARG DXWDL_VERSION=0.79.1
 RUN wget https://github.com/dnanexus/dxWDL/releases/download/$DXWDL_VERSION/dxWDL-$DXWDL_VERSION.jar && \
     chmod +x dxWDL-$DXWDL_VERSION.jar && mv dxWDL-$DXWDL_VERSION.jar dxWDL.jar
 


### PR DESCRIPTION
update dx-toolkit to 0.275 which supports private docker repos