### PR TITLE
Feature/fix reorg issue

### DIFF
--- a/scripts/build_all_releases.sh
+++ b/scripts/build_all_releases.sh
@@ -54,17 +54,17 @@ function tag {
 
 function build {
     # build the release on staging
-#    echo "building staging release"
-#    dx login --staging --token $staging_token --noprojects
-#    $top_dir/scripts/build_release.py --multi-region $build_flags
-#
-#    ## test that it actually works
-#    echo "running multi region tests on staging"
-#    $top_dir/scripts/multi_region_tests.py
-#    $top_dir/scripts/proxy_test.py
-#
-#    echo "leave staging"
-#    dx clearenv
+    echo "building staging release"
+    dx login --staging --token $staging_token --noprojects
+    $top_dir/scripts/build_release.py --multi-region $build_flags
+
+    ## test that it actually works
+    echo "running multi region tests on staging"
+    $top_dir/scripts/multi_region_tests.py
+    $top_dir/scripts/proxy_test.py
+
+    echo "leave staging"
+    dx clearenv
 
     ## build on production
     echo "building on production"

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -683,7 +683,7 @@ object Extras {
         // FIXME: this shouldn't be printed out when running tests. During tests, nothing should
         // be printed out, some software relies on this assumption.
         Utils.trace(
-            true,
+            verbose.on,
             s"""|Writing your own applet for reorganization purposes is tricky. If you are not careful,
                 |it may misplace or outright delete files.
                 |The applet: ${reorgAppId} requires CONTRIBUTE project access,

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -41,8 +41,8 @@ object Utils {
     val MAX_NUM_FILES_MOVE_LIMIT = 1000
     val UBUNTU_VERSION = "16.04"
     val VERSION_PROP = "dxWDL_version"
-    val REORG_CONFIG = "___reorg_conf"
-    val REORG_STATUS = "___reorg_status"
+    val REORG_CONFIG = "reorg_conf___"
+    val REORG_STATUS = "reorg_status___"
     val REORG_STATUS_COMPLETE = "completed"
 
 

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -123,8 +123,8 @@ case class GenerateIR(verbose: Verbose,
                                                                           callablesUsedInWorkflow)
 
         val gir = new GenerateIRWorkflow(
-            wf, wfSource, wfSourceStandAlone, callsLoToHi, callables, language, verbose, reorg)
-        gir.apply(locked)
+            wf, wfSource, wfSourceStandAlone, callsLoToHi, callables, language, verbose, locked, reorg)
+        gir.apply()
     }
 
     // Entry point for compiling tasks and workflows into IR

--- a/src/test/resources/compiler/wf_custom_reorg.wdl
+++ b/src/test/resources/compiler/wf_custom_reorg.wdl
@@ -1,8 +1,10 @@
+
 version 1.0
 
 workflow test_reorg {
 
     call stage_one
+
 
     output {
         File output_file = stage_one.output_file
@@ -14,8 +16,7 @@ workflow test_reorg {
 task stage_one {
 
     command <<<
-        set -euxo pipefail
-
+        set -euxo pipefai
         touch output_file && echo "This is the output file" >> output_file
         touch output_config_file && echo "This is the output config file" >> output_config_file
     >>>

--- a/src/test/resources/subworkflows/trains.wdl
+++ b/src/test/resources/subworkflows/trains.wdl
@@ -15,8 +15,7 @@ workflow trains {
         }
     }
 
-    Array[String] f_results = flatten(check_route.result)
     output {
-        Array[String] results = f_results
+        Array[String] results = flatten(check_route.result)
     }
 }

--- a/src/test/resources/subworkflows/trains_station.wdl
+++ b/src/test/resources/subworkflows/trains_station.wdl
@@ -1,0 +1,20 @@
+
+version 1.0
+
+import "trains.wdl"
+
+
+workflow trains_station {
+    input {}
+
+    call trains.trains {
+        input:
+            prefixes=["a", "b"],
+            ranges=["1", "2"]
+    }
+
+    output {
+        Array[String] out = trains.results
+    }
+}
+

--- a/src/test/scala/dxWDL/base/ExtrasTest.scala
+++ b/src/test/scala/dxWDL/base/ExtrasTest.scala
@@ -326,7 +326,6 @@ class ExtrasTest extends FlatSpec with Matchers {
   it should "throw IllegalArgumentException due to invalid file ID" in {
 
     // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-
     val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
     val inputs : String = "file-1223445"
     val reorg : JsValue =

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -690,6 +690,6 @@ class GenerateIRTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
         // this is a subworkflow so there is no reorg_status___ added.
         val trainsOutputVector: IR.Callable = bundle.allCallables("trains")
-        trainsOutputVector.outputVars.size shouldBe 2
+        trainsOutputVector.outputVars.size shouldBe 1
     }
 }

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -1,5 +1,6 @@
 package dxWDL.compiler
 
+import java.io.{BufferedWriter, File, FileWriter}
 import java.nio.file.{Path, Paths}
 
 import org.scalatest.{FlatSpec, Matchers}
@@ -25,6 +26,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     val TEST_PROJECT = "dxWDL_playground"
+
     lazy val dxTestProject =
         try {
             DxPath.resolveProject(TEST_PROJECT)
@@ -40,13 +42,20 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
                            "-locked",
                            "-quiet")
 
+    lazy private val cFlagsReorg = List(
+        "-compileMode", "NativeWithoutRuntimeAsset",
+        "--project", dxTestProject.getId,
+        "-quiet",  "--folder", "/reorg_tests")
+
     override def beforeAll() : Unit = {
         // building necessary applets before starting the tests
         val native_applets = Vector("native_concat",
                                     "native_diff",
                                     "native_mk_list",
                                     "native_sum",
-                                    "native_sum_012")
+                                    "native_sum_012",
+                                    "functional_reorg_test"
+        )
         val topDir = Paths.get(System.getProperty("user.dir"))
         native_applets.foreach { app =>
             try {
@@ -57,6 +66,29 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
             }
         }
     }
+
+    private def getAppletId(path: String): String = {
+        val (app_stdout, app_stderr) = Utils.execCommand(
+            s"dx describe $path --json")
+
+        app_stdout.parseJson.asJsObject.fields.get("id") match {
+            case Some(JsString(x)) => x
+            case other => throw new Exception(s"Unexpected result ${other}")
+        }
+    }
+
+    private def createExtras(extrasContent: String): String = {
+
+        val tmp_extras = File.createTempFile("reorg-", ".json")
+        tmp_extras.deleteOnExit()
+
+        val bw = new BufferedWriter(new FileWriter(tmp_extras))
+        bw.write(extrasContent)
+        bw.close()
+
+        tmp_extras.toString
+    }
+
 
 
     it should "Native compile a single WDL task" taggedAs(NativeTestXX) in {
@@ -128,7 +160,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         val content = Source.fromFile(outputPath).getLines.mkString("\n")
 
         val tasks : Map[String, String] = ParseWomSourceFile(false).scanForTasks(content)
-        tasks.keys shouldBe(Set("native_sum", "native_sum_012", "native_mk_list", "native_diff", "native_concat"))
+        tasks.keys shouldBe(
+            Set("native_sum", "native_sum_012", "functional_reorg_test", "native_mk_list", "native_diff", "native_concat"))
     }
 
     it should "be able to include license information in details" in {
@@ -258,5 +291,146 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
         //System.out.println(s"instanceType = ${instanceType}")
         instanceType should include ("_gpu")
+    }
+
+    it should "Compile a workflow with subworkflows on the platform with the reorg app" taggedAs(EdgeTest) in {
+        val path = pathFromBasename("subworkflows", basename="trains_station.wdl")
+        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+        val extrasContent =
+            s"""|{
+                | "custom_reorg" : {
+                |    "app_id" : "${appletId}",
+                |    "conf" : null
+                |  }
+                |}
+                |""".stripMargin
+
+        val tmpFile= createExtras(extrasContent)
+        // remove locked workflow flag
+        val retval = Main.compile(
+            path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+        )
+        retval shouldBe a [Main.SuccessfulTermination]
+        val wfId: String = retval match {
+            case Main.SuccessfulTermination(ir) => ir
+            case _ => throw new Exception("sanity")
+        }
+
+        val (stdout, stderr) = Utils.execCommand(s"dx describe ${wfId} --json")
+
+        val wfStages = stdout.parseJson.asJsObject.fields.get("stages") match {
+            case Some(JsArray(x)) => x.toVector
+            case other => throw new Exception(s"Unexpected result ${other}")
+        }
+
+        // there should be 4 stages: 1) common 2) train_stations 3) outputs 4) reorg
+        wfStages.size shouldBe 4
+
+        val reorgStage = wfStages.last
+
+        // if its not a JsObject return empty string and test will fail
+        val reorgDetails = reorgStage match {
+            case JsObject(x) => JsObject(x)
+            case _ => throw new Exception("sanity")
+        }
+
+        reorgDetails.getFields("id", "executable") shouldBe Seq(
+            JsString("stage-reorg"), JsString(s"${appletId}")
+        )
+        // There should be 3 inputs, the output from output stage and the custom reorg config file.
+        val reorgInput: JsObject = reorgDetails.fields("input") match {
+            case JsObject(x) => JsObject(x)
+            case _ => throw new Exception("sanity")
+        }
+
+        // no reorg conf input. only status.
+        reorgInput.fields.size shouldBe 1
+        reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS)
+    }
+
+    // ignore for now as the test will fail in staging
+    it should "Compile a workflow with subworkflows on the platform with the reorg app with config file in the input" taggedAs(EdgeTest) in {
+        // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
+        val path = pathFromBasename("subworkflows", basename="trains_station.wdl")
+        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+        // upload random file
+        val (uploadOut, uploadErr) = Utils.execCommand(
+            s"dx upload ${path.toString} --destination /reorg_tests --brief"
+        )
+        val fileId = uploadOut.trim
+        val extrasContent =
+            s"""|{
+                | "custom_reorg" : {
+                |    "app_id" : "${appletId}",
+                |    "conf" : "dx://$fileId"
+                |  }
+                |}
+                |""".stripMargin
+
+        val tmpFile= createExtras(extrasContent)
+        // remove locked workflow flag
+        val retval = Main.compile(
+            path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+        )
+
+        retval shouldBe a [Main.SuccessfulTermination]
+        val wfId: String = retval match {
+            case Main.SuccessfulTermination(wfId) => wfId
+            case _ => throw new Exception("sanity")
+        }
+
+        val (stdout, stderr) = Utils.execCommand(s"dx describe ${wfId} --json")
+
+        val wfStages = stdout.parseJson.asJsObject.fields.get("stages") match {
+            case Some(JsArray(x)) => x.toVector
+            case other => throw new Exception(s"Unexpected result ${other}")
+        }
+
+        val reorgStage = wfStages.last
+
+        val reorgDetails = reorgStage match {
+            case JsObject(x) => JsObject(x)
+            case _ => throw new Exception("sanity")
+        }
+
+        // There should be 3 inputs, the output from output stage and the custom reorg config file.
+        val reorgInput: JsObject = reorgDetails.fields("input") match {
+            case JsObject(x) => JsObject(x)
+            case _ => throw new Exception("sanity")
+        }
+        // no reorg conf input. only status.
+        reorgInput.fields.size shouldBe 2
+        reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS, Utils.REORG_CONFIG)
+    }
+    it should "Checks subworkflow with custom reorg app do not contain reorg attribute" taggedAs(EdgeTest) in {
+        // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
+        val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+        // upload random file
+        val extrasContent =
+            s"""|{
+                | "custom_reorg" : {
+                |    "app_id" : "${appletId}",
+                |    "conf" : null
+                |  }
+                |}
+                |""".stripMargin
+
+        val tmpFile = createExtras(extrasContent)
+
+        // remove compile mode
+        val retval = Main.compile(
+            path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg.drop(2)
+        )
+        retval shouldBe a [Main.SuccessfulTerminationIR]
+
+        val bundle = retval match {
+            case Main.SuccessfulTerminationIR(bundle) => bundle
+            case _ => throw new Exception("sanity")
+        }
+
+        // this is a subworkflow so there is no reorg_status___ added.
+        val trainsOutputVector: IR.Callable = bundle.allCallables("trains")
+        trainsOutputVector.outputVars.size shouldBe 1
     }
 }

--- a/test/applets/functional_reorg_test/code.py
+++ b/test/applets/functional_reorg_test/code.py
@@ -12,7 +12,7 @@ def create_folder(container, folder_name):
 
 
 @dxpy.entry_point('main')
-def main(___reorg_conf=None, ___reorg_status=None):
+def main(reorg_conf___=None, reorg_status___=None):
 
     job_describe = dxpy.describe(dxpy.JOB_ID)
     analysis_id = job_describe["analysis"]

--- a/test/applets/functional_reorg_test/dxapp.json
+++ b/test/applets/functional_reorg_test/dxapp.json
@@ -5,7 +5,7 @@
   "dxapi": "1.0.0",
   "inputSpec": [
     {
-      "name": "___reorg_conf",
+      "name": "reorg_conf___",
       "label": "Config",
       "help": "",
       "class": "file",
@@ -13,7 +13,7 @@
       "optional": true
     },
     {
-      "name": "___reorg_status",
+      "name": "reorg_status___",
       "label": "Config",
       "help": "",
       "class": "string",


### PR DESCRIPTION
@orodeh, I have made the fix for the reorg applet with subworkflow. Could you take a look and let me know if there are any issues...

I did not fix Extras.scala's comment block on using scala/java instead of dx as you mentioned that there will changes to DX Java. I will make those changes once it is ready. 

Changes:

1. Change variable name:
```
___reorg_status -> reorg_status___
___reorg_config -> reorg_config___
```
2. Subworkflows no longer generate __reorg_status as output
3. `locked` is now a member of `GeneratedIRWorkflow`
4. Update tests

