### PR TITLE
FindDataObjects: Correctly represent recurse == false

### DIFF
--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -110,7 +110,7 @@ case class DxFindDataObjects(limit: Option[Int],
             if (recurse)
                 Map("recurse" -> JsBoolean(true))
             else
-                Map.empty
+                Map("recurse" -> JsBoolean(false))
         JsObject(part1 ++ part2 ++ part3)
     }
 


### PR DESCRIPTION
I noticed that lookups for workflows and applets in the current folder seemed to have too high of a count (as if they were grabbing everything in the archive too). From findDataObjects API docs:

```
recurse boolean (optional, default true) Whether the search should be performed recursively on subfolders as well
```

So we need to set `recurse` explicitly to `false` to use API correctly and have results return back faster.

I think this should help quite a bit for workflows, where we've been seeing 16-30s look up times when someone reuses the same path over and over :)