### PR TITLE
Check if -locked supplied with reorg field in extras.json 

### DIFF
--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -363,11 +363,19 @@ object Main extends App {
         }
 
         if ( extras != None ) {
+
             if (extras.contains("reorg")  && (options contains "reorg")) {
 
                 throw new InvalidInputException("ERROR: cannot provide --reorg option when reorg is specified in extras.")
 
             }
+
+            if (extras.contains("reorg") && (options contains "locked")) {
+
+                throw new InvalidInputException("ERROR: cannot provide --locked option when reorg is specified in extras.")
+
+            }
+
         }
 
         CompilerOptions(options contains "archive",


### PR DESCRIPTION
Added check for if reorg is provided in extras.json and -locked in provided for the dxWDL workflow compile command. If it is then throw an InvalidInputException, otherwise proceed. 