### PR TITLE
Ensure hostname is job ID with native docker

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.81.6
+
+- Ensure that native docker uses the machine's hostname (i.e., the job ID) as
+  the hostname, matching the previous behavior of dx-docker.  This allows
+  setting the job ID in error messages, helping debugging.
+
 ## 0.81.5
 - Adding debug information to conversions from JSON to WDL variables. This helps
 track down runtime problems with missing variables that a task is expecting. Previously,

--- a/doc/Tips.md
+++ b/doc/Tips.md
@@ -67,8 +67,11 @@ workflow show_error {
 
 task make_error {
     command <<<
-        echo '{"error": {"type": "AppError", "message": "x must be at least 2"}}' > job_error.json
+        echo '{"error": {"type": "AppError", "message": "x must be at least 2' $(hostname)'"}}' > job_error.json
         exit 1
     >>>
 }
 ```
+
+(including the hostname in the error message allows the message to have the root
+job ID, facilitating debugging in complex workflows that may be deeply nested.)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -70,6 +70,7 @@ medium_test_list = [
     "private_registry",
     "native_docker_file_image",
     "samtools_count",
+    "hostname_is_jobid",
 
     # Setting defaults for tasks, not just workflows
     "population",

--- a/src/main/scala/dxWDL/runner/Task.scala
+++ b/src/main/scala/dxWDL/runner/Task.scala
@@ -533,6 +533,8 @@ case class Task(task:WdlTask,
         // we can reach the result files, and upload them to
         // the platform.
         val DX_HOME = Utils.DX_HOME
+        // ensure that docker hostname is the job ID to match existing
+        // dx-docker behavior and allow users to report errors more easily.
         val dockerRunScript =
             s"""|#!/bin/bash -ex
                 |
@@ -540,10 +542,10 @@ case class Task(task:WdlTask,
                 |
                 |extraFlags=""
                 |if [ $${DOCKER_CMD} == "docker" ]; then
-                |    # Run the container under the dnanexus user, so it will have permissions to read/write
-                |    # files in the home directory. This is required in cases where the container uses a
-                |    # different user.
-                |    extraFlags="--user $$(id -u):$$(id -g)"
+                |    # 1. Run the container under the dnanexus user, so it will have permissions to read/write
+                |    #    files in the home directory (e.g., when container uses a different user).
+                |    # 2. Set hostname to outer hostname to allow error reporting based on dx job ID.
+                |    extraFlags="--user $$(id -u):$$(id -g) --hostname $$(hostname)"
                 |fi
                 |
                 |$${DOCKER_CMD} run $${extraFlags} --entrypoint /bin/bash -v ${DX_HOME}:${DX_HOME} ${imgName} $${HOME}/execution/meta/script

--- a/test/docker/hostname_is_jobid.wdl
+++ b/test/docker/hostname_is_jobid.wdl
@@ -1,0 +1,27 @@
+# show that hostname is actually job ID for easier debugging of jobs
+# assert should look like hostname.startswith('job-')
+task example {
+    command <<<
+    python <<'EOF'
+import json
+import os
+import socket
+import subprocess
+hostname = socket.gethostname()
+print('Found hostname %r' % hostname)
+job_id = subprocess.check_output(['bash', '-c', 'source environment && echo $DX_JOB_ID']).strip()
+if not job_id:
+    raise ValueError('could not find job ID :(')
+if hostname != job_id:
+    with open('job_error.json', 'w') as fp:
+        json.dump({"error": {"type": "AppError", "message": "Expected hostname to be job id. Got %r instead :(" % hostname}}, fp)
+    raise ValueError('hostname %r did not match job id %r' % (hostname, job_id))
+EOF
+    >>>
+    runtime {
+        docker: "broadinstitute/genomes-in-the-cloud:2.2.4-1469632282"
+    }
+    output {
+        String hostname = read_string(stdout())
+    }
+}


### PR DESCRIPTION
@orodeh 

Changes:

1. Pass through using `--hostname` parameter of `docker run`
2. Add test case that checks this (confirms this currently passes with `dx-docker` and currently fails with `docker`).

Context:  With `dx-docker`, the hostname is the DNAnexus job ID, making it easy(ish) to provide useful error information back in complex scatters where the overall system will pick the wrong job as the failure source.  See https://github.com/dnanexus/dxWDL/issues/213 for more details. 

I have not been able to test this end to end (don't have a scala compiler on laptop), but hopefully I've hooked it together enough that you're able to test and run this.