### PR TITLE
Support object form of 'stream' annotation in parameter_meta

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -65,7 +65,10 @@ wdl_v1_list = [
 
     # Missing optional output files, returned as none, instead
     # of an error
-    "missing_optional_output_file"
+    "missing_optional_output_file",
+
+    # streaming
+    "streaming_inputs"
 ]
 
 # docker image tests

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "v1.36"
+    version = "v1.37"
 }
 
 #

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "v1.37"
+    version = "v1.36.1"
 }
 
 #

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -283,6 +283,10 @@ case class JobInputOutput(dxIoFunctions : DxIoFunctions,
                         case (Some(MetaValueElement.MetaValueElementString("stream"))) =>
                             findFiles(womValue)
                         case (Some(MetaValueElement.MetaValueElementObject(value))) =>
+                            // This enables the stream annotation in the object form of metadata value, e.g.
+                            // bam_file : {
+                            //   stream : true
+                            // }
                             if (value.contains("stream") && 
                                 value("stream").asInstanceOf[MetaValueElement.MetaValueElementBoolean].value) {
                                 findFiles(womValue)

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -282,6 +282,12 @@ case class JobInputOutput(dxIoFunctions : DxIoFunctions,
                     parameterMeta.get(iDef.name) match {
                         case (Some(MetaValueElement.MetaValueElementString("stream"))) =>
                             findFiles(womValue)
+                        case (Some(MetaValueElement.MetaValueElementObject(value))) =>
+                            if (value.getOrElse("stream", false)) {
+                                findFiles(womValue)
+                            } else {
+                                Vector.empty
+                            }
                         case _ =>
                             Vector.empty
                     }

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -283,7 +283,8 @@ case class JobInputOutput(dxIoFunctions : DxIoFunctions,
                         case (Some(MetaValueElement.MetaValueElementString("stream"))) =>
                             findFiles(womValue)
                         case (Some(MetaValueElement.MetaValueElementObject(value))) =>
-                            if (value.getOrElse("stream", false)) {
+                            if (value.contains("stream") && 
+                                value("stream").asInstanceOf[MetaValueElement.MetaValueElementBoolean].value) {
                                 findFiles(womValue)
                             } else {
                                 Vector.empty

--- a/src/test/resources/compiler/streaming_files_obj.wdl
+++ b/src/test/resources/compiler/streaming_files_obj.wdl
@@ -1,0 +1,47 @@
+version 1.0
+
+# Marking files as streaming should succeed. Marking
+# non files should fail.
+
+# Correct
+task cgrep {
+    input {
+        String pattern
+        File in_file
+    }
+    parameter_meta {
+        in_file : {
+            stream : true
+        }
+    }
+    command {
+        grep '${pattern}' ${in_file} | wc -l
+    }
+    output {
+        Int count = read_int(stdout())
+    }
+}
+
+task diff {
+    input {
+        File a
+        File b
+    }
+    parameter_meta {
+        a : {
+            stream : true
+        }
+        b : {
+            stream : true
+        }
+    }
+    runtime {
+        docker: "ubuntu:16.04"
+    }
+    command {
+        diff ${a} ${b} | wc -l
+    }
+    output {
+        Int result = read_int(stdout())
+    }
+}

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -301,6 +301,27 @@ class GenerateIRTest extends FlatSpec with Matchers {
                                              "b" -> MetaValueElement.MetaValueElementString("stream")))
     }
 
+    it should "recognize the streaming object annotation" in {
+        val path = pathFromBasename("compiler", "streaming_files_obj.wdl")
+        val retval = Main.compile(
+            path.toString :: cFlags
+        )
+        retval shouldBe a [Main.SuccessfulTerminationIR]
+        val bundle = retval match {
+            case Main.SuccessfulTerminationIR(ir) => ir
+            case _ => throw new Exception("sanity")
+        }
+
+        val cgrepTask = getTaskByName("cgrep", bundle)
+        cgrepTask.parameterMeta shouldBe (Map("in_file" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+        val iDef = cgrepTask.inputs.find(_.name == "in_file").get
+        iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+
+        val diffTask = getTaskByName("diff", bundle)
+        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true)),
+                                             "b" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+    }
+
     it should "recognize the streaming annotation for wdl draft2" in {
         val path = pathFromBasename("draft2", "streaming.wdl")
         val retval = Main.compile(

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -313,13 +313,13 @@ class GenerateIRTest extends FlatSpec with Matchers {
         }
 
         val cgrepTask = getTaskByName("cgrep", bundle)
-        cgrepTask.parameterMeta shouldBe (Map("in_file" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+        cgrepTask.parameterMeta shouldBe (Map("in_file" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
         val iDef = cgrepTask.inputs.find(_.name == "in_file").get
-        iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+        iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
 
         val diffTask = getTaskByName("diff", bundle)
-        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true)),
-                                             "b" -> MetaValueElement.MetaValueElementObject(Map("stream" -> true))))
+        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))),
+                                             "b" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
     }
 
     it should "recognize the streaming annotation for wdl draft2" in {

--- a/test/wdl_1_0/streaming_inputs.wdl
+++ b/test/wdl_1_0/streaming_inputs.wdl
@@ -1,0 +1,47 @@
+version 1.0
+
+workflow streaming_inputs {
+    input {
+         File f1
+         File f2
+    }
+
+    call test_streaming {
+        input:
+            f1=f1,
+            f2=f2
+    }
+
+    output {
+        String r1 = test_streaming.r1
+        String r2 = test_streaming.r2
+    }
+}
+
+task test_streaming {
+    input {
+        File f1
+        File f2
+    }
+
+    command <<<
+    zcat ~{f1} > r1
+    zcat ~{f2} > r2
+    >>>
+
+    output {
+        File r1 = "r1"
+        File r2 = "r2"
+    }
+
+    runtime {
+        docker: "debian:stretch-slim"
+    }
+
+    parameter_meta {
+        f1: "stream"
+        f2: {
+            stream: true
+        }
+    }
+}

--- a/test/wdl_1_0/streaming_inputs_input.json
+++ b/test/wdl_1_0/streaming_inputs_input.json
@@ -1,0 +1,4 @@
+{
+    "streaming_inputs.f1": "dx://dxWDL_playground:/test_data/f1.txt.gz",
+    "streaming_inputs.f2": "dx://dxWDL_playground:/test_data/f2.txt.gz"
+}

--- a/test/wdl_1_0/streaming_inputs_output.json
+++ b/test/wdl_1_0/streaming_inputs_output.json
@@ -1,0 +1,4 @@
+{
+    "streaming_inputs.r1": "foo",
+    "streaming_inputs.r2": "bar"
+}


### PR DESCRIPTION
Add support for recognizing the "stream" annotation in an object value of a parameter_meta key:

```
parameter_meta {
  foo: {
    stream: true
  }
}
```