### PR TITLE
Migrate to Scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+align = more    // For pretty alignment.
+maxColumn = 100 // For my wide 30" display.

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,6 @@
-maxColumn = 100 // For my wide 30" display.
+version = "2.3.2"
+continuationIndent.callSite = 4
+continuationIndent.defnSite = 4
+align.openParenCallSite = true
+align.openParenDefnSite = true
+maxColumn = 100

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,1 @@
-align = more    // For pretty alignment.
 maxColumn = 100 // For my wide 30" display.

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -6,15 +6,23 @@ import sbtassembly.{MergeStrategy, PathList}
 
 object Merging {
   val customMergeStrategy: Def.Initialize[String => MergeStrategy] = Def.setting {
-    case PathList(ps@_*) if ps.last == "project.properties" =>
+    case PathList(ps @ _*) if ps.last == "project.properties" =>
       // Merge/Filter project.properties files from Google jars that otherwise collide at merge time.
       MergeStrategy.filterDistinctLines
-    case PathList(ps@_*) if ps.last == "logback.xml" =>
+    case PathList(ps @ _*) if ps.last == "logback.xml" =>
       MergeStrategy.first
     // AWS SDK v2 configuration files - can be discarded
-    case PathList(ps@_*) if Set("codegen.config" , "service-2.json" , "waiters-2.json" , "customization.config" , "examples-1.json" , "paginators-1.json").contains(ps.last) =>
+    case PathList(ps @ _*)
+        if Set(
+          "codegen.config",
+          "service-2.json",
+          "waiters-2.json",
+          "customization.config",
+          "examples-1.json",
+          "paginators-1.json"
+        ).contains(ps.last) =>
       MergeStrategy.discard
-    case x@PathList("META-INF", path@_*) =>
+    case x @ PathList("META-INF", path @ _*) =>
       path map {
         _.toLowerCase
       } match {
@@ -28,7 +36,7 @@ object Merging {
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)
       }
-    case x@PathList("OSGI-INF", path@_*) =>
+    case x @ PathList("OSGI-INF", path @ _*) =>
       path map {
         _.toLowerCase
       } match {

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,12 +15,12 @@ object Merging {
       // AWS SDK v2 configuration files - can be discarded
       case PathList(ps @ _*)
           if Set(
-            "codegen.config",
-            "service-2.json",
-            "waiters-2.json",
-            "customization.config",
-            "examples-1.json",
-            "paginators-1.json"
+              "codegen.config",
+              "service-2.json",
+              "waiters-2.json",
+              "customization.config",
+              "examples-1.json",
+              "paginators-1.json"
           ).contains(ps.last) =>
         MergeStrategy.discard
       case x @ PathList("META-INF", path @ _*) =>

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -5,53 +5,54 @@ import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.{MergeStrategy, PathList}
 
 object Merging {
-  val customMergeStrategy: Def.Initialize[String => MergeStrategy] = Def.setting {
-    case PathList(ps @ _*) if ps.last == "project.properties" =>
-      // Merge/Filter project.properties files from Google jars that otherwise collide at merge time.
-      MergeStrategy.filterDistinctLines
-    case PathList(ps @ _*) if ps.last == "logback.xml" =>
-      MergeStrategy.first
-    // AWS SDK v2 configuration files - can be discarded
-    case PathList(ps @ _*)
-        if Set(
-          "codegen.config",
-          "service-2.json",
-          "waiters-2.json",
-          "customization.config",
-          "examples-1.json",
-          "paginators-1.json"
-        ).contains(ps.last) =>
-      MergeStrategy.discard
-    case x @ PathList("META-INF", path @ _*) =>
-      path map {
-        _.toLowerCase
-      } match {
-        case "spring.tooling" :: xs =>
-          MergeStrategy.discard
-        case "io.netty.versions.properties" :: Nil =>
-          MergeStrategy.first
-        case "maven" :: "com.google.guava" :: xs =>
-          MergeStrategy.first
-        case _ =>
-          val oldStrategy = (assemblyMergeStrategy in assembly).value
-          oldStrategy(x)
-      }
-    case x @ PathList("OSGI-INF", path @ _*) =>
-      path map {
-        _.toLowerCase
-      } match {
-        case "l10n" :: "bundle.properties" :: Nil =>
-          MergeStrategy.concat
-        case _ =>
-          val oldStrategy = (assemblyMergeStrategy in assembly).value
-          oldStrategy(x)
-      }
-    case "asm-license.txt" | "module-info.class" | "overview.html" | "cobertura.properties" =>
-      MergeStrategy.discard
-    case PathList("mime.types") =>
-      MergeStrategy.last
-    case x =>
-      val oldStrategy = (assemblyMergeStrategy in assembly).value
-      oldStrategy(x)
-  }
+  val customMergeStrategy: Def.Initialize[String => MergeStrategy] =
+    Def.setting {
+      case PathList(ps @ _*) if ps.last == "project.properties" =>
+        // Merge/Filter project.properties files from Google jars that otherwise collide at merge time.
+        MergeStrategy.filterDistinctLines
+      case PathList(ps @ _*) if ps.last == "logback.xml" =>
+        MergeStrategy.first
+      // AWS SDK v2 configuration files - can be discarded
+      case PathList(ps @ _*)
+          if Set(
+            "codegen.config",
+            "service-2.json",
+            "waiters-2.json",
+            "customization.config",
+            "examples-1.json",
+            "paginators-1.json"
+          ).contains(ps.last) =>
+        MergeStrategy.discard
+      case x @ PathList("META-INF", path @ _*) =>
+        path map {
+          _.toLowerCase
+        } match {
+          case "spring.tooling" :: xs =>
+            MergeStrategy.discard
+          case "io.netty.versions.properties" :: Nil =>
+            MergeStrategy.first
+          case "maven" :: "com.google.guava" :: xs =>
+            MergeStrategy.first
+          case _ =>
+            val oldStrategy = (assemblyMergeStrategy in assembly).value
+            oldStrategy(x)
+        }
+      case x @ PathList("OSGI-INF", path @ _*) =>
+        path map {
+          _.toLowerCase
+        } match {
+          case "l10n" :: "bundle.properties" :: Nil =>
+            MergeStrategy.concat
+          case _ =>
+            val oldStrategy = (assemblyMergeStrategy in assembly).value
+            oldStrategy(x)
+        }
+      case "asm-license.txt" | "module-info.class" | "overview.html" | "cobertura.properties" =>
+        MergeStrategy.discard
+      case PathList("mime.types") =>
+        MergeStrategy.last
+      case x =>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    }
 }

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -96,10 +96,10 @@ object Main extends App {
     ): Unit = {
       if (expectedNumArgs != subargs.length)
         throw new Exception(
-          s"""|Wrong number of arguments for ${keyword}.
+            s"""|Wrong number of arguments for ${keyword}.
                                         |Expected ${expectedNumArgs}, input is
                                         |${subargs}""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
     val cmdLineOpts = splitCmdLine(arglist)
@@ -186,7 +186,7 @@ object Main extends App {
             (keyword, subargs.head)
           case _ =>
             throw new IllegalArgumentException(
-              s"Unregonized keyword ${keyword}"
+                s"Unregonized keyword ${keyword}"
             )
         }
         options.get(nKeyword) match {
@@ -219,10 +219,10 @@ object Main extends App {
     // Note: we sanitize this string, to be absolutely sure that
     // it does not contain problematic JSON characters.
     val errMsg = JsObject(
-      "error" -> JsObject(
-        "type" -> JsString(errType),
-        "message" -> JsString(Utils.sanitize(e.getMessage))
-      )
+        "error" -> JsObject(
+            "type" -> JsString(errType),
+            "message" -> JsString(Utils.sanitize(e.getMessage))
+        )
     ).prettyPrint
     Utils.writeFileContent(jobErrorPath, errMsg)
 
@@ -291,7 +291,7 @@ object Main extends App {
         case e: Exception =>
           Utils.error(e.getMessage)
           throw new Exception(
-            s"""|Could not find project ${projectRaw}, you probably need to be logged into
+              s"""|Could not find project ${projectRaw}, you probably need to be logged into
                                             |the platform""".stripMargin
           )
       }
@@ -307,16 +307,16 @@ object Main extends App {
       } catch {
         case e: java.lang.NumberFormatException =>
           throw new Exception(
-            s"""|the runtimeDebugLevel flag takes an integer input,
+              s"""|the runtimeDebugLevel flag takes an integer input,
                                             |${numberStr} is not of type int""".stripMargin
-              .replaceAll("\n", " ")
+                .replaceAll("\n", " ")
           )
       }
     if (rtDebugLvl < 0 || rtDebugLvl > 2)
       throw new Exception(
-        s"""|the runtimeDebugLevel flag must be one of {0, 1, 2}.
+          s"""|the runtimeDebugLevel flag must be one of {0, 1, 2}.
                                     |Value ${rtDebugLvl} is out of bounds.""".stripMargin
-          .replaceAll("\n", " ")
+            .replaceAll("\n", " ")
       )
     rtDebugLvl
   }
@@ -327,9 +327,9 @@ object Main extends App {
       case "false" => false
       case other =>
         throw new Exception(
-          s"""|the streamAllFiles flag must be a boolean (true,false).
+            s"""|the streamAllFiles flag must be a boolean (true,false).
                                         |Value ${other} is illegal.""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
   }
@@ -386,7 +386,7 @@ object Main extends App {
       if (extras.contains("reorg") && (options contains "reorg")) {
 
         throw new InvalidInputException(
-          "ERROR: cannot provide --reorg option when reorg is specified in extras."
+            "ERROR: cannot provide --reorg option when reorg is specified in extras."
         )
 
       }
@@ -394,7 +394,7 @@ object Main extends App {
       if (extras.contains("reorg") && (options contains "locked")) {
 
         throw new InvalidInputException(
-          "ERROR: cannot provide --locked option when reorg is specified in extras."
+            "ERROR: cannot provide --locked option when reorg is specified in extras."
         )
 
       }
@@ -402,21 +402,21 @@ object Main extends App {
     }
 
     CompilerOptions(
-      options contains "archive",
-      compileMode,
-      defaults,
-      extras,
-      options contains "fatalValidationWarnings",
-      options contains "force",
-      imports,
-      inputs,
-      options contains "leaveWorkflowsOpen",
-      options contains "locked",
-      options contains "projectWideReuse",
-      options contains "reorg",
-      options contains "streamAllFiles",
-      runtimeDebugLevel,
-      verbose
+        options contains "archive",
+        compileMode,
+        defaults,
+        extras,
+        options contains "fatalValidationWarnings",
+        options contains "force",
+        imports,
+        inputs,
+        options contains "leaveWorkflowsOpen",
+        options contains "locked",
+        options contains "projectWideReuse",
+        options contains "reorg",
+        options contains "streamAllFiles",
+        runtimeDebugLevel,
+        verbose
     )
   }
 
@@ -439,7 +439,7 @@ object Main extends App {
           .replaceAll("-", "")
         if (!bufNorm.startsWith("wdl"))
           throw new Exception(
-            s"unknown language ${bufNorm}. Only WDL is supported"
+              s"unknown language ${bufNorm}. Only WDL is supported"
           )
         val suffix = bufNorm.substring("wdl".length)
         if (suffix contains "draft2")
@@ -448,19 +448,19 @@ object Main extends App {
           Language.WDLv1_0
         else
           throw new Exception(
-            s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1"
+              s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1"
           )
       case _ => throw new Exception("only one language can be specified")
     }
     val verbose =
       Verbose(options contains "verbose", options contains "quiet", verboseKeys)
     DxniOptions(
-      options contains "apps",
-      options contains "force",
-      outputFile,
-      options contains "recursive",
-      language,
-      verbose
+        options contains "apps",
+        options contains "force",
+        outputFile,
+        options contains "recursive",
+        language,
+        verbose
     )
   }
 
@@ -489,9 +489,9 @@ object Main extends App {
 
         case CompilerFlag.All | CompilerFlag.NativeWithoutRuntimeAsset =>
           val dxPathConfig = DxPathConfig.apply(
-            baseDNAxDir,
-            cOpt.streamAllFiles,
-            cOpt.verbose.on
+              baseDNAxDir,
+              cOpt.streamAllFiles,
+              cOpt.verbose.on
           )
           val retval = top.apply(sourceFile, folder, dxProject, dxPathConfig)
           val desc = retval.getOrElse("")
@@ -529,13 +529,13 @@ object Main extends App {
 
     try {
       compiler.DxNI.apply(
-        dxProject,
-        folder,
-        outputFile,
-        dOpt.recursive,
-        dOpt.force,
-        dOpt.language,
-        dOpt.verbose
+          dxProject,
+          folder,
+          outputFile,
+          dOpt.recursive,
+          dOpt.force,
+          dOpt.language,
+          dOpt.verbose
       )
       SuccessfulTermination("")
     } catch {
@@ -551,10 +551,10 @@ object Main extends App {
   ): Termination = {
     try {
       compiler.DxNI.applyApps(
-        outputFile,
-        dOpt.force,
-        dOpt.language,
-        dOpt.verbose
+          outputFile,
+          dOpt.force,
+          dOpt.language,
+          dOpt.verbose
       )
       SuccessfulTermination("")
     } catch {
@@ -612,15 +612,15 @@ object Main extends App {
       new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
     val inputs = jobInputOutput.loadInputs(originalInputs, task)
     val taskRunner = exec.TaskRunner(
-      task,
-      taskSourceCode,
-      typeAliases,
-      instanceTypeDB,
-      dxPathConfig,
-      dxIoFunctions,
-      jobInputOutput,
-      defaultRuntimeAttributes,
-      rtDebugLvl
+        task,
+        taskSourceCode,
+        typeAliases,
+        instanceTypeDB,
+        dxPathConfig,
+        dxIoFunctions,
+        jobInputOutput,
+        defaultRuntimeAttributes,
+        rtDebugLvl
     )
 
     // Running tasks
@@ -692,10 +692,10 @@ object Main extends App {
     // setup the utility directories that the frag-runner employs
     val fragInputOutput =
       new exec.WfFragInputOutput(
-        dxIoFunctions,
-        dxProject,
-        rtDebugLvl,
-        typeAliases
+          dxIoFunctions,
+          dxProject,
+          rtDebugLvl,
+          typeAliases
       )
 
     // process the inputs
@@ -704,85 +704,85 @@ object Main extends App {
       op match {
         case InternalOp.WfFragment =>
           val fragRunner = new exec.WfFragRunner(
-            wf,
-            taskDir,
-            typeAliases,
-            womSourceCode,
-            instanceTypeDB,
-            fragInputs.execLinkInfo,
-            dxPathConfig,
-            dxIoFunctions,
-            inputsRaw,
-            fragInputOutput,
-            defaultRuntimeAttributes,
-            rtDebugLvl
+              wf,
+              taskDir,
+              typeAliases,
+              womSourceCode,
+              instanceTypeDB,
+              fragInputs.execLinkInfo,
+              dxPathConfig,
+              dxIoFunctions,
+              inputsRaw,
+              fragInputOutput,
+              defaultRuntimeAttributes,
+              rtDebugLvl
           )
           fragRunner.apply(
-            fragInputs.blockPath,
-            fragInputs.env,
-            RunnerWfFragmentMode.Launch
+              fragInputs.blockPath,
+              fragInputs.env,
+              RunnerWfFragmentMode.Launch
           )
         case InternalOp.Collect =>
           val fragRunner = new exec.WfFragRunner(
-            wf,
-            taskDir,
-            typeAliases,
-            womSourceCode,
-            instanceTypeDB,
-            fragInputs.execLinkInfo,
-            dxPathConfig,
-            dxIoFunctions,
-            inputsRaw,
-            fragInputOutput,
-            defaultRuntimeAttributes,
-            rtDebugLvl
+              wf,
+              taskDir,
+              typeAliases,
+              womSourceCode,
+              instanceTypeDB,
+              fragInputs.execLinkInfo,
+              dxPathConfig,
+              dxIoFunctions,
+              inputsRaw,
+              fragInputOutput,
+              defaultRuntimeAttributes,
+              rtDebugLvl
           )
           fragRunner.apply(
-            fragInputs.blockPath,
-            fragInputs.env,
-            RunnerWfFragmentMode.Collect
+              fragInputs.blockPath,
+              fragInputs.env,
+              RunnerWfFragmentMode.Collect
           )
         case InternalOp.WfInputs =>
           val wfInputs = new exec.WfInputs(
-            wf,
-            womSourceCode,
-            typeAliases,
-            dxPathConfig,
-            dxIoFunctions,
-            rtDebugLvl
+              wf,
+              womSourceCode,
+              typeAliases,
+              dxPathConfig,
+              dxIoFunctions,
+              rtDebugLvl
           )
           wfInputs.apply(fragInputs.env)
         case InternalOp.WfOutputs =>
           val wfOutputs = new exec.WfOutputs(
-            wf,
-            womSourceCode,
-            typeAliases,
-            dxPathConfig,
-            dxIoFunctions,
-            rtDebugLvl
+              wf,
+              womSourceCode,
+              typeAliases,
+              dxPathConfig,
+              dxIoFunctions,
+              rtDebugLvl
           )
           wfOutputs.apply(fragInputs.env)
 
         case InternalOp.WfCustomReorgOutputs =>
           val wfCustomReorgOutputs = new exec.WfOutputs(
-            wf,
-            womSourceCode,
-            typeAliases,
-            dxPathConfig,
-            dxIoFunctions,
-            rtDebugLvl
+              wf,
+              womSourceCode,
+              typeAliases,
+              dxPathConfig,
+              dxIoFunctions,
+              rtDebugLvl
           )
           // add ___reconf_status as output.
           wfCustomReorgOutputs.apply(fragInputs.env, addStatus = true)
 
         case InternalOp.WorkflowOutputReorg =>
           val wfReorg = new exec.WorkflowOutputReorg(
-            wf,
-            womSourceCode,
-            typeAliases,
-            dxPathConfig,
-            dxIoFunctions,
-            rtDebugLvl
+              wf,
+              womSourceCode,
+              typeAliases,
+              dxPathConfig,
+              dxIoFunctions,
+              rtDebugLvl
           )
           val refDxFiles = fragInputOutput.findRefDxFiles(inputsRaw, metaInfo)
           wfReorg.apply(refDxFiles)
@@ -888,29 +888,29 @@ object Main extends App {
                 InternalOp.WfOutputs | InternalOp.WorkflowOutputReorg |
                 InternalOp.WfCustomReorgOutputs =>
               workflowFragAction(
-                op,
-                womSourceCode,
-                instanceTypeDB,
-                metaInfo,
-                jobInputPath,
-                jobOutputPath,
-                dxPathConfig,
-                dxIoFunctions,
-                defaultRuntimeAttrs,
-                rtDebugLvl
+                  op,
+                  womSourceCode,
+                  instanceTypeDB,
+                  metaInfo,
+                  jobInputPath,
+                  jobOutputPath,
+                  dxPathConfig,
+                  dxIoFunctions,
+                  defaultRuntimeAttrs,
+                  rtDebugLvl
               )
             case InternalOp.TaskCheckInstanceType | InternalOp.TaskEpilog | InternalOp.TaskProlog |
                 InternalOp.TaskRelaunch =>
               taskAction(
-                op,
-                womSourceCode,
-                instanceTypeDB,
-                jobInputPath,
-                jobOutputPath,
-                dxPathConfig,
-                dxIoFunctions,
-                defaultRuntimeAttrs,
-                rtDebugLvl
+                  op,
+                  womSourceCode,
+                  instanceTypeDB,
+                  jobInputPath,
+                  jobOutputPath,
+                  dxPathConfig,
+                  dxIoFunctions,
+                  defaultRuntimeAttrs,
+                  rtDebugLvl
               )
           }
         } catch {

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -11,10 +11,10 @@ import dxWDL.util._
 
 object Main extends App {
   sealed trait Termination
-  case class SuccessfulTermination(output: String)                     extends Termination
+  case class SuccessfulTermination(output: String) extends Termination
   case class SuccessfulTerminationIR(bundle: dxWDL.compiler.IR.Bundle) extends Termination
-  case class UnsuccessfulTermination(output: String)                   extends Termination
-  case class BadUsageTermination(info: String)                         extends Termination
+  case class UnsuccessfulTermination(output: String) extends Termination
+  case class BadUsageTermination(info: String) extends Termination
 
   type OptionsMap = Map[String, List[String]]
 
@@ -96,7 +96,7 @@ object Main extends App {
                                         |${subargs}""".stripMargin.replaceAll("\n", " "))
     }
     val cmdLineOpts = splitCmdLine(arglist)
-    val options     = HashMap.empty[String, List[String]]
+    val options = HashMap.empty[String, List[String]]
     cmdLineOpts.foreach {
       case Nil => throw new Exception("sanity: empty command line option")
       case keyOrg :: subargs =>
@@ -211,7 +211,7 @@ object Main extends App {
     // it does not contain problematic JSON characters.
     val errMsg = JsObject(
       "error" -> JsObject(
-        "type"    -> JsString(errType),
+        "type" -> JsString(errType),
         "message" -> JsString(Utils.sanitize(e.getMessage))
       )
     ).prettyPrint
@@ -458,8 +458,8 @@ object Main extends App {
       return BadUsageTermination("")
 
     try {
-      val cOpt                = compilerOptions(options)
-      val top                 = compiler.Top(cOpt)
+      val cOpt = compilerOptions(options)
+      val top = compiler.Top(cOpt)
       val (dxProject, folder) = pathOptions(options, cOpt.verbose)
       cOpt.compileMode match {
         case CompilerFlag.IR =>
@@ -468,8 +468,8 @@ object Main extends App {
 
         case CompilerFlag.All | CompilerFlag.NativeWithoutRuntimeAsset =>
           val dxPathConfig = DxPathConfig.apply(baseDNAxDir, cOpt.streamAllFiles, cOpt.verbose.on)
-          val retval       = top.apply(sourceFile, folder, dxProject, dxPathConfig)
-          val desc         = retval.getOrElse("")
+          val retval = top.apply(sourceFile, folder, dxProject, dxPathConfig)
+          val desc = retval.getOrElse("")
           return SuccessfulTermination(desc)
       }
     } catch {
@@ -560,8 +560,8 @@ object Main extends App {
   ): Termination = {
     // Parse the inputs, convert to WOM values. Delay downloading files
     // from the platform, we may not need to access them.
-    val verbose                 = rtDebugLvl > 0
-    val inputLines: String      = Utils.readFileContent(jobInputPath)
+    val verbose = rtDebugLvl > 0
+    val inputLines: String = Utils.readFileContent(jobInputPath)
     val originalInputs: JsValue = inputLines.parseJson
 
     val (task, typeAliases) = ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
@@ -570,7 +570,7 @@ object Main extends App {
     dxPathConfig.createCleanDirs()
 
     val jobInputOutput = new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
-    val inputs         = jobInputOutput.loadInputs(originalInputs, task)
+    val inputs = jobInputOutput.loadInputs(originalInputs, task)
     val taskRunner = exec.TaskRunner(
       task,
       taskSourceCode,
@@ -596,7 +596,7 @@ object Main extends App {
         SuccessfulTermination(s"success ${op}")
 
       case InternalOp.TaskEpilog =>
-        val (localizedInputs, dxUrl2path)      = taskRunner.readEnvFromDisk()
+        val (localizedInputs, dxUrl2path) = taskRunner.readEnvFromDisk()
         val outputFields: Map[String, JsValue] = taskRunner.epilog(localizedInputs, dxUrl2path)
 
         // write outputs, ignore null values, these could occur for optional
@@ -737,7 +737,7 @@ object Main extends App {
 
     // write outputs, ignore null values, these could occur for optional
     // values that were not specified.
-    val json   = JsObject(outputFields)
+    val json = JsObject(outputFields)
     val ast_pp = json.prettyPrint
     Utils.writeFileContent(jobOutputPath, ast_pp)
 
@@ -763,13 +763,13 @@ object Main extends App {
         throw new Exception(s"malformed applet field ${other} in job info")
     }
 
-    val details: JsValue               = applet.describe(Set(Field.Details)).details.get
+    val details: JsValue = applet.describe(Set(Field.Details)).details.get
     val JsString(womSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
-    val womSourceCode                  = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
+    val womSourceCode = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
 
     val JsString(instanceTypeDBEncoded) = details.asJsObject.fields("instanceTypeDB")
-    val dbRaw                           = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
-    val instanceTypeDB                  = dbRaw.parseJson.convertTo[InstanceTypeDB]
+    val dbRaw = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
+    val instanceTypeDB = dbRaw.parseJson.convertTo[InstanceTypeDB]
 
     val runtimeAttrs: Option[WdlRuntimeAttrs] =
       details.asJsObject.fields.get("runtimeAttrs") match {
@@ -805,13 +805,13 @@ object Main extends App {
       case None =>
         UnsuccessfulTermination(s"unknown internal action ${args.head}")
       case Some(op) if args.length == 4 =>
-        val homeDir        = Paths.get(args(1))
-        val rtDebugLvl     = parseRuntimeDebugLevel(args(2))
+        val homeDir = Paths.get(args(1))
+        val rtDebugLvl = parseRuntimeDebugLevel(args(2))
         val streamAllFiles = parseStreamAllFiles(args(3))
         val (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath) =
           Utils.jobFilesOfHomeDir(homeDir)
-        val dxPathConfig  = buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
-        val fileInfoDir   = runtimeBulkFileDescribe(jobInputPath)
+        val dxPathConfig = buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
+        val fileInfoDir = runtimeBulkFileDescribe(jobInputPath)
         val dxIoFunctions = DxIoFunctions(fileInfoDir, dxPathConfig, rtDebugLvl)
 
         // Get the WOM source code (currently WDL, could be also CWL in the future)

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -10,815 +10,879 @@ import dxWDL.dx._
 import dxWDL.util._
 
 object Main extends App {
-    sealed trait Termination
-    case class SuccessfulTermination(output: String) extends Termination
-    case class SuccessfulTerminationIR(bundle: dxWDL.compiler.IR.Bundle) extends Termination
-    case class UnsuccessfulTermination(output: String) extends Termination
-    case class BadUsageTermination(info: String) extends Termination
+  sealed trait Termination
+  case class SuccessfulTermination(output: String)                     extends Termination
+  case class SuccessfulTerminationIR(bundle: dxWDL.compiler.IR.Bundle) extends Termination
+  case class UnsuccessfulTermination(output: String)                   extends Termination
+  case class BadUsageTermination(info: String)                         extends Termination
 
-    type OptionsMap = Map[String, List[String]]
+  type OptionsMap = Map[String, List[String]]
 
-    object Actions extends Enumeration {
-        val Compile, Config, DXNI, Internal, Version  = Value
+  object Actions extends Enumeration {
+    val Compile, Config, DXNI, Internal, Version = Value
+  }
+  object InternalOp extends Enumeration {
+    val Collect, WfOutputs, WfInputs, WorkflowOutputReorg, WfCustomReorgOutputs, WfFragment,
+        TaskCheckInstanceType, TaskEpilog, TaskProlog, TaskRelaunch = Value
+  }
+
+  case class DxniOptions(
+      apps: Boolean,
+      force: Boolean,
+      outputFile: Option[Path],
+      recursive: Boolean,
+      language: Language.Value,
+      verbose: Verbose
+  )
+
+  // This directory exists only at runtime in the cloud. Beware of using
+  // it in code paths that run at compile time.
+  private lazy val baseDNAxDir: Path = Paths.get("/home/dnanexus")
+
+  // Setup the standard paths used for applets. These are used at
+  // runtime, not at compile time. On the cloud instance running the
+  // job, the user is "dnanexus", and the home directory is
+  // "/home/dnanexus".
+  private def buildRuntimePathConfig(streamAllFiles: Boolean, verbose: Boolean): DxPathConfig = {
+    DxPathConfig.apply(baseDNAxDir, streamAllFiles, verbose)
+  }
+
+  private def normKey(s: String): String = {
+    s.replaceAll("_", "").toUpperCase
+  }
+
+  // Split arguments into sub-lists, one per each option.
+  // For example:
+  //    --sort relaxed --reorg --compile-mode IR
+  // =>
+  //    [[--sort, relaxed], [--reorg], [--compile-mode, IR]]
+  //
+  def splitCmdLine(arglist: List[String]): List[List[String]] = {
+    def isKeyword(word: String): Boolean = word.startsWith("-")
+
+    val keywordAndOptions: List[List[String]] = arglist.foldLeft(List.empty[List[String]]) {
+      case (head :: tail, word) if (isKeyword(word)) =>
+        List(word) :: head :: tail
+      case ((head :: tail), word) =>
+        (word :: head) :: tail
+      case (head, word) if (isKeyword(word)) =>
+        List(word) :: head
+      case (Nil, word) if (isKeyword(word)) => List(List(word))
+      case (Nil, word) if (!isKeyword(word)) =>
+        throw new Exception("Keyword must precede options")
     }
-    object InternalOp extends Enumeration {
-        val Collect,
-            WfOutputs, WfInputs, WorkflowOutputReorg, WfCustomReorgOutputs,
-            WfFragment,
-            TaskCheckInstanceType, TaskEpilog, TaskProlog, TaskRelaunch = Value
+    keywordAndOptions.map(_.reverse).reverse
+  }
+
+  // parse extra command line arguments
+  def parseCmdlineOptions(arglist: List[String]): OptionsMap = {
+    def keywordValueIsList = Set("inputs", "imports", "verboseKey")
+    def normKeyword(word: String): String = {
+      // normalize a keyword, remove leading dashes
+      // letters to lowercase.
+      //
+      // "--Archive" -> "archive"
+      // "--archive-only -> "archiveonly"
+      word.replaceAll("-", "")
     }
-
-    case class DxniOptions(apps: Boolean,
-                           force: Boolean,
-                           outputFile: Option[Path],
-                           recursive: Boolean,
-                           language: Language.Value,
-                           verbose: Verbose)
-
-    // This directory exists only at runtime in the cloud. Beware of using
-    // it in code paths that run at compile time.
-    private lazy val baseDNAxDir : Path = Paths.get("/home/dnanexus")
-
-    // Setup the standard paths used for applets. These are used at
-    // runtime, not at compile time. On the cloud instance running the
-    // job, the user is "dnanexus", and the home directory is
-    // "/home/dnanexus".
-    private def buildRuntimePathConfig(streamAllFiles: Boolean, verbose: Boolean) : DxPathConfig = {
-        DxPathConfig.apply(baseDNAxDir, streamAllFiles, verbose)
-    }
-
-    private def normKey(s: String) : String= {
-        s.replaceAll("_", "").toUpperCase
-    }
-
-    // Split arguments into sub-lists, one per each option.
-    // For example:
-    //    --sort relaxed --reorg --compile-mode IR
-    // =>
-    //    [[--sort, relaxed], [--reorg], [--compile-mode, IR]]
-    //
-    def splitCmdLine(arglist: List[String]) : List[List[String]] = {
-        def isKeyword(word: String) : Boolean = word.startsWith("-")
-
-        val keywordAndOptions: List[List[String]] = arglist.foldLeft(List.empty[List[String]]) {
-            case (head :: tail, word) if (isKeyword(word)) =>
-                List(word) :: head :: tail
-            case ((head :: tail), word) =>
-                (word :: head) :: tail
-            case (head, word) if (isKeyword(word)) =>
-                List(word) :: head
-            case (Nil, word) if (isKeyword(word)) => List(List(word))
-            case (Nil, word) if (!isKeyword(word)) =>
-                throw new Exception("Keyword must precede options")
-        }
-        keywordAndOptions.map(_.reverse).reverse
-    }
-
-    // parse extra command line arguments
-    def parseCmdlineOptions(arglist: List[String]) : OptionsMap = {
-        def keywordValueIsList = Set("inputs", "imports", "verboseKey")
-        def normKeyword(word: String) : String = {
-            // normalize a keyword, remove leading dashes
-            // letters to lowercase.
-            //
-            // "--Archive" -> "archive"
-            // "--archive-only -> "archiveonly"
-            word.replaceAll("-", "")
-        }
-        def checkNumberOfArguments(keyword: String,
-                                   expectedNumArgs:Int,
-                                   subargs:List[String]) : Unit = {
-            if (expectedNumArgs != subargs.length)
-                throw new Exception(s"""|Wrong number of arguments for ${keyword}.
+    def checkNumberOfArguments(
+        keyword: String,
+        expectedNumArgs: Int,
+        subargs: List[String]
+    ): Unit = {
+      if (expectedNumArgs != subargs.length)
+        throw new Exception(s"""|Wrong number of arguments for ${keyword}.
                                         |Expected ${expectedNumArgs}, input is
-                                        |${subargs}"""
-                                        .stripMargin.replaceAll("\n", " "))
+                                        |${subargs}""".stripMargin.replaceAll("\n", " "))
+    }
+    val cmdLineOpts = splitCmdLine(arglist)
+    val options     = HashMap.empty[String, List[String]]
+    cmdLineOpts.foreach {
+      case Nil => throw new Exception("sanity: empty command line option")
+      case keyOrg :: subargs =>
+        val keyword = normKeyword(keyOrg)
+        val (nKeyword, value) = keyword match {
+          case "apps" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "archive" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "compileMode" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "defaults" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "destination" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "extras" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "fatalValidationWarnings" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "folder" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case ("force" | "f" | "overwrite") =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            ("force", "")
+          case "help" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case ("input" | "inputs") =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case ("imports" | "p") =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            ("imports", subargs.head)
+          case "language" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "leaveWorkflowsOpen" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "locked" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case ("o" | "output" | "outputFile") =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            ("outputFile", subargs.head)
+          case "project" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "projectWideReuse" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case ("q" | "quiet") =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            ("quiet", "")
+          case ("r" | "recursive") =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            ("recursive", "")
+          case "reorg" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "runtimeDebugLevel" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case "streamAllFiles" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            ("streamAllFiles", "")
+          case "verbose" =>
+            checkNumberOfArguments(keyword, 0, subargs)
+            (keyword, "")
+          case "verboseKey" =>
+            checkNumberOfArguments(keyword, 1, subargs)
+            (keyword, subargs.head)
+          case _ =>
+            throw new IllegalArgumentException(s"Unregonized keyword ${keyword}")
         }
-        val cmdLineOpts = splitCmdLine(arglist)
-        val options = HashMap.empty[String, List[String]]
-        cmdLineOpts.foreach {
-            case Nil => throw new Exception("sanity: empty command line option")
-            case keyOrg :: subargs =>
-                val keyword = normKeyword(keyOrg)
-                val (nKeyword, value) = keyword match {
-                    case "apps" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "archive" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "compileMode" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "defaults" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "destination" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "extras" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "fatalValidationWarnings" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "folder" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case ("force"|"f"|"overwrite") =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        ("force", "")
-                    case "help" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case ("input" | "inputs") =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case ("imports"|"p") =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        ("imports", subargs.head)
-                    case "language" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "leaveWorkflowsOpen" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "locked" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case ("o"|"output"|"outputFile") =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        ("outputFile", subargs.head)
-                    case "project" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "projectWideReuse" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case ("q"|"quiet") =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        ("quiet", "")
-                    case ("r"|"recursive") =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        ("recursive", "")
-                    case "reorg" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "runtimeDebugLevel" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case "streamAllFiles" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        ("streamAllFiles", "")
-                    case "verbose" =>
-                        checkNumberOfArguments(keyword, 0, subargs)
-                        (keyword, "")
-                    case "verboseKey" =>
-                        checkNumberOfArguments(keyword, 1, subargs)
-                        (keyword, subargs.head)
-                    case _ =>
-                        throw new IllegalArgumentException(s"Unregonized keyword ${keyword}")
-                }
-                options.get(nKeyword) match {
-                    case None =>
-                        // first time
-                        options(nKeyword) = List(value)
-                    case Some(x) if (keywordValueIsList contains nKeyword) =>
-                        // append to the already existing verbose flags
-                        options(nKeyword) = value :: x
-                    case Some(x) =>
-                        // overwrite the previous flag value
-                        options(nKeyword) = List(value)
-                }
+        options.get(nKeyword) match {
+          case None =>
+            // first time
+            options(nKeyword) = List(value)
+          case Some(x) if (keywordValueIsList contains nKeyword) =>
+            // append to the already existing verbose flags
+            options(nKeyword) = value :: x
+          case Some(x) =>
+            // overwrite the previous flag value
+            options(nKeyword) = List(value)
         }
-        options.toMap
+    }
+    options.toMap
+  }
+
+  // Report an error, since this is called from a bash script, we
+  // can't simply raise an exception. Instead, we write the error to
+  // a standard JSON file.
+  def writeJobError(jobErrorPath: Path, e: Throwable): Unit = {
+    val errType = e match {
+      case _: AppException         => "AppError"
+      case _: AppInternalException => "AppInternalError"
+      case _: Throwable            => "AppInternalError"
+    }
+    // We are limited in what characters can be written to json, so we
+    // provide a short description for json.
+    //
+    // Note: we sanitize this string, to be absolutely sure that
+    // it does not contain problematic JSON characters.
+    val errMsg = JsObject(
+      "error" -> JsObject(
+        "type"    -> JsString(errType),
+        "message" -> JsString(Utils.sanitize(e.getMessage))
+      )
+    ).prettyPrint
+    Utils.writeFileContent(jobErrorPath, errMsg)
+
+    // Write out a full stack trace to standard error.
+    System.err.println(Utils.exceptionToString(e))
+  }
+
+  private def pathOptions(options: OptionsMap, verbose: Verbose): (DxProject, String) = {
+    var folderOpt: Option[String] = options.get("folder") match {
+      case None          => None
+      case Some(List(f)) => Some(f)
+      case _             => throw new Exception("sanity")
+    }
+    var projectOpt: Option[String] = options.get("project") match {
+      case None          => None
+      case Some(List(p)) => Some(p)
+      case _             => throw new Exception("sanity")
+    }
+    val destinationOpt: Option[String] = options.get("destination") match {
+      case None          => None
+      case Some(List(d)) => Some(d)
+      case Some(other)   => throw new Exception(s"Invalid path syntex <${other}>")
     }
 
-    // Report an error, since this is called from a bash script, we
-    // can't simply raise an exception. Instead, we write the error to
-    // a standard JSON file.
-    def writeJobError(jobErrorPath : Path, e: Throwable) : Unit = {
-        val errType = e match {
-            case _ : AppException => "AppError"
-            case _ : AppInternalException => "AppInternalError"
-            case _ : Throwable => "AppInternalError"
+    // There are three possible syntaxes:
+    //    project-id:/folder
+    //    project-id:
+    //    /folder
+    destinationOpt match {
+      case None => ()
+      case Some(d) if d contains ":" =>
+        val vec = d.split(":")
+        vec.length match {
+          case 1 if (d.endsWith(":")) =>
+            projectOpt = Some(vec(0))
+          case 2 =>
+            projectOpt = Some(vec(0))
+            folderOpt = Some(vec(1))
+          case _ => throw new Exception(s"Invalid path syntex <${d}>")
         }
-        // We are limited in what characters can be written to json, so we
-        // provide a short description for json.
-        //
-        // Note: we sanitize this string, to be absolutely sure that
-        // it does not contain problematic JSON characters.
-        val errMsg = JsObject(
-            "error" -> JsObject(
-                "type" -> JsString(errType),
-                "message" -> JsString(Utils.sanitize(e.getMessage))
-            )
-        ).prettyPrint
-        Utils.writeFileContent(jobErrorPath, errMsg)
-
-        // Write out a full stack trace to standard error.
-        System.err.println(Utils.exceptionToString(e))
+      case Some(d) if d.startsWith("/") =>
+        folderOpt = Some(d)
+      case Some(other) => throw new Exception(s"Invalid path syntex <${other}>")
     }
 
+    // Use the current dx path, if nothing else was
+    // specified
+    val (projectRaw, folderRaw) = (projectOpt, folderOpt) match {
+      case (None, _)          => throw new Exception("project is unspecified")
+      case (Some(p), None)    => (p, "/")
+      case (Some(p), Some(d)) => (p, d)
+    }
 
-    private def pathOptions(options: OptionsMap,
-                            verbose: Verbose) : (DxProject, String) = {
-        var folderOpt:Option[String] = options.get("folder") match {
-            case None => None
-            case Some(List(f)) => Some(f)
-            case _ => throw new Exception("sanity")
-        }
-        var projectOpt:Option[String] = options.get("project") match {
-            case None => None
-            case Some(List(p)) => Some(p)
-            case _ => throw new Exception("sanity")
-        }
-        val destinationOpt : Option[String] = options.get("destination") match {
-            case None => None
-            case Some(List(d)) => Some(d)
-            case Some(other) => throw new Exception(s"Invalid path syntex <${other}>")
-        }
-
-        // There are three possible syntaxes:
-        //    project-id:/folder
-        //    project-id:
-        //    /folder
-        destinationOpt match {
-            case None => ()
-            case Some(d) if d contains ":" =>
-                val vec = d.split(":")
-                vec.length match {
-                    case 1 if (d.endsWith(":")) =>
-                        projectOpt = Some(vec(0))
-                    case 2 =>
-                        projectOpt = Some(vec(0))
-                        folderOpt = Some(vec(1))
-                    case _ => throw new Exception(s"Invalid path syntex <${d}>")
-                }
-            case Some(d) if d.startsWith("/") =>
-                folderOpt = Some(d)
-            case Some(other) => throw new Exception(s"Invalid path syntex <${other}>")
-        }
-
-        // Use the current dx path, if nothing else was
-        // specified
-        val (projectRaw, folderRaw) = (projectOpt, folderOpt) match {
-            case (None, _) => throw new Exception("project is unspecified")
-            case (Some(p), None) => (p, "/")
-            case (Some(p), Some(d)) =>(p, d)
-        }
-
-        if (folderRaw.isEmpty)
-            throw new Exception(s"Cannot specify empty folder")
-        if (!folderRaw.startsWith("/"))
-            throw new Exception(s"Folder must start with '/'")
-        val dxFolder = folderRaw
-        val dxProject =
-            try {
-                DxPath.resolveProject(projectRaw)
-            } catch {
-                case e : Exception =>
-                    Utils.error(e.getMessage)
-                    throw new Exception(s"""|Could not find project ${projectRaw}, you probably need to be logged into
-                                            |the platform""".stripMargin)
-            }
-        Utils.trace(verbose.on,
-                    s"""|project ID: ${dxProject.id}
+    if (folderRaw.isEmpty)
+      throw new Exception(s"Cannot specify empty folder")
+    if (!folderRaw.startsWith("/"))
+      throw new Exception(s"Folder must start with '/'")
+    val dxFolder = folderRaw
+    val dxProject =
+      try {
+        DxPath.resolveProject(projectRaw)
+      } catch {
+        case e: Exception =>
+          Utils.error(e.getMessage)
+          throw new Exception(
+            s"""|Could not find project ${projectRaw}, you probably need to be logged into
+                                            |the platform""".stripMargin
+          )
+      }
+    Utils.trace(verbose.on, s"""|project ID: ${dxProject.id}
                         |folder: ${dxFolder}""".stripMargin)
-        (dxProject, dxFolder)
+    (dxProject, dxFolder)
+  }
+
+  private def parseRuntimeDebugLevel(numberStr: String): Int = {
+    val rtDebugLvl =
+      try {
+        numberStr.toInt
+      } catch {
+        case e: java.lang.NumberFormatException =>
+          throw new Exception(
+            s"""|the runtimeDebugLevel flag takes an integer input,
+                                            |${numberStr} is not of type int""".stripMargin
+              .replaceAll("\n", " ")
+          )
+      }
+    if (rtDebugLvl < 0 || rtDebugLvl > 2)
+      throw new Exception(
+        s"""|the runtimeDebugLevel flag must be one of {0, 1, 2}.
+                                    |Value ${rtDebugLvl} is out of bounds.""".stripMargin
+          .replaceAll("\n", " ")
+      )
+    rtDebugLvl
+  }
+
+  private def parseStreamAllFiles(s: String): Boolean = {
+    s.toLowerCase match {
+      case "true"  => true
+      case "false" => false
+      case other =>
+        throw new Exception(
+          s"""|the streamAllFiles flag must be a boolean (true,false).
+                                        |Value ${other} is illegal.""".stripMargin
+            .replaceAll("\n", " ")
+        )
+    }
+  }
+
+  // Get basic information about the dx environment, and process
+  // the compiler flags
+  private def compilerOptions(options: OptionsMap): CompilerOptions = {
+    // First: get the verbosity mode. It is used almost everywhere.
+    val verboseKeys: Set[String] = options.get("verboseKey") match {
+      case None                 => Set.empty
+      case Some(modulesToTrace) => modulesToTrace.toSet
+    }
+    val verbose = Verbose(options contains "verbose", options contains "quiet", verboseKeys)
+
+    val compileMode: CompilerFlag.Value = options.get("compileMode") match {
+      case None                                                 => CompilerFlag.All
+      case Some(List(x)) if (x.toLowerCase == "IR".toLowerCase) => CompilerFlag.IR
+      case Some(List(x)) if (x.toLowerCase == "NativeWithoutRuntimeAsset".toLowerCase) =>
+        CompilerFlag.NativeWithoutRuntimeAsset
+      case Some(other) => throw new Exception(s"unrecognized compiler flag ${other}")
+    }
+    val defaults: Option[Path] = options.get("defaults") match {
+      case None          => None
+      case Some(List(p)) => Some(Paths.get(p))
+      case _             => throw new Exception("defaults specified twice")
+    }
+    val extras = options.get("extras") match {
+      case None => None
+      case Some(List(p)) =>
+        val contents = Utils.readFileContent(Paths.get(p))
+        Some(Extras.parse(contents.parseJson, verbose))
+      case _ => throw new Exception("extras specified twice")
+    }
+    val inputs: List[Path] = options.get("inputs") match {
+      case None     => List.empty
+      case Some(pl) => pl.map(p => Paths.get(p))
+    }
+    val imports: List[Path] = options.get("imports") match {
+      case None     => List.empty
+      case Some(pl) => pl.map(p => Paths.get(p))
+    }
+    val runtimeDebugLevel: Option[Int] = options.get("runtimeDebugLevel") match {
+      case None                  => None
+      case Some(List(numberStr)) => Some(parseRuntimeDebugLevel(numberStr))
+      case _                     => throw new Exception("debug level specified twice")
     }
 
-    private def parseRuntimeDebugLevel(numberStr: String) : Int = {
-        val rtDebugLvl =
-            try {
-                numberStr.toInt
-            } catch {
-                case e : java.lang.NumberFormatException =>
-                    throw new Exception(s"""|the runtimeDebugLevel flag takes an integer input,
-                                            |${numberStr} is not of type int"""
-                                            .stripMargin.replaceAll("\n", " "))
-            }
-        if (rtDebugLvl < 0 || rtDebugLvl > 2)
-            throw new Exception(s"""|the runtimeDebugLevel flag must be one of {0, 1, 2}.
-                                    |Value ${rtDebugLvl} is out of bounds."""
-                                    .stripMargin.replaceAll("\n", " "))
-        rtDebugLvl
+    if (extras != None) {
+
+      if (extras.contains("reorg") && (options contains "reorg")) {
+
+        throw new InvalidInputException(
+          "ERROR: cannot provide --reorg option when reorg is specified in extras."
+        )
+
+      }
+
+      if (extras.contains("reorg") && (options contains "locked")) {
+
+        throw new InvalidInputException(
+          "ERROR: cannot provide --locked option when reorg is specified in extras."
+        )
+
+      }
+
     }
 
-    private def parseStreamAllFiles(s: String) : Boolean = {
-        s.toLowerCase match {
-            case "true" => true
-            case "false" => false
-            case other =>
-                throw new Exception(s"""|the streamAllFiles flag must be a boolean (true,false).
-                                        |Value ${other} is illegal."""
-                                        .stripMargin.replaceAll("\n", " "))
-        }
+    CompilerOptions(
+      options contains "archive",
+      compileMode,
+      defaults,
+      extras,
+      options contains "fatalValidationWarnings",
+      options contains "force",
+      imports,
+      inputs,
+      options contains "leaveWorkflowsOpen",
+      options contains "locked",
+      options contains "projectWideReuse",
+      options contains "reorg",
+      options contains "streamAllFiles",
+      runtimeDebugLevel,
+      verbose
+    )
+  }
+
+  private def dxniOptions(options: OptionsMap): DxniOptions = {
+    val outputFile: Option[Path] = options.get("outputFile") match {
+      case None          => None
+      case Some(List(p)) => Some(Paths.get(p))
+      case _             => throw new Exception("only one output file can be specified")
+    }
+    val verboseKeys: Set[String] = options.get("verbose") match {
+      case None                 => Set.empty
+      case Some(modulesToTrace) => modulesToTrace.toSet
+    }
+    val language = options.get("language") match {
+      case None => Language.WDLvDraft2
+      case Some(List(buf)) =>
+        val bufNorm = buf.toLowerCase
+          .replaceAll("\\.", "")
+          .replaceAll("_", "")
+          .replaceAll("-", "")
+        if (!bufNorm.startsWith("wdl"))
+          throw new Exception(s"unknown language ${bufNorm}. Only WDL is supported")
+        val suffix = bufNorm.substring("wdl".length)
+        if (suffix contains "draft2")
+          Language.WDLvDraft2
+        else if (suffix contains ("10"))
+          Language.WDLv1_0
+        else
+          throw new Exception(s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1")
+      case _ => throw new Exception("only one language can be specified")
+    }
+    val verbose = Verbose(options contains "verbose", options contains "quiet", verboseKeys)
+    DxniOptions(
+      options contains "apps",
+      options contains "force",
+      outputFile,
+      options contains "recursive",
+      language,
+      verbose
+    )
+  }
+
+  def compile(args: Seq[String]): Termination = {
+    if (args.isEmpty)
+      return BadUsageTermination("WDL file to compile is missing")
+    val sourceFile = Paths.get(args.head)
+    val options =
+      try {
+        parseCmdlineOptions(args.tail.toList)
+      } catch {
+        case e: Throwable =>
+          return BadUsageTermination(Utils.exceptionToString(e))
+      }
+    if (options contains "help")
+      return BadUsageTermination("")
+
+    try {
+      val cOpt                = compilerOptions(options)
+      val top                 = compiler.Top(cOpt)
+      val (dxProject, folder) = pathOptions(options, cOpt.verbose)
+      cOpt.compileMode match {
+        case CompilerFlag.IR =>
+          val ir: compiler.IR.Bundle = top.applyOnlyIR(sourceFile, dxProject)
+          return SuccessfulTerminationIR(ir)
+
+        case CompilerFlag.All | CompilerFlag.NativeWithoutRuntimeAsset =>
+          val dxPathConfig = DxPathConfig.apply(baseDNAxDir, cOpt.streamAllFiles, cOpt.verbose.on)
+          val retval       = top.apply(sourceFile, folder, dxProject, dxPathConfig)
+          val desc         = retval.getOrElse("")
+          return SuccessfulTermination(desc)
+      }
+    } catch {
+      case e: Throwable =>
+        return UnsuccessfulTermination(Utils.exceptionToString(e))
+    }
+  }
+
+  private def dxniApplets(options: OptionsMap, dOpt: DxniOptions, outputFile: Path): Termination = {
+    val (dxProject, folder) =
+      try {
+        pathOptions(options, dOpt.verbose)
+      } catch {
+        case e: Throwable =>
+          return BadUsageTermination(Utils.exceptionToString(e))
+      }
+
+    // Validate the folder. It would have been nicer to be able
+    // to check if a folder exists, instead of validating by
+    // listing its contents, which could be very large.
+    try {
+      dxProject.listFolder(folder)
+    } catch {
+      case e: Throwable =>
+        System.err.println(s"err when validating folder ${folder} : ${e}")
+        return UnsuccessfulTermination(s"Folder ${folder} is invalid")
     }
 
-    // Get basic information about the dx environment, and process
-    // the compiler flags
-    private def compilerOptions(options: OptionsMap) : CompilerOptions = {
-        // First: get the verbosity mode. It is used almost everywhere.
-        val verboseKeys: Set[String] = options.get("verboseKey") match {
-            case None => Set.empty
-            case Some(modulesToTrace) => modulesToTrace.toSet
-        }
-        val verbose = Verbose(options contains "verbose",
-                              options contains "quiet",
-                              verboseKeys)
-
-        val compileMode: CompilerFlag.Value = options.get("compileMode") match {
-            case None => CompilerFlag.All
-            case Some(List(x)) if (x.toLowerCase == "IR".toLowerCase) => CompilerFlag.IR
-            case Some(List(x)) if (x.toLowerCase == "NativeWithoutRuntimeAsset".toLowerCase) => CompilerFlag.NativeWithoutRuntimeAsset
-            case Some(other) => throw new Exception(s"unrecognized compiler flag ${other}")
-        }
-        val defaults: Option[Path] = options.get("defaults") match {
-            case None => None
-            case Some(List(p)) => Some(Paths.get(p))
-            case _ => throw new Exception("defaults specified twice")
-        }
-        val extras = options.get("extras") match {
-            case None => None
-            case Some(List(p)) =>
-                val contents = Utils.readFileContent(Paths.get(p))
-                Some(Extras.parse(contents.parseJson, verbose))
-            case _ => throw new Exception("extras specified twice")
-        }
-        val inputs: List[Path] = options.get("inputs") match {
-            case None => List.empty
-            case Some(pl) => pl.map(p => Paths.get(p))
-        }
-        val imports: List[Path] = options.get("imports") match {
-            case None => List.empty
-            case Some(pl) => pl.map(p => Paths.get(p))
-        }
-        val runtimeDebugLevel:Option[Int] = options.get("runtimeDebugLevel") match {
-            case None => None
-            case Some(List(numberStr)) => Some(parseRuntimeDebugLevel(numberStr))
-            case _ => throw new Exception("debug level specified twice")
-        }
-
-        if ( extras != None ) {
-
-            if (extras.contains("reorg")  && (options contains "reorg")) {
-
-                throw new InvalidInputException("ERROR: cannot provide --reorg option when reorg is specified in extras.")
-
-            }
-
-            if (extras.contains("reorg") && (options contains "locked")) {
-
-                throw new InvalidInputException("ERROR: cannot provide --locked option when reorg is specified in extras.")
-
-            }
-
-        }
-
-        CompilerOptions(options contains "archive",
-                        compileMode,
-                        defaults,
-                        extras,
-                        options contains "fatalValidationWarnings",
-                        options contains "force",
-                        imports,
-                        inputs,
-                        options contains "leaveWorkflowsOpen",
-                        options contains "locked",
-                        options contains "projectWideReuse",
-                        options contains "reorg",
-                        options contains "streamAllFiles",
-                        runtimeDebugLevel,
-                        verbose)
+    try {
+      compiler.DxNI.apply(
+        dxProject,
+        folder,
+        outputFile,
+        dOpt.recursive,
+        dOpt.force,
+        dOpt.language,
+        dOpt.verbose
+      )
+      SuccessfulTermination("")
+    } catch {
+      case e: Throwable =>
+        return UnsuccessfulTermination(Utils.exceptionToString(e))
     }
+  }
 
-    private def dxniOptions(options: OptionsMap) : DxniOptions = {
-        val outputFile: Option[Path] = options.get("outputFile") match {
-            case None => None
-            case Some(List(p)) => Some(Paths.get(p))
-            case _ => throw new Exception("only one output file can be specified")
-        }
-        val verboseKeys: Set[String] = options.get("verbose") match {
-            case None => Set.empty
-            case Some(modulesToTrace) => modulesToTrace.toSet
-        }
-        val language = options.get("language") match {
-            case None => Language.WDLvDraft2
-            case Some(List(buf)) =>
-                val bufNorm = buf.toLowerCase
-                    .replaceAll("\\.", "")
-                    .replaceAll("_", "")
-                    .replaceAll("-", "")
-                if (!bufNorm.startsWith("wdl"))
-                    throw new Exception(s"unknown language ${bufNorm}. Only WDL is supported")
-                val suffix = bufNorm.substring("wdl".length)
-                if (suffix contains "draft2")
-                    Language.WDLvDraft2
-                else if (suffix contains ("10"))
-                    Language.WDLv1_0
-                else
-                    throw new Exception(s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1")
-            case _ => throw new Exception("only one language can be specified")
-        }
-        val verbose = Verbose(options contains "verbose",
-                              options contains "quiet",
-                              verboseKeys)
-        DxniOptions(options contains "apps",
-                    options contains "force",
-                    outputFile,
-                    options contains "recursive",
-                    language,
-                    verbose)
+  private def dxniApps(options: OptionsMap, dOpt: DxniOptions, outputFile: Path): Termination = {
+    try {
+      compiler.DxNI.applyApps(outputFile, dOpt.force, dOpt.language, dOpt.verbose)
+      SuccessfulTermination("")
+    } catch {
+      case e: Throwable =>
+        return UnsuccessfulTermination(Utils.exceptionToString(e))
     }
+  }
 
-    def compile(args: Seq[String]): Termination = {
-        if (args.isEmpty)
-            return BadUsageTermination("WDL file to compile is missing")
-        val sourceFile = Paths.get(args.head)
-        val options =
-            try {
-                parseCmdlineOptions(args.tail.toList)
-            } catch {
-                case e : Throwable =>
-                    return BadUsageTermination(Utils.exceptionToString(e))
-            }
-        if (options contains "help")
-            return BadUsageTermination("")
+  def dxni(args: Seq[String]): Termination = {
+    try {
+      val options = parseCmdlineOptions(args.toList)
+      if (options contains "help")
+        return BadUsageTermination("")
 
-        try {
-            val cOpt = compilerOptions(options)
-            val top = compiler.Top(cOpt)
-            val (dxProject, folder) = pathOptions(options, cOpt.verbose)
-            cOpt.compileMode match {
-                case CompilerFlag.IR =>
-                    val ir: compiler.IR.Bundle = top.applyOnlyIR(sourceFile, dxProject)
-                    return SuccessfulTerminationIR(ir)
+      val dOpt = dxniOptions(options)
+      val output = dOpt.outputFile match {
+        case None    => throw new Exception("Output file not specified")
+        case Some(x) => x
+      }
 
-                case CompilerFlag.All
-                       | CompilerFlag.NativeWithoutRuntimeAsset =>
-                    val dxPathConfig = DxPathConfig.apply(baseDNAxDir, cOpt.streamAllFiles, cOpt.verbose.on)
-                    val retval = top.apply(sourceFile, folder, dxProject, dxPathConfig)
-                    val desc = retval.getOrElse("")
-                    return SuccessfulTermination(desc)
-            }
-        } catch {
-            case e : Throwable =>
-                return UnsuccessfulTermination(Utils.exceptionToString(e))
-        }
+      if (dOpt.apps)
+        dxniApps(options, dOpt, output)
+      else
+        dxniApplets(options, dOpt, output)
+    } catch {
+      case e: Throwable =>
+        return BadUsageTermination(Utils.exceptionToString(e))
     }
+  }
 
-    private def dxniApplets(options: OptionsMap,
-                            dOpt: DxniOptions,
-                            outputFile: Path): Termination = {
-        val (dxProject, folder) =
-            try {
-                pathOptions(options, dOpt.verbose)
-            } catch {
-                case e: Throwable =>
-                    return BadUsageTermination(Utils.exceptionToString(e))
-            }
+  private def taskAction(
+      op: InternalOp.Value,
+      taskSourceCode: String,
+      instanceTypeDB: InstanceTypeDB,
+      jobInputPath: Path,
+      jobOutputPath: Path,
+      dxPathConfig: DxPathConfig,
+      dxIoFunctions: DxIoFunctions,
+      defaultRuntimeAttributes: Option[WdlRuntimeAttrs],
+      rtDebugLvl: Int
+  ): Termination = {
+    // Parse the inputs, convert to WOM values. Delay downloading files
+    // from the platform, we may not need to access them.
+    val verbose                 = rtDebugLvl > 0
+    val inputLines: String      = Utils.readFileContent(jobInputPath)
+    val originalInputs: JsValue = inputLines.parseJson
 
-        // Validate the folder. It would have been nicer to be able
-        // to check if a folder exists, instead of validating by
-        // listing its contents, which could be very large.
-        try {
-            dxProject.listFolder(folder)
-        } catch {
-            case e : Throwable =>
-                System.err.println(s"err when validating folder ${folder} : ${e}")
-                return UnsuccessfulTermination(s"Folder ${folder} is invalid")
-        }
+    val (task, typeAliases) = ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
 
-        try {
-            compiler.DxNI.apply(dxProject, folder, outputFile,
-                                dOpt.recursive, dOpt.force,
-                                dOpt.language,
-                                dOpt.verbose)
-            SuccessfulTermination("")
-        } catch {
-            case e : Throwable =>
-                return UnsuccessfulTermination(Utils.exceptionToString(e))
-        }
-    }
+    // setup the utility directories that the task-runner employs
+    dxPathConfig.createCleanDirs()
 
-    private def dxniApps(options: OptionsMap,
-                         dOpt: DxniOptions,
-                         outputFile: Path): Termination = {
-        try {
-            compiler.DxNI.applyApps(outputFile, dOpt.force, dOpt.language, dOpt.verbose)
-            SuccessfulTermination("")
-        } catch {
-            case e : Throwable =>
-                return UnsuccessfulTermination(Utils.exceptionToString(e))
-        }
-    }
+    val jobInputOutput = new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
+    val inputs         = jobInputOutput.loadInputs(originalInputs, task)
+    val taskRunner = exec.TaskRunner(
+      task,
+      taskSourceCode,
+      typeAliases,
+      instanceTypeDB,
+      dxPathConfig,
+      dxIoFunctions,
+      jobInputOutput,
+      defaultRuntimeAttributes,
+      rtDebugLvl
+    )
 
-    def dxni(args: Seq[String]): Termination = {
-        try {
-            val options = parseCmdlineOptions(args.toList)
-            if (options contains "help")
-                return BadUsageTermination("")
+    // Running tasks
+    op match {
+      case InternalOp.TaskCheckInstanceType =>
+        // special operation to check if this task is on the right instance type
+        val correctInstanceType: Boolean = taskRunner.checkInstanceType(inputs)
+        SuccessfulTermination(correctInstanceType.toString)
 
-            val dOpt = dxniOptions(options)
-            val output = dOpt.outputFile match {
-                case None => throw new Exception("Output file not specified")
-                case Some(x) => x
-            }
+      case InternalOp.TaskProlog =>
+        val (localizedInputs, dxUrl2path) = taskRunner.prolog(inputs)
+        taskRunner.writeEnvToDisk(localizedInputs, dxUrl2path)
+        SuccessfulTermination(s"success ${op}")
 
-            if (dOpt.apps)
-                dxniApps(options, dOpt, output)
-            else
-                dxniApplets(options, dOpt, output)
-        } catch {
-            case e: Throwable =>
-                return BadUsageTermination(Utils.exceptionToString(e))
-        }
-    }
-
-    private def taskAction(op: InternalOp.Value,
-                           taskSourceCode: String,
-                           instanceTypeDB: InstanceTypeDB,
-                           jobInputPath: Path,
-                           jobOutputPath: Path,
-                           dxPathConfig : DxPathConfig,
-                           dxIoFunctions : DxIoFunctions,
-                           defaultRuntimeAttributes : Option[WdlRuntimeAttrs],
-                           rtDebugLvl: Int): Termination = {
-        // Parse the inputs, convert to WOM values. Delay downloading files
-        // from the platform, we may not need to access them.
-        val verbose = rtDebugLvl > 0
-        val inputLines : String = Utils.readFileContent(jobInputPath)
-        val originalInputs : JsValue = inputLines.parseJson
-
-        val (task, typeAliases) = ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
-
-        // setup the utility directories that the task-runner employs
-        dxPathConfig.createCleanDirs()
-
-        val jobInputOutput = new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
-        val inputs = jobInputOutput.loadInputs(originalInputs, task)
-        val taskRunner = exec.TaskRunner(task, taskSourceCode, typeAliases, instanceTypeDB,
-                                         dxPathConfig, dxIoFunctions, jobInputOutput,
-                                         defaultRuntimeAttributes, rtDebugLvl)
-
-        // Running tasks
-        op match {
-            case InternalOp.TaskCheckInstanceType =>
-                // special operation to check if this task is on the right instance type
-                val correctInstanceType:Boolean = taskRunner.checkInstanceType(inputs)
-                SuccessfulTermination(correctInstanceType.toString)
-
-            case InternalOp.TaskProlog =>
-                val (localizedInputs, dxUrl2path) = taskRunner.prolog(inputs)
-                taskRunner.writeEnvToDisk(localizedInputs, dxUrl2path)
-                SuccessfulTermination(s"success ${op}")
-
-            case InternalOp.TaskEpilog =>
-                val (localizedInputs, dxUrl2path) = taskRunner.readEnvFromDisk()
-                val outputFields: Map[String, JsValue] = taskRunner.epilog(localizedInputs, dxUrl2path)
-
-                // write outputs, ignore null values, these could occur for optional
-                // values that were not specified.
-                val json = JsObject(outputFields.filter{
-                                        case (_,jsValue) => jsValue != null && jsValue != JsNull
-                                    })
-                val ast_pp = json.prettyPrint
-                Utils.writeFileContent(jobOutputPath, ast_pp)
-                SuccessfulTermination(s"success ${op}")
-
-            case InternalOp.TaskRelaunch =>
-                val outputFields: Map[String, JsValue] = taskRunner.relaunch(inputs, originalInputs)
-                val json = JsObject(outputFields.filter{
-                                        case (_,jsValue) => jsValue != null && jsValue != JsNull
-                                    })
-                val ast_pp = json.prettyPrint
-                Utils.writeFileContent(jobOutputPath, ast_pp)
-                SuccessfulTermination(s"success ${op}")
-
-            case _ =>
-                UnsuccessfulTermination(s"Illegal task operation ${op}")
-        }
-    }
-
-    // Execute a part of a workflow
-    private def workflowFragAction(op: InternalOp.Value,
-                                   womSourceCode: String,
-                                   instanceTypeDB: InstanceTypeDB,
-                                   metaInfo: JsValue,
-                                   jobInputPath: Path,
-                                   jobOutputPath: Path,
-                                   dxPathConfig : DxPathConfig,
-                                   dxIoFunctions : DxIoFunctions,
-                                   defaultRuntimeAttributes : Option[WdlRuntimeAttrs],
-                                   rtDebugLvl: Int): Termination = {
-        val dxProject = DxUtils.dxCrntProject
-        //val dxProject = DxUtils.dxEnv.getProjectContext()
-        val verbose = rtDebugLvl > 0
-
-        // Parse the inputs, convert to WOM values. Delay downloading files
-        // from the platform, we may not need to access them.
-        val inputLines : String = Utils.readFileContent(jobInputPath)
-        val inputsRaw : JsValue = inputLines.parseJson
-
-        val (wf, taskDir, typeAliases) = ParseWomSourceFile(verbose).parseWdlWorkflow(womSourceCode)
-
-        // setup the utility directories that the frag-runner employs
-        val fragInputOutput = new exec.WfFragInputOutput(dxIoFunctions, dxProject, rtDebugLvl, typeAliases)
-
-        // process the inputs
-        val fragInputs = fragInputOutput.loadInputs(inputsRaw, metaInfo)
-        val outputFields: Map[String, JsValue] =
-            op match {
-                case InternalOp.WfFragment =>
-                    val fragRunner = new exec.WfFragRunner(wf, taskDir, typeAliases,
-                                                           womSourceCode, instanceTypeDB,
-                                                           fragInputs.execLinkInfo,
-                                                           dxPathConfig, dxIoFunctions,
-                                                           inputsRaw,
-                                                           fragInputOutput,
-                                                           defaultRuntimeAttributes,
-                                                           rtDebugLvl)
-                    fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Launch)
-                case InternalOp.Collect =>
-                    val fragRunner = new exec.WfFragRunner(wf, taskDir, typeAliases,
-                                                           womSourceCode, instanceTypeDB,
-                                                           fragInputs.execLinkInfo,
-                                                           dxPathConfig, dxIoFunctions,
-                                                           inputsRaw,
-                                                           fragInputOutput,
-                                                           defaultRuntimeAttributes,
-                                                           rtDebugLvl)
-                    fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Collect)
-                case InternalOp.WfInputs =>
-                    val wfInputs = new exec.WfInputs(wf, womSourceCode, typeAliases,
-                                                     dxPathConfig, dxIoFunctions,
-                                                     rtDebugLvl)
-                    wfInputs.apply(fragInputs.env)
-                case InternalOp.WfOutputs =>
-                    val wfOutputs = new exec.
-                    WfOutputs(wf, womSourceCode, typeAliases,
-                                                       dxPathConfig, dxIoFunctions,
-                                                       rtDebugLvl)
-                    wfOutputs.apply(fragInputs.env)
-
-                case InternalOp.WfCustomReorgOutputs =>
-                    val wfCustomReorgOutputs = new exec.WfOutputs(
-                        wf, womSourceCode, typeAliases, dxPathConfig, dxIoFunctions, rtDebugLvl
-                    )
-                    // add ___reconf_status as output.
-                    wfCustomReorgOutputs.apply(fragInputs.env, addStatus = true)
-
-                case InternalOp.WorkflowOutputReorg =>
-                    val wfReorg = new exec.WorkflowOutputReorg(wf, womSourceCode, typeAliases,
-                                                               dxPathConfig, dxIoFunctions,
-                                                               rtDebugLvl)
-                    val refDxFiles = fragInputOutput.findRefDxFiles(inputsRaw, metaInfo)
-                    wfReorg.apply(refDxFiles)
-
-                case _ =>
-                    throw new Exception(s"Illegal workflow fragment operation ${op}")
-            }
+      case InternalOp.TaskEpilog =>
+        val (localizedInputs, dxUrl2path)      = taskRunner.readEnvFromDisk()
+        val outputFields: Map[String, JsValue] = taskRunner.epilog(localizedInputs, dxUrl2path)
 
         // write outputs, ignore null values, these could occur for optional
         // values that were not specified.
-        val json = JsObject(outputFields)
+        val json = JsObject(outputFields.filter {
+          case (_, jsValue) => jsValue != null && jsValue != JsNull
+        })
         val ast_pp = json.prettyPrint
         Utils.writeFileContent(jobOutputPath, ast_pp)
-
         SuccessfulTermination(s"success ${op}")
+
+      case InternalOp.TaskRelaunch =>
+        val outputFields: Map[String, JsValue] = taskRunner.relaunch(inputs, originalInputs)
+        val json = JsObject(outputFields.filter {
+          case (_, jsValue) => jsValue != null && jsValue != JsNull
+        })
+        val ast_pp = json.prettyPrint
+        Utils.writeFileContent(jobOutputPath, ast_pp)
+        SuccessfulTermination(s"success ${op}")
+
+      case _ =>
+        UnsuccessfulTermination(s"Illegal task operation ${op}")
     }
+  }
 
+  // Execute a part of a workflow
+  private def workflowFragAction(
+      op: InternalOp.Value,
+      womSourceCode: String,
+      instanceTypeDB: InstanceTypeDB,
+      metaInfo: JsValue,
+      jobInputPath: Path,
+      jobOutputPath: Path,
+      dxPathConfig: DxPathConfig,
+      dxIoFunctions: DxIoFunctions,
+      defaultRuntimeAttributes: Option[WdlRuntimeAttrs],
+      rtDebugLvl: Int
+  ): Termination = {
+    val dxProject = DxUtils.dxCrntProject
+    //val dxProject = DxUtils.dxEnv.getProjectContext()
+    val verbose = rtDebugLvl > 0
 
-    // Get the WOM source code, and the instance type database from the
-    // details field stored on the platform
-    private def retrieveFromDetails(jobInfoPath: Path) : (String,
-                                                          InstanceTypeDB,
-                                                          JsValue,
-                                                          Option[WdlRuntimeAttrs]) = {
-        val jobInfo = Utils.readFileContent(jobInfoPath).parseJson
-        val applet: DxApplet = jobInfo.asJsObject.fields.get("applet") match {
-            case None =>
-                Utils.trace(true,
-                            s"""|applet field not found locally, performing
+    // Parse the inputs, convert to WOM values. Delay downloading files
+    // from the platform, we may not need to access them.
+    val inputLines: String = Utils.readFileContent(jobInputPath)
+    val inputsRaw: JsValue = inputLines.parseJson
+
+    val (wf, taskDir, typeAliases) = ParseWomSourceFile(verbose).parseWdlWorkflow(womSourceCode)
+
+    // setup the utility directories that the frag-runner employs
+    val fragInputOutput =
+      new exec.WfFragInputOutput(dxIoFunctions, dxProject, rtDebugLvl, typeAliases)
+
+    // process the inputs
+    val fragInputs = fragInputOutput.loadInputs(inputsRaw, metaInfo)
+    val outputFields: Map[String, JsValue] =
+      op match {
+        case InternalOp.WfFragment =>
+          val fragRunner = new exec.WfFragRunner(
+            wf,
+            taskDir,
+            typeAliases,
+            womSourceCode,
+            instanceTypeDB,
+            fragInputs.execLinkInfo,
+            dxPathConfig,
+            dxIoFunctions,
+            inputsRaw,
+            fragInputOutput,
+            defaultRuntimeAttributes,
+            rtDebugLvl
+          )
+          fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Launch)
+        case InternalOp.Collect =>
+          val fragRunner = new exec.WfFragRunner(
+            wf,
+            taskDir,
+            typeAliases,
+            womSourceCode,
+            instanceTypeDB,
+            fragInputs.execLinkInfo,
+            dxPathConfig,
+            dxIoFunctions,
+            inputsRaw,
+            fragInputOutput,
+            defaultRuntimeAttributes,
+            rtDebugLvl
+          )
+          fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Collect)
+        case InternalOp.WfInputs =>
+          val wfInputs = new exec.WfInputs(
+            wf,
+            womSourceCode,
+            typeAliases,
+            dxPathConfig,
+            dxIoFunctions,
+            rtDebugLvl
+          )
+          wfInputs.apply(fragInputs.env)
+        case InternalOp.WfOutputs =>
+          val wfOutputs = new exec.WfOutputs(
+            wf,
+            womSourceCode,
+            typeAliases,
+            dxPathConfig,
+            dxIoFunctions,
+            rtDebugLvl
+          )
+          wfOutputs.apply(fragInputs.env)
+
+        case InternalOp.WfCustomReorgOutputs =>
+          val wfCustomReorgOutputs = new exec.WfOutputs(
+            wf,
+            womSourceCode,
+            typeAliases,
+            dxPathConfig,
+            dxIoFunctions,
+            rtDebugLvl
+          )
+          // add ___reconf_status as output.
+          wfCustomReorgOutputs.apply(fragInputs.env, addStatus = true)
+
+        case InternalOp.WorkflowOutputReorg =>
+          val wfReorg = new exec.WorkflowOutputReorg(
+            wf,
+            womSourceCode,
+            typeAliases,
+            dxPathConfig,
+            dxIoFunctions,
+            rtDebugLvl
+          )
+          val refDxFiles = fragInputOutput.findRefDxFiles(inputsRaw, metaInfo)
+          wfReorg.apply(refDxFiles)
+
+        case _ =>
+          throw new Exception(s"Illegal workflow fragment operation ${op}")
+      }
+
+    // write outputs, ignore null values, these could occur for optional
+    // values that were not specified.
+    val json   = JsObject(outputFields)
+    val ast_pp = json.prettyPrint
+    Utils.writeFileContent(jobOutputPath, ast_pp)
+
+    SuccessfulTermination(s"success ${op}")
+  }
+
+  // Get the WOM source code, and the instance type database from the
+  // details field stored on the platform
+  private def retrieveFromDetails(
+      jobInfoPath: Path
+  ): (String, InstanceTypeDB, JsValue, Option[WdlRuntimeAttrs]) = {
+    val jobInfo = Utils.readFileContent(jobInfoPath).parseJson
+    val applet: DxApplet = jobInfo.asJsObject.fields.get("applet") match {
+      case None =>
+        Utils.trace(true, s"""|applet field not found locally, performing
                                 |an API call.
                                 |""".stripMargin)
-                val dxJob = DxJob(DxUtils.dxEnv.getJob())
-                dxJob.describe().applet
-            case Some(JsString(x)) =>
-                DxApplet(x, None)
-            case Some(other) =>
-                throw new Exception(s"malformed applet field ${other} in job info")
-        }
-
-        val details: JsValue = applet.describe(Set(Field.Details)).details.get
-        val JsString(womSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
-        val womSourceCode = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
-
-        val JsString(instanceTypeDBEncoded) = details.asJsObject.fields("instanceTypeDB")
-        val dbRaw = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
-        val instanceTypeDB = dbRaw.parseJson.convertTo[InstanceTypeDB]
-
-        val runtimeAttrs : Option[WdlRuntimeAttrs] = details.asJsObject.fields.get("runtimeAttrs") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(x) => Some(x.convertTo[WdlRuntimeAttrs])
-        }
-        (womSourceCode, instanceTypeDB, details, runtimeAttrs)
+        val dxJob = DxJob(DxUtils.dxEnv.getJob())
+        dxJob.describe().applet
+      case Some(JsString(x)) =>
+        DxApplet(x, None)
+      case Some(other) =>
+        throw new Exception(s"malformed applet field ${other} in job info")
     }
 
-    // Make a list of all the files cloned for access by this applet.
-    // Bulk describe all the them.
-    private def runtimeBulkFileDescribe(jobInputPath: Path) : Map[String, (DxFile, DxFileDescribe)] = {
-        val inputs: JsValue = Utils.readFileContent(jobInputPath).parseJson
+    val details: JsValue               = applet.describe(Set(Field.Details)).details.get
+    val JsString(womSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
+    val womSourceCode                  = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
 
-        val allFilesReferenced = inputs.asJsObject.fields.flatMap{
-            case (_, jsElem) => DxUtils.findDxFiles(jsElem)
-        }.toVector
+    val JsString(instanceTypeDBEncoded) = details.asJsObject.fields("instanceTypeDB")
+    val dbRaw                           = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
+    val instanceTypeDB                  = dbRaw.parseJson.convertTo[InstanceTypeDB]
 
-        // Describe all the files, in one go
-        val descAll = DxFile.bulkDescribe(allFilesReferenced)
-        descAll.map{
-            case (DxFile(fid, proj), desc) =>
-                fid -> (DxFile(fid, proj), desc)
-            case (other, _) =>
-                throw new Exception(s"wrong object type ${other} (should be a file)")
-        }.toMap
-    }
+    val runtimeAttrs: Option[WdlRuntimeAttrs] =
+      details.asJsObject.fields.get("runtimeAttrs") match {
+        case None         => None
+        case Some(JsNull) => None
+        case Some(x)      => Some(x.convertTo[WdlRuntimeAttrs])
+      }
+    (womSourceCode, instanceTypeDB, details, runtimeAttrs)
+  }
 
-    def internalOp(args : Seq[String]) : Termination = {
-        val operation = InternalOp.values find (x => normKey(x.toString) == normKey(args.head))
-        operation match {
-            case None =>
-                UnsuccessfulTermination(s"unknown internal action ${args.head}")
-            case Some(op) if args.length == 4 =>
-                val homeDir = Paths.get(args(1))
-                val rtDebugLvl = parseRuntimeDebugLevel(args(2))
-                val streamAllFiles = parseStreamAllFiles(args(3))
-                val (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath) =
-                    Utils.jobFilesOfHomeDir(homeDir)
-                val dxPathConfig = buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
-                val fileInfoDir = runtimeBulkFileDescribe(jobInputPath)
-                val dxIoFunctions = DxIoFunctions(fileInfoDir, dxPathConfig, rtDebugLvl)
+  // Make a list of all the files cloned for access by this applet.
+  // Bulk describe all the them.
+  private def runtimeBulkFileDescribe(jobInputPath: Path): Map[String, (DxFile, DxFileDescribe)] = {
+    val inputs: JsValue = Utils.readFileContent(jobInputPath).parseJson
 
-                // Get the WOM source code (currently WDL, could be also CWL in the future)
-                // Parse the inputs, convert to WOM values.
-                val (womSourceCode, instanceTypeDB, metaInfo, defaultRuntimeAttrs) =
-                    retrieveFromDetails(jobInfoPath)
+    val allFilesReferenced = inputs.asJsObject.fields.flatMap {
+      case (_, jsElem) => DxUtils.findDxFiles(jsElem)
+    }.toVector
 
-                try {
-                    op match {
-                        case InternalOp.Collect |
-                                InternalOp.WfFragment |
-                                InternalOp.WfInputs |
-                                InternalOp.WfOutputs |
-                                InternalOp.WorkflowOutputReorg |
-                                InternalOp.WfCustomReorgOutputs =>
-                            workflowFragAction(op, womSourceCode, instanceTypeDB, metaInfo,
-                                               jobInputPath, jobOutputPath,
-                                               dxPathConfig, dxIoFunctions,
-                                               defaultRuntimeAttrs, rtDebugLvl)
-                        case InternalOp.TaskCheckInstanceType|
-                                InternalOp.TaskEpilog|
-                                InternalOp.TaskProlog|
-                                InternalOp.TaskRelaunch =>
-                            taskAction(op, womSourceCode, instanceTypeDB,
-                                       jobInputPath, jobOutputPath,
-                                       dxPathConfig, dxIoFunctions,
-                                       defaultRuntimeAttrs, rtDebugLvl)
-                    }
-                } catch {
-                    case e : Throwable =>
-                        writeJobError(jobErrorPath, e)
-                        UnsuccessfulTermination(s"failure running ${op}")
-                }
-            case Some(_) =>
-                BadUsageTermination(s"""|Bad arguments to internal operation
+    // Describe all the files, in one go
+    val descAll = DxFile.bulkDescribe(allFilesReferenced)
+    descAll.map {
+      case (DxFile(fid, proj), desc) =>
+        fid -> (DxFile(fid, proj), desc)
+      case (other, _) =>
+        throw new Exception(s"wrong object type ${other} (should be a file)")
+    }.toMap
+  }
+
+  def internalOp(args: Seq[String]): Termination = {
+    val operation = InternalOp.values find (x => normKey(x.toString) == normKey(args.head))
+    operation match {
+      case None =>
+        UnsuccessfulTermination(s"unknown internal action ${args.head}")
+      case Some(op) if args.length == 4 =>
+        val homeDir        = Paths.get(args(1))
+        val rtDebugLvl     = parseRuntimeDebugLevel(args(2))
+        val streamAllFiles = parseStreamAllFiles(args(3))
+        val (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath) =
+          Utils.jobFilesOfHomeDir(homeDir)
+        val dxPathConfig  = buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
+        val fileInfoDir   = runtimeBulkFileDescribe(jobInputPath)
+        val dxIoFunctions = DxIoFunctions(fileInfoDir, dxPathConfig, rtDebugLvl)
+
+        // Get the WOM source code (currently WDL, could be also CWL in the future)
+        // Parse the inputs, convert to WOM values.
+        val (womSourceCode, instanceTypeDB, metaInfo, defaultRuntimeAttrs) =
+          retrieveFromDetails(jobInfoPath)
+
+        try {
+          op match {
+            case InternalOp.Collect | InternalOp.WfFragment | InternalOp.WfInputs |
+                InternalOp.WfOutputs | InternalOp.WorkflowOutputReorg |
+                InternalOp.WfCustomReorgOutputs =>
+              workflowFragAction(
+                op,
+                womSourceCode,
+                instanceTypeDB,
+                metaInfo,
+                jobInputPath,
+                jobOutputPath,
+                dxPathConfig,
+                dxIoFunctions,
+                defaultRuntimeAttrs,
+                rtDebugLvl
+              )
+            case InternalOp.TaskCheckInstanceType | InternalOp.TaskEpilog | InternalOp.TaskProlog |
+                InternalOp.TaskRelaunch =>
+              taskAction(
+                op,
+                womSourceCode,
+                instanceTypeDB,
+                jobInputPath,
+                jobOutputPath,
+                dxPathConfig,
+                dxIoFunctions,
+                defaultRuntimeAttrs,
+                rtDebugLvl
+              )
+          }
+        } catch {
+          case e: Throwable =>
+            writeJobError(jobErrorPath, e)
+            UnsuccessfulTermination(s"failure running ${op}")
+        }
+      case Some(_) =>
+        BadUsageTermination(s"""|Bad arguments to internal operation
                                         |  ${args}
                                         |Usage:
                                         |  java -jar dxWDL.jar internal <action> <home dir> <debug level>
                                         |""".stripMargin)
+    }
+  }
+
+  def dispatchCommand(args: Seq[String]): Termination = {
+    if (args.isEmpty)
+      return BadUsageTermination("")
+    val action = Actions.values find (x => normKey(x.toString) == normKey(args.head))
+    action match {
+      case None => BadUsageTermination("")
+      case Some(x) =>
+        x match {
+          case Actions.Compile  => compile(args.tail)
+          case Actions.Config   => SuccessfulTermination(ConfigFactory.load().toString)
+          case Actions.DXNI     => dxni(args.tail)
+          case Actions.Internal => internalOp(args.tail)
+          case Actions.Version  => SuccessfulTermination(Utils.getVersion())
         }
     }
+  }
 
-    def dispatchCommand(args: Seq[String]): Termination = {
-        if (args.isEmpty)
-            return BadUsageTermination("")
-        val action = Actions.values find (x => normKey(x.toString) == normKey(args.head))
-        action match {
-            case None => BadUsageTermination("")
-            case Some(x) => x match {
-                case Actions.Compile => compile(args.tail)
-                case Actions.Config => SuccessfulTermination(ConfigFactory.load().toString)
-                case Actions.DXNI => dxni(args.tail)
-                case Actions.Internal => internalOp(args.tail)
-                case Actions.Version => SuccessfulTermination(Utils.getVersion())
-            }
-        }
-    }
-
-    val usageMessage =
-        s"""|java -jar dxWDL.jar <action> <parameters> [options]
+  val usageMessage =
+    s"""|java -jar dxWDL.jar <action> <parameters> [options]
             |
             |Actions:
             |  compile <WDL file>
@@ -866,22 +930,22 @@ object Main extends App {
             |    -verboseKey [module]     Detailed information for a specific module
             |""".stripMargin
 
-    val termination = dispatchCommand(args)
+  val termination = dispatchCommand(args)
 
-    termination match {
-        case SuccessfulTermination(s) =>
-            println(s)
-        case SuccessfulTerminationIR(s) =>
-            println("Intermediate representation")
-        case BadUsageTermination(s) if (s == "") =>
-            Console.err.println(usageMessage)
-            System.exit(1)
-        case BadUsageTermination(s) =>
-            Utils.error(s)
-            System.exit(1)
-        case UnsuccessfulTermination(s) =>
-            Utils.error(s)
-            System.exit(1)
-    }
-    System.exit(0)
+  termination match {
+    case SuccessfulTermination(s) =>
+      println(s)
+    case SuccessfulTerminationIR(s) =>
+      println("Intermediate representation")
+    case BadUsageTermination(s) if (s == "") =>
+      Console.err.println(usageMessage)
+      System.exit(1)
+    case BadUsageTermination(s) =>
+      Utils.error(s)
+      System.exit(1)
+    case UnsuccessfulTermination(s) =>
+      Utils.error(s)
+      System.exit(1)
+  }
+  System.exit(0)
 }

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -43,7 +43,10 @@ object Main extends App {
   // runtime, not at compile time. On the cloud instance running the
   // job, the user is "dnanexus", and the home directory is
   // "/home/dnanexus".
-  private def buildRuntimePathConfig(streamAllFiles: Boolean, verbose: Boolean): DxPathConfig = {
+  private def buildRuntimePathConfig(
+      streamAllFiles: Boolean,
+      verbose: Boolean
+  ): DxPathConfig = {
     DxPathConfig.apply(baseDNAxDir, streamAllFiles, verbose)
   }
 
@@ -60,17 +63,18 @@ object Main extends App {
   def splitCmdLine(arglist: List[String]): List[List[String]] = {
     def isKeyword(word: String): Boolean = word.startsWith("-")
 
-    val keywordAndOptions: List[List[String]] = arglist.foldLeft(List.empty[List[String]]) {
-      case (head :: tail, word) if (isKeyword(word)) =>
-        List(word) :: head :: tail
-      case ((head :: tail), word) =>
-        (word :: head) :: tail
-      case (head, word) if (isKeyword(word)) =>
-        List(word) :: head
-      case (Nil, word) if (isKeyword(word)) => List(List(word))
-      case (Nil, word) if (!isKeyword(word)) =>
-        throw new Exception("Keyword must precede options")
-    }
+    val keywordAndOptions: List[List[String]] =
+      arglist.foldLeft(List.empty[List[String]]) {
+        case (head :: tail, word) if (isKeyword(word)) =>
+          List(word) :: head :: tail
+        case ((head :: tail), word) =>
+          (word :: head) :: tail
+        case (head, word) if (isKeyword(word)) =>
+          List(word) :: head
+        case (Nil, word) if (isKeyword(word)) => List(List(word))
+        case (Nil, word) if (!isKeyword(word)) =>
+          throw new Exception("Keyword must precede options")
+      }
     keywordAndOptions.map(_.reverse).reverse
   }
 
@@ -91,9 +95,12 @@ object Main extends App {
         subargs: List[String]
     ): Unit = {
       if (expectedNumArgs != subargs.length)
-        throw new Exception(s"""|Wrong number of arguments for ${keyword}.
+        throw new Exception(
+          s"""|Wrong number of arguments for ${keyword}.
                                         |Expected ${expectedNumArgs}, input is
-                                        |${subargs}""".stripMargin.replaceAll("\n", " "))
+                                        |${subargs}""".stripMargin
+            .replaceAll("\n", " ")
+        )
     }
     val cmdLineOpts = splitCmdLine(arglist)
     val options = HashMap.empty[String, List[String]]
@@ -178,7 +185,9 @@ object Main extends App {
             checkNumberOfArguments(keyword, 1, subargs)
             (keyword, subargs.head)
           case _ =>
-            throw new IllegalArgumentException(s"Unregonized keyword ${keyword}")
+            throw new IllegalArgumentException(
+              s"Unregonized keyword ${keyword}"
+            )
         }
         options.get(nKeyword) match {
           case None =>
@@ -221,7 +230,10 @@ object Main extends App {
     System.err.println(Utils.exceptionToString(e))
   }
 
-  private def pathOptions(options: OptionsMap, verbose: Verbose): (DxProject, String) = {
+  private def pathOptions(
+      options: OptionsMap,
+      verbose: Verbose
+  ): (DxProject, String) = {
     var folderOpt: Option[String] = options.get("folder") match {
       case None          => None
       case Some(List(f)) => Some(f)
@@ -330,14 +342,17 @@ object Main extends App {
       case None                 => Set.empty
       case Some(modulesToTrace) => modulesToTrace.toSet
     }
-    val verbose = Verbose(options contains "verbose", options contains "quiet", verboseKeys)
+    val verbose =
+      Verbose(options contains "verbose", options contains "quiet", verboseKeys)
 
     val compileMode: CompilerFlag.Value = options.get("compileMode") match {
-      case None                                                 => CompilerFlag.All
-      case Some(List(x)) if (x.toLowerCase == "IR".toLowerCase) => CompilerFlag.IR
+      case None => CompilerFlag.All
+      case Some(List(x)) if (x.toLowerCase == "IR".toLowerCase) =>
+        CompilerFlag.IR
       case Some(List(x)) if (x.toLowerCase == "NativeWithoutRuntimeAsset".toLowerCase) =>
         CompilerFlag.NativeWithoutRuntimeAsset
-      case Some(other) => throw new Exception(s"unrecognized compiler flag ${other}")
+      case Some(other) =>
+        throw new Exception(s"unrecognized compiler flag ${other}")
     }
     val defaults: Option[Path] = options.get("defaults") match {
       case None          => None
@@ -359,11 +374,12 @@ object Main extends App {
       case None     => List.empty
       case Some(pl) => pl.map(p => Paths.get(p))
     }
-    val runtimeDebugLevel: Option[Int] = options.get("runtimeDebugLevel") match {
-      case None                  => None
-      case Some(List(numberStr)) => Some(parseRuntimeDebugLevel(numberStr))
-      case _                     => throw new Exception("debug level specified twice")
-    }
+    val runtimeDebugLevel: Option[Int] =
+      options.get("runtimeDebugLevel") match {
+        case None                  => None
+        case Some(List(numberStr)) => Some(parseRuntimeDebugLevel(numberStr))
+        case _                     => throw new Exception("debug level specified twice")
+      }
 
     if (extras != None) {
 
@@ -422,17 +438,22 @@ object Main extends App {
           .replaceAll("_", "")
           .replaceAll("-", "")
         if (!bufNorm.startsWith("wdl"))
-          throw new Exception(s"unknown language ${bufNorm}. Only WDL is supported")
+          throw new Exception(
+            s"unknown language ${bufNorm}. Only WDL is supported"
+          )
         val suffix = bufNorm.substring("wdl".length)
         if (suffix contains "draft2")
           Language.WDLvDraft2
         else if (suffix contains ("10"))
           Language.WDLv1_0
         else
-          throw new Exception(s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1")
+          throw new Exception(
+            s"unknown language ${bufNorm}. Supported: WDL_draft2, WDL_v1"
+          )
       case _ => throw new Exception("only one language can be specified")
     }
-    val verbose = Verbose(options contains "verbose", options contains "quiet", verboseKeys)
+    val verbose =
+      Verbose(options contains "verbose", options contains "quiet", verboseKeys)
     DxniOptions(
       options contains "apps",
       options contains "force",
@@ -467,7 +488,11 @@ object Main extends App {
           return SuccessfulTerminationIR(ir)
 
         case CompilerFlag.All | CompilerFlag.NativeWithoutRuntimeAsset =>
-          val dxPathConfig = DxPathConfig.apply(baseDNAxDir, cOpt.streamAllFiles, cOpt.verbose.on)
+          val dxPathConfig = DxPathConfig.apply(
+            baseDNAxDir,
+            cOpt.streamAllFiles,
+            cOpt.verbose.on
+          )
           val retval = top.apply(sourceFile, folder, dxProject, dxPathConfig)
           val desc = retval.getOrElse("")
           return SuccessfulTermination(desc)
@@ -478,7 +503,11 @@ object Main extends App {
     }
   }
 
-  private def dxniApplets(options: OptionsMap, dOpt: DxniOptions, outputFile: Path): Termination = {
+  private def dxniApplets(
+      options: OptionsMap,
+      dOpt: DxniOptions,
+      outputFile: Path
+  ): Termination = {
     val (dxProject, folder) =
       try {
         pathOptions(options, dOpt.verbose)
@@ -515,9 +544,18 @@ object Main extends App {
     }
   }
 
-  private def dxniApps(options: OptionsMap, dOpt: DxniOptions, outputFile: Path): Termination = {
+  private def dxniApps(
+      options: OptionsMap,
+      dOpt: DxniOptions,
+      outputFile: Path
+  ): Termination = {
     try {
-      compiler.DxNI.applyApps(outputFile, dOpt.force, dOpt.language, dOpt.verbose)
+      compiler.DxNI.applyApps(
+        outputFile,
+        dOpt.force,
+        dOpt.language,
+        dOpt.verbose
+      )
       SuccessfulTermination("")
     } catch {
       case e: Throwable =>
@@ -564,12 +602,14 @@ object Main extends App {
     val inputLines: String = Utils.readFileContent(jobInputPath)
     val originalInputs: JsValue = inputLines.parseJson
 
-    val (task, typeAliases) = ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
+    val (task, typeAliases) =
+      ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
 
     // setup the utility directories that the task-runner employs
     dxPathConfig.createCleanDirs()
 
-    val jobInputOutput = new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
+    val jobInputOutput =
+      new exec.JobInputOutput(dxIoFunctions, rtDebugLvl, typeAliases)
     val inputs = jobInputOutput.loadInputs(originalInputs, task)
     val taskRunner = exec.TaskRunner(
       task,
@@ -597,7 +637,8 @@ object Main extends App {
 
       case InternalOp.TaskEpilog =>
         val (localizedInputs, dxUrl2path) = taskRunner.readEnvFromDisk()
-        val outputFields: Map[String, JsValue] = taskRunner.epilog(localizedInputs, dxUrl2path)
+        val outputFields: Map[String, JsValue] =
+          taskRunner.epilog(localizedInputs, dxUrl2path)
 
         // write outputs, ignore null values, these could occur for optional
         // values that were not specified.
@@ -609,7 +650,8 @@ object Main extends App {
         SuccessfulTermination(s"success ${op}")
 
       case InternalOp.TaskRelaunch =>
-        val outputFields: Map[String, JsValue] = taskRunner.relaunch(inputs, originalInputs)
+        val outputFields: Map[String, JsValue] =
+          taskRunner.relaunch(inputs, originalInputs)
         val json = JsObject(outputFields.filter {
           case (_, jsValue) => jsValue != null && jsValue != JsNull
         })
@@ -644,11 +686,17 @@ object Main extends App {
     val inputLines: String = Utils.readFileContent(jobInputPath)
     val inputsRaw: JsValue = inputLines.parseJson
 
-    val (wf, taskDir, typeAliases) = ParseWomSourceFile(verbose).parseWdlWorkflow(womSourceCode)
+    val (wf, taskDir, typeAliases) =
+      ParseWomSourceFile(verbose).parseWdlWorkflow(womSourceCode)
 
     // setup the utility directories that the frag-runner employs
     val fragInputOutput =
-      new exec.WfFragInputOutput(dxIoFunctions, dxProject, rtDebugLvl, typeAliases)
+      new exec.WfFragInputOutput(
+        dxIoFunctions,
+        dxProject,
+        rtDebugLvl,
+        typeAliases
+      )
 
     // process the inputs
     val fragInputs = fragInputOutput.loadInputs(inputsRaw, metaInfo)
@@ -669,7 +717,11 @@ object Main extends App {
             defaultRuntimeAttributes,
             rtDebugLvl
           )
-          fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Launch)
+          fragRunner.apply(
+            fragInputs.blockPath,
+            fragInputs.env,
+            RunnerWfFragmentMode.Launch
+          )
         case InternalOp.Collect =>
           val fragRunner = new exec.WfFragRunner(
             wf,
@@ -685,7 +737,11 @@ object Main extends App {
             defaultRuntimeAttributes,
             rtDebugLvl
           )
-          fragRunner.apply(fragInputs.blockPath, fragInputs.env, RunnerWfFragmentMode.Collect)
+          fragRunner.apply(
+            fragInputs.blockPath,
+            fragInputs.env,
+            RunnerWfFragmentMode.Collect
+          )
         case InternalOp.WfInputs =>
           val wfInputs = new exec.WfInputs(
             wf,
@@ -764,10 +820,12 @@ object Main extends App {
     }
 
     val details: JsValue = applet.describe(Set(Field.Details)).details.get
-    val JsString(womSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
+    val JsString(womSourceCodeEncoded) =
+      details.asJsObject.fields("womSourceCode")
     val womSourceCode = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
 
-    val JsString(instanceTypeDBEncoded) = details.asJsObject.fields("instanceTypeDB")
+    val JsString(instanceTypeDBEncoded) =
+      details.asJsObject.fields("instanceTypeDB")
     val dbRaw = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
     val instanceTypeDB = dbRaw.parseJson.convertTo[InstanceTypeDB]
 
@@ -782,7 +840,9 @@ object Main extends App {
 
   // Make a list of all the files cloned for access by this applet.
   // Bulk describe all the them.
-  private def runtimeBulkFileDescribe(jobInputPath: Path): Map[String, (DxFile, DxFileDescribe)] = {
+  private def runtimeBulkFileDescribe(
+      jobInputPath: Path
+  ): Map[String, (DxFile, DxFileDescribe)] = {
     val inputs: JsValue = Utils.readFileContent(jobInputPath).parseJson
 
     val allFilesReferenced = inputs.asJsObject.fields.flatMap {
@@ -800,7 +860,9 @@ object Main extends App {
   }
 
   def internalOp(args: Seq[String]): Termination = {
-    val operation = InternalOp.values find (x => normKey(x.toString) == normKey(args.head))
+    val operation = InternalOp.values find (
+        x => normKey(x.toString) == normKey(args.head)
+    )
     operation match {
       case None =>
         UnsuccessfulTermination(s"unknown internal action ${args.head}")
@@ -810,7 +872,8 @@ object Main extends App {
         val streamAllFiles = parseStreamAllFiles(args(3))
         val (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath) =
           Utils.jobFilesOfHomeDir(homeDir)
-        val dxPathConfig = buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
+        val dxPathConfig =
+          buildRuntimePathConfig(streamAllFiles, rtDebugLvl >= 1)
         val fileInfoDir = runtimeBulkFileDescribe(jobInputPath)
         val dxIoFunctions = DxIoFunctions(fileInfoDir, dxPathConfig, rtDebugLvl)
 
@@ -867,13 +930,16 @@ object Main extends App {
   def dispatchCommand(args: Seq[String]): Termination = {
     if (args.isEmpty)
       return BadUsageTermination("")
-    val action = Actions.values find (x => normKey(x.toString) == normKey(args.head))
+    val action = Actions.values find (
+        x => normKey(x.toString) == normKey(args.head)
+    )
     action match {
       case None => BadUsageTermination("")
       case Some(x) =>
         x match {
-          case Actions.Compile  => compile(args.tail)
-          case Actions.Config   => SuccessfulTermination(ConfigFactory.load().toString)
+          case Actions.Compile => compile(args.tail)
+          case Actions.Config =>
+            SuccessfulTermination(ConfigFactory.load().toString)
           case Actions.DXNI     => dxni(args.tail)
           case Actions.Internal => internalOp(args.tail)
           case Actions.Version  => SuccessfulTermination(Utils.getVersion())

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -10,7 +10,10 @@ import wom.values._
 
 import dxWDL.dx._
 
-case class DxExecPolicy(restartOn: Option[Map[String, Int]], maxRestarts: Option[Int]) {
+case class DxExecPolicy(
+    restartOn: Option[Map[String, Int]],
+    maxRestarts: Option[Int]
+) {
   def toJson: Map[String, JsValue] = {
     val restartOnFields = restartOn match {
       case None => Map.empty
@@ -30,7 +33,11 @@ case class DxExecPolicy(restartOn: Option[Map[String, Int]], maxRestarts: Option
   }
 }
 
-case class DxTimeout(days: Option[Int], hours: Option[Int], minutes: Option[Int]) {
+case class DxTimeout(
+    days: Option[Int],
+    hours: Option[Int],
+    minutes: Option[Int]
+) {
   def toJson: Map[String, JsValue] = {
     val daysField: Map[String, JsValue] = days match {
       case None    => Map.empty
@@ -86,7 +93,10 @@ case class DxAccess(
     networkField ++ projectField ++ allProjectsField ++ developerField ++ projectCreationField
   }
 
-  private def takeMaxAccessLevel(x: AccessLevel, y: AccessLevel): AccessLevel = {
+  private def takeMaxAccessLevel(
+      x: AccessLevel,
+      y: AccessLevel
+  ): AccessLevel = {
     def levelToInt(al: AccessLevel): Int = al match {
       case AccessLevel.ADMINISTER => 5
       case AccessLevel.CONTRIBUTE => 4
@@ -121,7 +131,10 @@ case class DxAccess(
         case _            => None
       }
     }
-    def mergeBooleans(a: Option[Boolean], b: Option[Boolean]): Option[Boolean] = {
+    def mergeBooleans(
+        a: Option[Boolean],
+        b: Option[Boolean]
+    ): Option[Boolean] = {
       Vector(a, b).flatten match {
         case Vector(x)    => Some(x)
         case Vector(x, y) => Some(x || y)
@@ -139,7 +152,13 @@ case class DxAccess(
     val developerMrg = mergeBooleans(developer, dxa.developer)
     val projectCreationMrg = mergeBooleans(projectCreation, dxa.projectCreation)
 
-    DxAccess(networkMrg, projectMrg, allProjectsMrg, developerMrg, projectCreationMrg)
+    DxAccess(
+      networkMrg,
+      projectMrg,
+      allProjectsMrg,
+      developerMrg,
+      projectCreationMrg
+    )
   }
 }
 
@@ -162,8 +181,9 @@ case class DxRunSpec(
         execPolicy.toJson
     }
     val restartableEntryPointsFields = restartableEntryPoints match {
-      case None                => Map.empty
-      case Some(value: String) => Map("restartableEntryPoints" -> JsString(value))
+      case None => Map.empty
+      case Some(value: String) =>
+        Map("restartableEntryPoints" -> JsString(value))
     }
     val timeoutFields = timeoutPolicy match {
       case None             => Map.empty
@@ -267,7 +287,11 @@ object WdlRuntimeAttrs extends DefaultJsonProtocol {
   }
 }
 
-case class DockerRegistry(registry: String, username: String, credentials: String)
+case class DockerRegistry(
+    registry: String,
+    username: String,
+    credentials: String
+)
 
 case class Extras(
     defaultRuntimeAttributes: WdlRuntimeAttrs,
@@ -319,8 +343,17 @@ object Extras {
     "custom_reorg"
   )
   val RUNTIME_ATTRS =
-    Set("dx_instance_type", "memory", "disks", "cpu", "docker", "docker_registry", "custom_reorg")
-  val RUN_SPEC_ATTRS = Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
+    Set(
+      "dx_instance_type",
+      "memory",
+      "disks",
+      "cpu",
+      "docker",
+      "docker_registry",
+      "custom_reorg"
+    )
+  val RUN_SPEC_ATTRS =
+    Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
   val RUN_SPEC_ACCESS_ATTRS =
     Set("network", "project", "allProjects", "developer", "projectCreation")
   val RUN_SPEC_TIMEOUT_ATTRS = Set("days", "hours", "minutes")
@@ -336,11 +369,15 @@ object Extras {
   val TASK_DX_ATTRS = Set("runSpec", "details")
   val DX_DETAILS_ATTRS = Set("upstreamProjects")
 
-  private def checkedParseIntField(fields: Map[String, JsValue], fieldName: String): Option[Int] = {
+  private def checkedParseIntField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[Int] = {
     fields.get(fieldName) match {
       case None                => None
       case Some(JsNumber(bnm)) => Some(bnm.intValue)
-      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -351,7 +388,8 @@ object Extras {
     fields.get(fieldName) match {
       case None                => None
       case Some(JsString(str)) => Some(str)
-      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -363,7 +401,8 @@ object Extras {
       case None                => None
       case Some(JsString(str)) => Some(str)
       case Some(JsNull)        => Some("")
-      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -376,10 +415,12 @@ object Extras {
       case Some(JsArray(vec)) =>
         val v = vec.map {
           case JsString(str) => str
-          case other         => throw new Exception(s"Malformed ${fieldName} (${other})")
+          case other =>
+            throw new Exception(s"Malformed ${fieldName} (${other})")
         }
         Some(v)
-      case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -390,7 +431,8 @@ object Extras {
     fields.get(fieldName) match {
       case None               => None
       case Some(JsBoolean(b)) => Some(b)
-      case Some(other)        => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -410,11 +452,15 @@ object Extras {
     }
   }
 
-  private def checkedParseObjectField(fields: Map[String, JsValue], fieldName: String): JsValue = {
+  private def checkedParseObjectField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): JsValue = {
     fields.get(fieldName) match {
       case None                   => JsNull
       case Some(JsObject(fields)) => JsObject(fields)
-      case Some(other)            => throw new Exception(s"Malformed ${fieldName} (${other})")
+      case Some(other) =>
+        throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
 
@@ -427,12 +473,16 @@ object Extras {
       return None
     val m1 = m.asJsObject.fields.map {
       case (name, JsNumber(nmb)) => name -> nmb.intValue
-      case (name, other)         => throw new Exception(s"Malformed ${fieldName} (${name} -> ${other})")
+      case (name, other) =>
+        throw new Exception(s"Malformed ${fieldName} (${name} -> ${other})")
     }.toMap
     return Some(m1)
   }
 
-  private def parseWdlRuntimeAttrs(jsv: JsValue, verbose: Verbose): WdlRuntimeAttrs = {
+  private def parseWdlRuntimeAttrs(
+      jsv: JsValue,
+      verbose: Verbose
+  ): WdlRuntimeAttrs = {
     if (jsv == JsNull)
       return WdlRuntimeAttrs(Map.empty)
     val fields = jsv.asJsObject.fields
@@ -527,16 +577,20 @@ object Extras {
       throw new Exception("Exactly one entry-point timeout can be specified")
     val key = fields.keys.head
     if (key != "*")
-      throw new Exception("""Only a general timeout for all entry points is supported ("*")""")
+      throw new Exception(
+        """Only a general timeout for all entry points is supported ("*")"""
+      )
     val subObj = checkedParseObjectField(fields, "*")
     if (subObj == JsNull)
       return None
     val subFields = subObj.asJsObject.fields
     for (k <- subFields.keys) {
       if (!(RUN_SPEC_TIMEOUT_ATTRS contains k))
-        throw new Exception(s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
+        throw new Exception(
+          s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
                                         |we currently support ${RUN_SPEC_TIMEOUT_ATTRS}
-                                        |""".stripMargin.replaceAll("\n", ""))
+                                        |""".stripMargin.replaceAll("\n", "")
+        )
 
     }
     return Some(
@@ -564,12 +618,17 @@ object Extras {
       checkedParseStringField(fields, "restartableEntryPoints") match {
         case None                                            => None
         case Some(str) if List("all", "master") contains str => Some(str)
-        case Some(str)                                       => throw new Exception(s"Unsupported restartableEntryPoints value ${str}")
+        case Some(str) =>
+          throw new Exception(
+            s"Unsupported restartableEntryPoints value ${str}"
+          )
       }
     return Some(
       DxRunSpec(
         parseAccess(checkedParseObjectField(fields, "access")),
-        parseExecutionPolicy(checkedParseObjectField(fields, "executionPolicy")),
+        parseExecutionPolicy(
+          checkedParseObjectField(fields, "executionPolicy")
+        ),
         restartable,
         parseTimeoutPolicy(checkedParseObjectField(fields, "timeoutPolicy"))
       )
@@ -577,7 +636,9 @@ object Extras {
 
   }
 
-  private def parseUpstreamProjects(jsv: Option[JsValue]): Option[List[DxLicense]] = {
+  private def parseUpstreamProjects(
+      jsv: Option[JsValue]
+  ): Option[List[DxLicense]] = {
     if (jsv == JsNull)
       return None
 
@@ -595,7 +656,10 @@ object Extras {
     Some(DxDetails(parseUpstreamProjects(fields.get("upstreamProjects"))))
   }
 
-  private def parseTaskDxAttrs(jsv: JsValue, verbose: Verbose): Option[DxAttrs] = {
+  private def parseTaskDxAttrs(
+      jsv: JsValue,
+      verbose: Verbose
+  ): Option[DxAttrs] = {
     if (jsv == JsNull)
       return None
     val fields = jsv.asJsObject.fields
@@ -614,7 +678,10 @@ object Extras {
 
   }
 
-  private def parseDockerRegistry(jsv: JsValue, verbose: Verbose): Option[DockerRegistry] = {
+  private def parseDockerRegistry(
+      jsv: JsValue,
+      verbose: Verbose
+  ): Option[DockerRegistry] = {
     if (jsv == JsNull)
       return None
     val fields = jsv.asJsObject.fields
@@ -627,7 +694,10 @@ object Extras {
     }
     def getSome(fieldName: String): String = {
       checkedParseStringField(fields, fieldName) match {
-        case None    => throw new Exception(s"${fieldName} must be specified in the docker section")
+        case None =>
+          throw new Exception(
+            s"${fieldName} must be specified in the docker section"
+          )
         case Some(x) => x
       }
     }
@@ -641,25 +711,30 @@ object Extras {
 
     for (k <- fields.keys) {
       if (!(CUSTOM_REORG_ATTRS contains k))
-        throw new IllegalArgumentException(s"""|Unsupported custom reorg attribute ${k},
+        throw new IllegalArgumentException(
+          s"""|Unsupported custom reorg attribute ${k},
                         |we currently support ${CUSTOM_REORG_ATTRS}
-                        |""".stripMargin.replaceAll("\n", ""))
+                        |""".stripMargin.replaceAll("\n", "")
+        )
     }
 
     val reorgAppId: String = checkedParseStringField(fields, "app_id") match {
       case None =>
-        throw new IllegalArgumentException("app_id must be specified in the custom_reorg section.")
-      case Some(x) => x
-    }
-
-    val reorgConf: String = checkedParseStringFieldReplaceNull(fields, "conf") match {
-      case None =>
         throw new IllegalArgumentException(
-          "conf must be specified in the custom_reorg section. " +
-            "Please set the value to null if there is no conf file."
+          "app_id must be specified in the custom_reorg section."
         )
       case Some(x) => x
     }
+
+    val reorgConf: String =
+      checkedParseStringFieldReplaceNull(fields, "conf") match {
+        case None =>
+          throw new IllegalArgumentException(
+            "conf must be specified in the custom_reorg section. " +
+              "Please set the value to null if there is no conf file."
+          )
+        case Some(x) => x
+      }
 
     return (reorgAppId, reorgConf)
 
@@ -670,10 +745,13 @@ object Extras {
     val app_regex = "app-[0-9a-zA-Z]{24}"
     val applet_regex = "applet-[0-9a-zA-Z]{24}"
 
-    val isValidID: Boolean = reorgAppId.matches(app_regex) || reorgAppId.matches(applet_regex)
+    val isValidID: Boolean = reorgAppId.matches(app_regex) || reorgAppId
+      .matches(applet_regex)
 
     if (!isValidID) {
-      throw new IllegalArgumentException("dxId must match applet-[A-Za-z0-9]{24}")
+      throw new IllegalArgumentException(
+        "dxId must match applet-[A-Za-z0-9]{24}"
+      )
     }
 
     // FIXME: This needs to be done --without-- using dx. Use java/scala describe instead.
@@ -710,7 +788,10 @@ object Extras {
 
   }
 
-  def parseCustomReorgAttrs(jsv: JsValue, verbose: Verbose): Option[ReorgAttrs] = {
+  def parseCustomReorgAttrs(
+      jsv: JsValue,
+      verbose: Verbose
+  ): Option[ReorgAttrs] = {
     if (jsv == JsNull)
       return None
 
@@ -767,10 +848,19 @@ object Extras {
       }
 
     Extras(
-      parseWdlRuntimeAttrs(checkedParseObjectField(fields, "default_runtime_attributes"), verbose),
-      parseTaskDxAttrs(checkedParseObjectField(fields, "default_task_dx_attributes"), verbose),
+      parseWdlRuntimeAttrs(
+        checkedParseObjectField(fields, "default_runtime_attributes"),
+        verbose
+      ),
+      parseTaskDxAttrs(
+        checkedParseObjectField(fields, "default_task_dx_attributes"),
+        verbose
+      ),
       perTaskDxAttrs,
-      parseDockerRegistry(checkedParseObjectField(fields, "docker_registry"), verbose),
+      parseDockerRegistry(
+        checkedParseObjectField(fields, "docker_registry"),
+        verbose
+      ),
       parseCustomReorgAttrs(
         checkedParseObjectField(fields, fieldName = "custom_reorg"),
         verbose

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -153,11 +153,11 @@ case class DxAccess(
     val projectCreationMrg = mergeBooleans(projectCreation, dxa.projectCreation)
 
     DxAccess(
-      networkMrg,
-      projectMrg,
-      allProjectsMrg,
-      developerMrg,
-      projectCreationMrg
+        networkMrg,
+        projectMrg,
+        allProjectsMrg,
+        developerMrg,
+        projectCreationMrg
     )
   }
 }
@@ -233,12 +233,12 @@ case class DxDetails(upstreamProjects: Option[List[DxLicense]]) {
       case Some(x) =>
         x.map { dxLicense: DxLicense =>
           JsObject(
-            "name" -> JsString(dxLicense.name),
-            "repoUrl" -> JsString(dxLicense.repoUrl),
-            "version" -> JsString(dxLicense.version),
-            "license" -> JsString(dxLicense.license),
-            "licenseUrl" -> JsString(dxLicense.licenseUrl),
-            "author" -> JsString(dxLicense.author)
+              "name" -> JsString(dxLicense.name),
+              "repoUrl" -> JsString(dxLicense.repoUrl),
+              "version" -> JsString(dxLicense.version),
+              "license" -> JsString(dxLicense.license),
+              "licenseUrl" -> JsString(dxLicense.licenseUrl),
+              "author" -> JsString(dxLicense.author)
           )
         }
     }
@@ -336,21 +336,21 @@ object Extras {
   val DOCKER_REGISTRY_ATTRS = Set("username", "registry", "credentials")
   val CUSTOM_REORG_ATTRS = Set("app_id", "conf")
   val EXTRA_ATTRS = Set(
-    "default_runtime_attributes",
-    "default_task_dx_attributes",
-    "per_task_dx_attributes",
-    "docker_registry",
-    "custom_reorg"
+      "default_runtime_attributes",
+      "default_task_dx_attributes",
+      "per_task_dx_attributes",
+      "docker_registry",
+      "custom_reorg"
   )
   val RUNTIME_ATTRS =
     Set(
-      "dx_instance_type",
-      "memory",
-      "disks",
-      "cpu",
-      "docker",
-      "docker_registry",
-      "custom_reorg"
+        "dx_instance_type",
+        "memory",
+        "disks",
+        "cpu",
+        "docker",
+        "docker_registry",
+        "custom_reorg"
     )
   val RUN_SPEC_ATTRS =
     Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
@@ -359,12 +359,12 @@ object Extras {
   val RUN_SPEC_TIMEOUT_ATTRS = Set("days", "hours", "minutes")
   val RUN_SPEC_EXEC_POLICY_ATTRS = Set("restartOn", "maxRestarts")
   val RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS = Set(
-    "ExecutionError",
-    "UnresponsiveWorker",
-    "JMInternalError",
-    "AppInternalError",
-    "JobTimeoutExceeded",
-    "*"
+      "ExecutionError",
+      "UnresponsiveWorker",
+      "JMInternalError",
+      "AppInternalError",
+      "JobTimeoutExceeded",
+      "*"
   )
   val TASK_DX_ATTRS = Set("runSpec", "details")
   val DX_DETAILS_ATTRS = Set("upstreamProjects")
@@ -489,8 +489,8 @@ object Extras {
     for (k <- fields.keys) {
       if (!(RUNTIME_ATTRS contains k))
         Utils.warning(
-          verbose,
-          s"""|Unsupported runtime attribute ${k},
+            verbose,
+            s"""|Unsupported runtime attribute ${k},
                                            |we currently support ${RUNTIME_ATTRS}
                                            |""".stripMargin.replaceAll("\n", "")
         )
@@ -552,13 +552,13 @@ object Extras {
     }
 
     return Some(
-      DxAccess(
-        checkedParseStringArrayField(fields, "network"),
-        checkedParseAccessLevelField(fields, "project"),
-        checkedParseAccessLevelField(fields, "allProjects"),
-        checkedParseBooleanField(fields, "developer"),
-        checkedParseBooleanField(fields, "projectCreation")
-      )
+        DxAccess(
+            checkedParseStringArrayField(fields, "network"),
+            checkedParseAccessLevelField(fields, "project"),
+            checkedParseAccessLevelField(fields, "allProjects"),
+            checkedParseBooleanField(fields, "developer"),
+            checkedParseBooleanField(fields, "projectCreation")
+        )
     )
   }
 
@@ -578,7 +578,7 @@ object Extras {
     val key = fields.keys.head
     if (key != "*")
       throw new Exception(
-        """Only a general timeout for all entry points is supported ("*")"""
+          """Only a general timeout for all entry points is supported ("*")"""
       )
     val subObj = checkedParseObjectField(fields, "*")
     if (subObj == JsNull)
@@ -587,18 +587,18 @@ object Extras {
     for (k <- subFields.keys) {
       if (!(RUN_SPEC_TIMEOUT_ATTRS contains k))
         throw new Exception(
-          s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
+            s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
                                         |we currently support ${RUN_SPEC_TIMEOUT_ATTRS}
                                         |""".stripMargin.replaceAll("\n", "")
         )
 
     }
     return Some(
-      DxTimeout(
-        checkedParseIntField(subFields, "days"),
-        checkedParseIntField(subFields, "hours"),
-        checkedParseIntField(subFields, "minutes")
-      )
+        DxTimeout(
+            checkedParseIntField(subFields, "days"),
+            checkedParseIntField(subFields, "hours"),
+            checkedParseIntField(subFields, "minutes")
+        )
     )
   }
 
@@ -620,18 +620,18 @@ object Extras {
         case Some(str) if List("all", "master") contains str => Some(str)
         case Some(str) =>
           throw new Exception(
-            s"Unsupported restartableEntryPoints value ${str}"
+              s"Unsupported restartableEntryPoints value ${str}"
           )
       }
     return Some(
-      DxRunSpec(
-        parseAccess(checkedParseObjectField(fields, "access")),
-        parseExecutionPolicy(
-          checkedParseObjectField(fields, "executionPolicy")
-        ),
-        restartable,
-        parseTimeoutPolicy(checkedParseObjectField(fields, "timeoutPolicy"))
-      )
+        DxRunSpec(
+            parseAccess(checkedParseObjectField(fields, "access")),
+            parseExecutionPolicy(
+                checkedParseObjectField(fields, "executionPolicy")
+            ),
+            restartable,
+            parseTimeoutPolicy(checkedParseObjectField(fields, "timeoutPolicy"))
+        )
     )
 
   }
@@ -696,7 +696,7 @@ object Extras {
       checkedParseStringField(fields, fieldName) match {
         case None =>
           throw new Exception(
-            s"${fieldName} must be specified in the docker section"
+              s"${fieldName} must be specified in the docker section"
           )
         case Some(x) => x
       }
@@ -712,7 +712,7 @@ object Extras {
     for (k <- fields.keys) {
       if (!(CUSTOM_REORG_ATTRS contains k))
         throw new IllegalArgumentException(
-          s"""|Unsupported custom reorg attribute ${k},
+            s"""|Unsupported custom reorg attribute ${k},
                         |we currently support ${CUSTOM_REORG_ATTRS}
                         |""".stripMargin.replaceAll("\n", "")
         )
@@ -721,7 +721,7 @@ object Extras {
     val reorgAppId: String = checkedParseStringField(fields, "app_id") match {
       case None =>
         throw new IllegalArgumentException(
-          "app_id must be specified in the custom_reorg section."
+            "app_id must be specified in the custom_reorg section."
         )
       case Some(x) => x
     }
@@ -730,8 +730,8 @@ object Extras {
       checkedParseStringFieldReplaceNull(fields, "conf") match {
         case None =>
           throw new IllegalArgumentException(
-            "conf must be specified in the custom_reorg section. " +
-              "Please set the value to null if there is no conf file."
+              "conf must be specified in the custom_reorg section. " +
+                "Please set the value to null if there is no conf file."
           )
         case Some(x) => x
       }
@@ -750,7 +750,7 @@ object Extras {
 
     if (!isValidID) {
       throw new IllegalArgumentException(
-        "dxId must match applet-[A-Za-z0-9]{24}"
+          "dxId must match applet-[A-Za-z0-9]{24}"
       )
     }
 
@@ -801,8 +801,8 @@ object Extras {
     verifyInputs(reorgConf)
 
     Utils.trace(
-      verbose.on,
-      s"""|Writing your own applet for reorganization purposes is tricky. If you are not careful,
+        verbose.on,
+        s"""|Writing your own applet for reorganization purposes is tricky. If you are not careful,
                 |it may misplace or outright delete files.
                 |The applet: ${reorgAppId} requires CONTRIBUTE project access,
                 |so it can move files and folders around and has to be idempotent, so that if the instance it runs on crashes, it can safely restart. It has to be careful about inputs that are also outputs. Normally, these should not be moved. It should use bulk object operations, so as not to overload the API server.'
@@ -848,23 +848,23 @@ object Extras {
       }
 
     Extras(
-      parseWdlRuntimeAttrs(
-        checkedParseObjectField(fields, "default_runtime_attributes"),
-        verbose
-      ),
-      parseTaskDxAttrs(
-        checkedParseObjectField(fields, "default_task_dx_attributes"),
-        verbose
-      ),
-      perTaskDxAttrs,
-      parseDockerRegistry(
-        checkedParseObjectField(fields, "docker_registry"),
-        verbose
-      ),
-      parseCustomReorgAttrs(
-        checkedParseObjectField(fields, fieldName = "custom_reorg"),
-        verbose
-      )
+        parseWdlRuntimeAttrs(
+            checkedParseObjectField(fields, "default_runtime_attributes"),
+            verbose
+        ),
+        parseTaskDxAttrs(
+            checkedParseObjectField(fields, "default_task_dx_attributes"),
+            verbose
+        ),
+        perTaskDxAttrs,
+        parseDockerRegistry(
+            checkedParseObjectField(fields, "docker_registry"),
+            verbose
+        ),
+        parseCustomReorgAttrs(
+            checkedParseObjectField(fields, fieldName = "custom_reorg"),
+            verbose
+        )
     )
 
   }

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -134,9 +134,9 @@ case class DxAccess(
       case Vector(x, y) => Some((x.toSet ++ y.toSet).toVector)
       case _            => None
     }
-    val projectMrg         = mergeAccessLevels(project, dxa.project)
-    val allProjectsMrg     = mergeAccessLevels(allProjects, dxa.allProjects)
-    val developerMrg       = mergeBooleans(developer, dxa.developer)
+    val projectMrg = mergeAccessLevels(project, dxa.project)
+    val allProjectsMrg = mergeAccessLevels(allProjects, dxa.allProjects)
+    val developerMrg = mergeBooleans(developer, dxa.developer)
     val projectCreationMrg = mergeBooleans(projectCreation, dxa.projectCreation)
 
     DxAccess(networkMrg, projectMrg, allProjectsMrg, developerMrg, projectCreationMrg)
@@ -213,12 +213,12 @@ case class DxDetails(upstreamProjects: Option[List[DxLicense]]) {
       case Some(x) =>
         x.map { dxLicense: DxLicense =>
           JsObject(
-            "name"       -> JsString(dxLicense.name),
-            "repoUrl"    -> JsString(dxLicense.repoUrl),
-            "version"    -> JsString(dxLicense.version),
-            "license"    -> JsString(dxLicense.license),
+            "name" -> JsString(dxLicense.name),
+            "repoUrl" -> JsString(dxLicense.repoUrl),
+            "version" -> JsString(dxLicense.version),
+            "license" -> JsString(dxLicense.license),
             "licenseUrl" -> JsString(dxLicense.licenseUrl),
-            "author"     -> JsString(dxLicense.author)
+            "author" -> JsString(dxLicense.author)
           )
         }
     }
@@ -310,7 +310,7 @@ case class Extras(
 
 object Extras {
   val DOCKER_REGISTRY_ATTRS = Set("username", "registry", "credentials")
-  val CUSTOM_REORG_ATTRS    = Set("app_id", "conf")
+  val CUSTOM_REORG_ATTRS = Set("app_id", "conf")
   val EXTRA_ATTRS = Set(
     "default_runtime_attributes",
     "default_task_dx_attributes",
@@ -323,7 +323,7 @@ object Extras {
   val RUN_SPEC_ATTRS = Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
   val RUN_SPEC_ACCESS_ATTRS =
     Set("network", "project", "allProjects", "developer", "projectCreation")
-  val RUN_SPEC_TIMEOUT_ATTRS     = Set("days", "hours", "minutes")
+  val RUN_SPEC_TIMEOUT_ATTRS = Set("days", "hours", "minutes")
   val RUN_SPEC_EXEC_POLICY_ATTRS = Set("restartOn", "maxRestarts")
   val RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS = Set(
     "ExecutionError",
@@ -333,7 +333,7 @@ object Extras {
     "JobTimeoutExceeded",
     "*"
   )
-  val TASK_DX_ATTRS    = Set("runSpec", "details")
+  val TASK_DX_ATTRS = Set("runSpec", "details")
   val DX_DETAILS_ATTRS = Set("upstreamProjects")
 
   private def checkedParseIntField(fields: Map[String, JsValue], fieldName: String): Option[Int] = {
@@ -631,8 +631,8 @@ object Extras {
         case Some(x) => x
       }
     }
-    val registry    = getSome("registry")
-    val username    = getSome("username")
+    val registry = getSome("registry")
+    val username = getSome("username")
     val credentials = getSome("credentials")
     Some(DockerRegistry(registry, username, credentials))
   }
@@ -667,7 +667,7 @@ object Extras {
 
   private def veryifyReorgApp(reorgAppId: String): Unit = {
 
-    val app_regex    = "app-[0-9a-zA-Z]{24}"
+    val app_regex = "app-[0-9a-zA-Z]{24}"
     val applet_regex = "applet-[0-9a-zA-Z]{24}"
 
     val isValidID: Boolean = reorgAppId.matches(app_regex) || reorgAppId.matches(applet_regex)
@@ -714,7 +714,7 @@ object Extras {
     if (jsv == JsNull)
       return None
 
-    val fields                  = jsv.asJsObject.fields
+    val fields = jsv.asJsObject.fields
     val (reorgAppId, reorgConf) = checkAttrs(fields)
     veryifyReorgApp(reorgAppId)
     verifyInputs(reorgConf)

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -10,215 +10,221 @@ import wom.values._
 
 import dxWDL.dx._
 
-case class DxExecPolicy(restartOn: Option[Map[String, Int]],
-                        maxRestarts: Option[Int]) {
-    def toJson : Map[String, JsValue] = {
-        val restartOnFields = restartOn match {
-            case None => Map.empty
-            case Some(m) =>
-                val jsm = m.map{ case (name, i) => name -> JsNumber(i) }
-                Map("restartOn" -> JsObject(jsm))
-        }
-        val maxRestartsFields = maxRestarts match {
-            case None => Map.empty
-            case Some(n) => Map("maxRestarts" -> JsNumber(n))
-        }
-        val m = restartOnFields ++ maxRestartsFields
-        if (m.isEmpty)
-            Map.empty
-        else
-            Map("executionPolicy" -> JsObject(m))
+case class DxExecPolicy(restartOn: Option[Map[String, Int]], maxRestarts: Option[Int]) {
+  def toJson: Map[String, JsValue] = {
+    val restartOnFields = restartOn match {
+      case None => Map.empty
+      case Some(m) =>
+        val jsm = m.map { case (name, i) => name -> JsNumber(i) }
+        Map("restartOn" -> JsObject(jsm))
     }
+    val maxRestartsFields = maxRestarts match {
+      case None    => Map.empty
+      case Some(n) => Map("maxRestarts" -> JsNumber(n))
+    }
+    val m = restartOnFields ++ maxRestartsFields
+    if (m.isEmpty)
+      Map.empty
+    else
+      Map("executionPolicy" -> JsObject(m))
+  }
 }
 
-case class DxTimeout(days: Option[Int],
-                     hours: Option[Int],
-                     minutes: Option[Int]) {
-    def toJson : Map[String, JsValue] = {
-        val daysField : Map[String, JsValue] = days match {
-            case None => Map.empty
-            case Some(d) => Map("days" -> JsNumber(d))
-        }
-        val hoursField : Map[String, JsValue] = hours match {
-            case None => Map.empty
-            case Some(d) => Map("hours" -> JsNumber(d))
-        }
-        val minutesField : Map[String, JsValue] = minutes match {
-            case None => Map.empty
-            case Some(d) => Map("minutes" -> JsNumber(d))
-        }
-        val timeoutFields = daysField ++ hoursField ++ minutesField
-        if (timeoutFields.isEmpty)
-            Map.empty
-        else
-            Map("timeoutPolicy" -> JsObject("*" -> JsObject(timeoutFields)))
+case class DxTimeout(days: Option[Int], hours: Option[Int], minutes: Option[Int]) {
+  def toJson: Map[String, JsValue] = {
+    val daysField: Map[String, JsValue] = days match {
+      case None    => Map.empty
+      case Some(d) => Map("days" -> JsNumber(d))
     }
+    val hoursField: Map[String, JsValue] = hours match {
+      case None    => Map.empty
+      case Some(d) => Map("hours" -> JsNumber(d))
+    }
+    val minutesField: Map[String, JsValue] = minutes match {
+      case None    => Map.empty
+      case Some(d) => Map("minutes" -> JsNumber(d))
+    }
+    val timeoutFields = daysField ++ hoursField ++ minutesField
+    if (timeoutFields.isEmpty)
+      Map.empty
+    else
+      Map("timeoutPolicy" -> JsObject("*" -> JsObject(timeoutFields)))
+  }
 }
-case class DxAccess(network: Option[Vector[String]],
-                    project: Option[AccessLevel],
-                    allProjects: Option[AccessLevel],
-                    developer: Option[Boolean],
-                    projectCreation: Option[Boolean]) {
-    def toJson : Map[String, JsValue] = {
-        val networkField: Map[String, JsValue] = network match {
-            case None => Map.empty
-            case Some(hostsAndNetworks) =>
-                val arr = hostsAndNetworks.map{ x => JsString(x) }.toVector
-                Map("network" -> JsArray(arr))
-        }
-        val projectField : Map[String, JsValue] = project match {
-            case None => Map.empty
-            case Some(x) => Map("project" -> JsString(x.toString))
-        }
-        val allProjectsField: Map[String, JsValue] = allProjects match {
-            case None => Map.empty
-            case Some(x) => Map("allProjects" -> JsString(x.toString))
-        }
-        val developerField: Map[String, JsValue] = developer match {
-            case None => Map.empty
-            case Some(x) => Map("developer" -> JsBoolean(x))
-        }
-        val projectCreationField: Map[String, JsValue] = projectCreation match {
-            case None => Map.empty
-            case Some(x) => Map("projectCreation" -> JsBoolean(x))
-        }
-        networkField ++ projectField ++ allProjectsField ++ developerField ++ projectCreationField
+case class DxAccess(
+    network: Option[Vector[String]],
+    project: Option[AccessLevel],
+    allProjects: Option[AccessLevel],
+    developer: Option[Boolean],
+    projectCreation: Option[Boolean]
+) {
+  def toJson: Map[String, JsValue] = {
+    val networkField: Map[String, JsValue] = network match {
+      case None => Map.empty
+      case Some(hostsAndNetworks) =>
+        val arr = hostsAndNetworks.map { x =>
+          JsString(x)
+        }.toVector
+        Map("network" -> JsArray(arr))
+    }
+    val projectField: Map[String, JsValue] = project match {
+      case None    => Map.empty
+      case Some(x) => Map("project" -> JsString(x.toString))
+    }
+    val allProjectsField: Map[String, JsValue] = allProjects match {
+      case None    => Map.empty
+      case Some(x) => Map("allProjects" -> JsString(x.toString))
+    }
+    val developerField: Map[String, JsValue] = developer match {
+      case None    => Map.empty
+      case Some(x) => Map("developer" -> JsBoolean(x))
+    }
+    val projectCreationField: Map[String, JsValue] = projectCreation match {
+      case None    => Map.empty
+      case Some(x) => Map("projectCreation" -> JsBoolean(x))
+    }
+    networkField ++ projectField ++ allProjectsField ++ developerField ++ projectCreationField
+  }
+
+  private def takeMaxAccessLevel(x: AccessLevel, y: AccessLevel): AccessLevel = {
+    def levelToInt(al: AccessLevel): Int = al match {
+      case AccessLevel.ADMINISTER => 5
+      case AccessLevel.CONTRIBUTE => 4
+      case AccessLevel.UPLOAD     => 3
+      case AccessLevel.VIEW       => 2
+      case AccessLevel.NONE       => 1
+    }
+    def intToLevel(i: Int): AccessLevel = i match {
+      case 5 => AccessLevel.ADMINISTER
+      case 4 => AccessLevel.CONTRIBUTE
+      case 3 => AccessLevel.UPLOAD
+      case 2 => AccessLevel.VIEW
+      case 1 => AccessLevel.NONE
+      case _ => throw new Exception(s"sanity, bad integer level ${i}")
+    }
+    val xi = levelToInt(x)
+    val yi = levelToInt(y)
+    val mi = Math.max(xi, yi)
+    intToLevel(mi)
+  }
+
+  // Merge with an additional set of access requirments.
+  // Take the maximum for each field, and merge the network.
+  def merge(dxa: DxAccess): DxAccess = {
+    def mergeAccessLevels(
+        al1: Option[AccessLevel],
+        al2: Option[AccessLevel]
+    ): Option[AccessLevel] = {
+      Vector(al1, al2).flatten match {
+        case Vector(x)    => Some(x)
+        case Vector(x, y) => Some(takeMaxAccessLevel(x, y))
+        case _            => None
+      }
+    }
+    def mergeBooleans(a: Option[Boolean], b: Option[Boolean]): Option[Boolean] = {
+      Vector(a, b).flatten match {
+        case Vector(x)    => Some(x)
+        case Vector(x, y) => Some(x || y)
+        case _            => None
+      }
     }
 
-    private def takeMaxAccessLevel(x: AccessLevel,
-                                   y: AccessLevel) : AccessLevel = {
-        def levelToInt(al: AccessLevel) : Int = al match {
-            case AccessLevel.ADMINISTER => 5
-            case AccessLevel.CONTRIBUTE => 4
-            case AccessLevel.UPLOAD => 3
-            case AccessLevel.VIEW => 2
-            case AccessLevel.NONE => 1
-        }
-        def intToLevel(i: Int) : AccessLevel = i match {
-            case 5 => AccessLevel.ADMINISTER
-            case 4 => AccessLevel.CONTRIBUTE
-            case 3 => AccessLevel.UPLOAD
-            case 2 => AccessLevel.VIEW
-            case 1 => AccessLevel.NONE
-            case _ => throw new Exception(s"sanity, bad integer level ${i}")
-        }
-        val xi = levelToInt(x)
-        val yi = levelToInt(y)
-        val mi = Math.max(xi, yi)
-        intToLevel(mi)
+    val networkMrg = Vector(network, dxa.network).flatten match {
+      case Vector(x)    => Some(x)
+      case Vector(x, y) => Some((x.toSet ++ y.toSet).toVector)
+      case _            => None
     }
+    val projectMrg         = mergeAccessLevels(project, dxa.project)
+    val allProjectsMrg     = mergeAccessLevels(allProjects, dxa.allProjects)
+    val developerMrg       = mergeBooleans(developer, dxa.developer)
+    val projectCreationMrg = mergeBooleans(projectCreation, dxa.projectCreation)
 
-    // Merge with an additional set of access requirments.
-    // Take the maximum for each field, and merge the network.
-    def merge(dxa: DxAccess) : DxAccess = {
-        def mergeAccessLevels(al1: Option[AccessLevel],
-                              al2: Option[AccessLevel]) : Option[AccessLevel] = {
-            Vector(al1, al2).flatten match {
-                case Vector(x) => Some(x)
-                case Vector(x, y) => Some(takeMaxAccessLevel(x, y))
-                case _ => None
-            }
-        }
-        def mergeBooleans(a: Option[Boolean], b: Option[Boolean]) : Option[Boolean] = {
-            Vector(a, b).flatten match {
-                case Vector(x) => Some(x)
-                case Vector(x, y) => Some(x || y)
-                case _ => None
-            }
-        }
-
-        val networkMrg = Vector(network, dxa.network).flatten match {
-            case Vector(x) => Some(x)
-            case Vector(x, y) =>  Some((x.toSet ++ y.toSet).toVector)
-            case _ => None
-        }
-        val projectMrg = mergeAccessLevels(project, dxa.project)
-        val allProjectsMrg = mergeAccessLevels(allProjects, dxa.allProjects)
-        val developerMrg = mergeBooleans(developer, dxa.developer)
-        val projectCreationMrg = mergeBooleans(projectCreation, dxa.projectCreation)
-
-        DxAccess(networkMrg, projectMrg, allProjectsMrg, developerMrg, projectCreationMrg)
-    }
+    DxAccess(networkMrg, projectMrg, allProjectsMrg, developerMrg, projectCreationMrg)
+  }
 }
 
 object DxAccess {
-    val empty = DxAccess(None, None, None, None, None)
+  val empty = DxAccess(None, None, None, None, None)
 }
 
-case class DxRunSpec(access: Option[DxAccess],
-                     execPolicy: Option[DxExecPolicy],
-                     restartableEntryPoints: Option[String],
-                     timeoutPolicy: Option[DxTimeout]) {
-    // The access field DOES NOT go into the run-specification in the API
-    // call. It does fit, however, in dxapp.json.
-    def toRunSpecJson : Map[String, JsValue] = {
-        val execPolicyFields = execPolicy match {
-            case None => Map.empty
-            case Some(execPolicy) =>
-                execPolicy.toJson
-        }
-        val restartableEntryPointsFields = restartableEntryPoints match {
-            case None => Map.empty
-            case Some(value: String) => Map("restartableEntryPoints" -> JsString(value))
-        }
-        val timeoutFields = timeoutPolicy match {
-            case None => Map.empty
-            case Some(execPolicy) => execPolicy.toJson
-        }
-        execPolicyFields ++ restartableEntryPointsFields ++ timeoutFields
+case class DxRunSpec(
+    access: Option[DxAccess],
+    execPolicy: Option[DxExecPolicy],
+    restartableEntryPoints: Option[String],
+    timeoutPolicy: Option[DxTimeout]
+) {
+  // The access field DOES NOT go into the run-specification in the API
+  // call. It does fit, however, in dxapp.json.
+  def toRunSpecJson: Map[String, JsValue] = {
+    val execPolicyFields = execPolicy match {
+      case None => Map.empty
+      case Some(execPolicy) =>
+        execPolicy.toJson
     }
+    val restartableEntryPointsFields = restartableEntryPoints match {
+      case None                => Map.empty
+      case Some(value: String) => Map("restartableEntryPoints" -> JsString(value))
+    }
+    val timeoutFields = timeoutPolicy match {
+      case None             => Map.empty
+      case Some(execPolicy) => execPolicy.toJson
+    }
+    execPolicyFields ++ restartableEntryPointsFields ++ timeoutFields
+  }
 }
 
-case class DxAttrs(runSpec: Option[DxRunSpec],
-                   details: Option[DxDetails]){
+case class DxAttrs(runSpec: Option[DxRunSpec], details: Option[DxDetails]) {
 
-    def getRunSpecJson: Map[String, JsValue] = {
-        val runSpecJson: Map[String, JsValue] = runSpec match {
-            case None => Map.empty
-            case Some(runSpec) => runSpec.toRunSpecJson
-        }
-
-        runSpecJson
+  def getRunSpecJson: Map[String, JsValue] = {
+    val runSpecJson: Map[String, JsValue] = runSpec match {
+      case None          => Map.empty
+      case Some(runSpec) => runSpec.toRunSpecJson
     }
 
-    def getDetailsJson: Map[String, JsValue] = {
-        val detailsJson: Map[String, JsValue] = details match {
-            case None => Map.empty
-            case Some(details) => details.toDetailsJson
-        }
-        detailsJson
+    runSpecJson
+  }
+
+  def getDetailsJson: Map[String, JsValue] = {
+    val detailsJson: Map[String, JsValue] = details match {
+      case None          => Map.empty
+      case Some(details) => details.toDetailsJson
     }
+    detailsJson
+  }
 }
 
 case class ReorgAttrs(appId: String, reorgConf: String)
 
-case class DxLicense(name: String,
-                     repoUrl: String,
-                     version: String,
-                     license: String,
-                     licenseUrl: String,
-                     author: String)
+case class DxLicense(
+    name: String,
+    repoUrl: String,
+    version: String,
+    license: String,
+    licenseUrl: String,
+    author: String
+)
 
-case class DxDetails(upstreamProjects: Option[List[DxLicense]]){
+case class DxDetails(upstreamProjects: Option[List[DxLicense]]) {
 
-    def toDetailsJson : Map[String, JsValue] = {
+  def toDetailsJson: Map[String, JsValue] = {
 
-        val upstreamProjectList: List[JsObject] = upstreamProjects match {
-            case None => List.empty
-            case Some(x) => x.map{ dxLicense : DxLicense =>
-                JsObject(
-                    "name" -> JsString(dxLicense.name),
-                    "repoUrl" -> JsString(dxLicense.repoUrl),
-                    "version" -> JsString(dxLicense.version),
-                    "license" -> JsString(dxLicense.license),
-                    "licenseUrl" -> JsString(dxLicense.licenseUrl),
-                    "author" -> JsString(dxLicense.author)
-                )
-            }
+    val upstreamProjectList: List[JsObject] = upstreamProjects match {
+      case None => List.empty
+      case Some(x) =>
+        x.map { dxLicense: DxLicense =>
+          JsObject(
+            "name"       -> JsString(dxLicense.name),
+            "repoUrl"    -> JsString(dxLicense.repoUrl),
+            "version"    -> JsString(dxLicense.version),
+            "license"    -> JsString(dxLicense.license),
+            "licenseUrl" -> JsString(dxLicense.licenseUrl),
+            "author"     -> JsString(dxLicense.author)
+          )
         }
-
-        return Map("upstreamProjects" -> upstreamProjectList.toJson)
     }
+
+    return Map("upstreamProjects" -> upstreamProjectList.toJson)
+  }
 }
 
 // The available fields are:
@@ -228,418 +234,450 @@ case class DxDetails(upstreamProjects: Option[List[DxLicense]]){
 //    cpu
 //    docker
 //
-case class WdlRuntimeAttrs(m : Map[String, WomValue])
+case class WdlRuntimeAttrs(m: Map[String, WomValue])
 
 // support automatic conversion to/from JsValue
 object WdlRuntimeAttrs extends DefaultJsonProtocol {
-    implicit object WdlRuntimeAttrsFormat extends RootJsonFormat[WdlRuntimeAttrs] {
-        private def readWomValue(value : JsValue) : WomValue = value match {
-            case JsBoolean(b) => WomBoolean(b.booleanValue)
-            case JsNumber(nmb) => WomInteger(nmb.intValue)
-            case JsString(s) => WomString(s)
-            case other => throw new Exception(s"Unsupported json value ${other}")
-        }
-        private def writeWomValue(wValue : WomValue) : JsValue = wValue match {
-            case WomBoolean(b) => JsBoolean(b)
-            case WomInteger(i) => JsNumber(i)
-            case WomString(s) => JsString(s)
-            case other => throw new Exception(s"Unsupported wom value value ${other}")
-        }
-
-        def read(jsv : JsValue) : WdlRuntimeAttrs = {
-            val m = jsv.asJsObject.fields.map{ case (k,v) => k -> readWomValue(v) }.toMap
-            WdlRuntimeAttrs(m)
-        }
-
-        def write(wra : WdlRuntimeAttrs) : JsValue = {
-            val fields = wra.m.map{ case (k, v) =>
-                k -> writeWomValue(v)
-            }.toMap
-            JsObject(fields)
-        }
+  implicit object WdlRuntimeAttrsFormat extends RootJsonFormat[WdlRuntimeAttrs] {
+    private def readWomValue(value: JsValue): WomValue = value match {
+      case JsBoolean(b)  => WomBoolean(b.booleanValue)
+      case JsNumber(nmb) => WomInteger(nmb.intValue)
+      case JsString(s)   => WomString(s)
+      case other         => throw new Exception(s"Unsupported json value ${other}")
     }
+    private def writeWomValue(wValue: WomValue): JsValue = wValue match {
+      case WomBoolean(b) => JsBoolean(b)
+      case WomInteger(i) => JsNumber(i)
+      case WomString(s)  => JsString(s)
+      case other         => throw new Exception(s"Unsupported wom value value ${other}")
+    }
+
+    def read(jsv: JsValue): WdlRuntimeAttrs = {
+      val m = jsv.asJsObject.fields.map { case (k, v) => k -> readWomValue(v) }.toMap
+      WdlRuntimeAttrs(m)
+    }
+
+    def write(wra: WdlRuntimeAttrs): JsValue = {
+      val fields = wra.m.map {
+        case (k, v) =>
+          k -> writeWomValue(v)
+      }.toMap
+      JsObject(fields)
+    }
+  }
 }
 
-case class DockerRegistry(registry: String,
-                           username: String,
-                           credentials: String)
+case class DockerRegistry(registry: String, username: String, credentials: String)
 
-case class Extras(defaultRuntimeAttributes: WdlRuntimeAttrs,
-                  defaultTaskDxAttributes: Option[DxAttrs],
-                  perTaskDxAttributes: Map[String, DxAttrs],
-                  dockerRegistry : Option[DockerRegistry],
-                  customReorgAttributes: Option[ReorgAttrs]) {
-    def getDefaultAccess : DxAccess = {
-        defaultTaskDxAttributes match {
-            case None => DxAccess.empty
-            case Some(dta) => dta.runSpec match {
-                case None => DxAccess.empty
-                case Some(runSpec) => runSpec.access match {
-                    case None => DxAccess.empty
-                    case Some(access) => access
-                }
+case class Extras(
+    defaultRuntimeAttributes: WdlRuntimeAttrs,
+    defaultTaskDxAttributes: Option[DxAttrs],
+    perTaskDxAttributes: Map[String, DxAttrs],
+    dockerRegistry: Option[DockerRegistry],
+    customReorgAttributes: Option[ReorgAttrs]
+) {
+  def getDefaultAccess: DxAccess = {
+    defaultTaskDxAttributes match {
+      case None => DxAccess.empty
+      case Some(dta) =>
+        dta.runSpec match {
+          case None => DxAccess.empty
+          case Some(runSpec) =>
+            runSpec.access match {
+              case None         => DxAccess.empty
+              case Some(access) => access
             }
         }
     }
+  }
 
-    def getTaskAccess(taskName: String) : DxAccess = {
-        perTaskDxAttributes.get(taskName) match {
-            case None => DxAccess.empty
-            case Some(dta) => dta.runSpec match {
-                case None => DxAccess.empty
-                case Some(runSpec) => runSpec.access match {
-                    case None => DxAccess.empty
-                    case Some(access) => access
-                }
+  def getTaskAccess(taskName: String): DxAccess = {
+    perTaskDxAttributes.get(taskName) match {
+      case None => DxAccess.empty
+      case Some(dta) =>
+        dta.runSpec match {
+          case None => DxAccess.empty
+          case Some(runSpec) =>
+            runSpec.access match {
+              case None         => DxAccess.empty
+              case Some(access) => access
             }
         }
     }
+  }
 
 }
 
 object Extras {
-    val DOCKER_REGISTRY_ATTRS = Set("username", "registry", "credentials")
-    val CUSTOM_REORG_ATTRS = Set("app_id", "conf")
-    val EXTRA_ATTRS = Set("default_runtime_attributes",
-                          "default_task_dx_attributes",
-                          "per_task_dx_attributes",
-                          "docker_registry",
-                          "custom_reorg")
-    val RUNTIME_ATTRS = Set("dx_instance_type", "memory", "disks", "cpu", "docker",
-                          "docker_registry",
-                          "custom_reorg")
-    val RUN_SPEC_ATTRS = Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
-    val RUN_SPEC_ACCESS_ATTRS = Set("network", "project", "allProjects", "developer", "projectCreation")
-    val RUN_SPEC_TIMEOUT_ATTRS = Set("days", "hours", "minutes")
-    val RUN_SPEC_EXEC_POLICY_ATTRS = Set("restartOn", "maxRestarts")
-    val RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS = Set("ExecutionError", "UnresponsiveWorker",
-                                                    "JMInternalError", "AppInternalError",
-                                                    "JobTimeoutExceeded", "*")
-    val TASK_DX_ATTRS = Set("runSpec", "details")
-    val DX_DETAILS_ATTRS = Set("upstreamProjects")
+  val DOCKER_REGISTRY_ATTRS = Set("username", "registry", "credentials")
+  val CUSTOM_REORG_ATTRS    = Set("app_id", "conf")
+  val EXTRA_ATTRS = Set(
+    "default_runtime_attributes",
+    "default_task_dx_attributes",
+    "per_task_dx_attributes",
+    "docker_registry",
+    "custom_reorg"
+  )
+  val RUNTIME_ATTRS =
+    Set("dx_instance_type", "memory", "disks", "cpu", "docker", "docker_registry", "custom_reorg")
+  val RUN_SPEC_ATTRS = Set("access", "executionPolicy", "restartableEntryPoints", "timeoutPolicy")
+  val RUN_SPEC_ACCESS_ATTRS =
+    Set("network", "project", "allProjects", "developer", "projectCreation")
+  val RUN_SPEC_TIMEOUT_ATTRS     = Set("days", "hours", "minutes")
+  val RUN_SPEC_EXEC_POLICY_ATTRS = Set("restartOn", "maxRestarts")
+  val RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS = Set(
+    "ExecutionError",
+    "UnresponsiveWorker",
+    "JMInternalError",
+    "AppInternalError",
+    "JobTimeoutExceeded",
+    "*"
+  )
+  val TASK_DX_ATTRS    = Set("runSpec", "details")
+  val DX_DETAILS_ATTRS = Set("upstreamProjects")
 
+  private def checkedParseIntField(fields: Map[String, JsValue], fieldName: String): Option[Int] = {
+    fields.get(fieldName) match {
+      case None                => None
+      case Some(JsNumber(bnm)) => Some(bnm.intValue)
+      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+    }
+  }
 
-    private def checkedParseIntField(fields: Map[String, JsValue],
-                                     fieldName: String) : Option[Int] = {
-        fields.get(fieldName) match {
-            case None => None
-            case Some(JsNumber(bnm)) => Some(bnm.intValue)
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
+  private def checkedParseStringField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[String] = {
+    fields.get(fieldName) match {
+      case None                => None
+      case Some(JsString(str)) => Some(str)
+      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedParseStringFieldReplaceNull(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[String] = {
+    fields.get(fieldName) match {
+      case None                => None
+      case Some(JsString(str)) => Some(str)
+      case Some(JsNull)        => Some("")
+      case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedParseStringArrayField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[Vector[String]] = {
+    fields.get(fieldName) match {
+      case None => None
+      case Some(JsArray(vec)) =>
+        val v = vec.map {
+          case JsString(str) => str
+          case other         => throw new Exception(s"Malformed ${fieldName} (${other})")
         }
+        Some(v)
+      case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
     }
+  }
 
-    private def checkedParseStringField(fields: Map[String, JsValue],
-                                        fieldName: String) : Option[String] = {
-        fields.get(fieldName) match {
-            case None => None
-            case Some(JsString(str)) => Some(str)
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
+  private def checkedParseBooleanField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[Boolean] = {
+    fields.get(fieldName) match {
+      case None               => None
+      case Some(JsBoolean(b)) => Some(b)
+      case Some(other)        => throw new Exception(s"Malformed ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedParseAccessLevelField(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[AccessLevel] = {
+    checkedParseStringField(fields, fieldName) match {
+      case None =>
+        return None
+      case Some(s) =>
+        for (x <- AccessLevel.values()) {
+          if (x.toString.toLowerCase == s.toLowerCase)
+            return Some(x)
         }
+        throw new Exception(s"Invalid access level ${s}")
     }
+  }
 
-    private def checkedParseStringFieldReplaceNull(fields: Map[String, JsValue],
-                                        fieldName: String) : Option[String] = {
-        fields.get(fieldName) match {
-            case None => None
-            case Some(JsString(str)) => Some(str)
-            case Some(JsNull) => Some("")
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
-        }
+  private def checkedParseObjectField(fields: Map[String, JsValue], fieldName: String): JsValue = {
+    fields.get(fieldName) match {
+      case None                   => JsNull
+      case Some(JsObject(fields)) => JsObject(fields)
+      case Some(other)            => throw new Exception(s"Malformed ${fieldName} (${other})")
     }
+  }
 
-    private def checkedParseStringArrayField(fields: Map[String, JsValue],
-                                             fieldName: String) : Option[Vector[String]] = {
-        fields.get(fieldName) match {
-            case None => None
-            case Some(JsArray(vec)) =>
-                val v = vec.map{
-                    case JsString(str) => str
-                    case other => throw new Exception(s"Malformed ${fieldName} (${other})")
-                }
-                Some(v)
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
-        }
-    }
+  private def checkedParseMapStringInt(
+      fields: Map[String, JsValue],
+      fieldName: String
+  ): Option[Map[String, Int]] = {
+    val m = checkedParseObjectField(fields, fieldName)
+    if (m == JsNull)
+      return None
+    val m1 = m.asJsObject.fields.map {
+      case (name, JsNumber(nmb)) => name -> nmb.intValue
+      case (name, other)         => throw new Exception(s"Malformed ${fieldName} (${name} -> ${other})")
+    }.toMap
+    return Some(m1)
+  }
 
-    private def checkedParseBooleanField(fields: Map[String, JsValue],
-                                        fieldName: String) : Option[Boolean] = {
-        fields.get(fieldName) match {
-            case None => None
-            case Some(JsBoolean(b)) => Some(b)
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
-        }
-    }
-
-    private def checkedParseAccessLevelField(fields: Map[String, JsValue],
-                                             fieldName: String) : Option[AccessLevel] = {
-        checkedParseStringField(fields, fieldName) match {
-            case None =>
-                return None
-            case Some(s) =>
-                for (x <-  AccessLevel.values()) {
-                    if (x.toString.toLowerCase == s.toLowerCase)
-                        return Some(x)
-                }
-                throw new Exception(s"Invalid access level ${s}")
-        }
-    }
-
-    private def checkedParseObjectField(fields: Map[String, JsValue],
-                                        fieldName: String) : JsValue = {
-        fields.get(fieldName) match {
-            case None => JsNull
-            case Some(JsObject(fields)) => JsObject(fields)
-            case Some(other) => throw new Exception(s"Malformed ${fieldName} (${other})")
-        }
-    }
-
-    private def checkedParseMapStringInt(fields: Map[String, JsValue],
-                                         fieldName: String) : Option[Map[String, Int]] = {
-        val m = checkedParseObjectField(fields, fieldName)
-        if (m == JsNull)
-            return None
-        val m1 = m.asJsObject.fields.map{
-            case (name, JsNumber(nmb)) => name -> nmb.intValue
-            case (name, other) => throw new Exception(s"Malformed ${fieldName} (${name} -> ${other})")
-        }.toMap
-        return Some(m1)
-    }
-
-    private def parseWdlRuntimeAttrs(jsv: JsValue,
-                                     verbose: Verbose) : WdlRuntimeAttrs = {
-        if (jsv == JsNull)
-            return WdlRuntimeAttrs(Map.empty)
-        val fields = jsv.asJsObject.fields
-        for (k <- fields.keys) {
-            if (!(RUNTIME_ATTRS contains k))
-                Utils.warning(verbose, s"""|Unsupported runtime attribute ${k},
+  private def parseWdlRuntimeAttrs(jsv: JsValue, verbose: Verbose): WdlRuntimeAttrs = {
+    if (jsv == JsNull)
+      return WdlRuntimeAttrs(Map.empty)
+    val fields = jsv.asJsObject.fields
+    for (k <- fields.keys) {
+      if (!(RUNTIME_ATTRS contains k))
+        Utils.warning(
+          verbose,
+          s"""|Unsupported runtime attribute ${k},
                                            |we currently support ${RUNTIME_ATTRS}
-                                           |""".stripMargin.replaceAll("\n", ""))
-        }
-
-        def wdlValueFromJsValue(jsv: JsValue) : WomValue = {
-            jsv match {
-                case JsBoolean(b) => WomBoolean(b.booleanValue)
-                case JsNumber(nmb) => WomInteger(nmb.intValue)
-                case JsString(s) => WomString(s)
-                case other => throw new Exception(s"Unsupported json value ${other}")
-            }
-        }
-        val attrs = fields
-            .filter{ case (key,_) => RUNTIME_ATTRS contains key }
-            .map{ case (name, jsValue) =>
-                name -> wdlValueFromJsValue(jsValue) }.toMap
-        return WdlRuntimeAttrs(attrs)
+                                           |""".stripMargin.replaceAll("\n", "")
+        )
     }
 
-    private def parseExecutionPolicy(jsv: JsValue) : Option[DxExecPolicy] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
-        for (k <- fields.keys) {
-            if (!(RUN_SPEC_EXEC_POLICY_ATTRS contains k))
-                throw new Exception(s"""|Unsupported runSpec.access attribute ${k},
+    def wdlValueFromJsValue(jsv: JsValue): WomValue = {
+      jsv match {
+        case JsBoolean(b)  => WomBoolean(b.booleanValue)
+        case JsNumber(nmb) => WomInteger(nmb.intValue)
+        case JsString(s)   => WomString(s)
+        case other         => throw new Exception(s"Unsupported json value ${other}")
+      }
+    }
+    val attrs = fields
+      .filter { case (key, _) => RUNTIME_ATTRS contains key }
+      .map {
+        case (name, jsValue) =>
+          name -> wdlValueFromJsValue(jsValue)
+      }
+      .toMap
+    return WdlRuntimeAttrs(attrs)
+  }
+
+  private def parseExecutionPolicy(jsv: JsValue): Option[DxExecPolicy] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+    for (k <- fields.keys) {
+      if (!(RUN_SPEC_EXEC_POLICY_ATTRS contains k))
+        throw new Exception(s"""|Unsupported runSpec.access attribute ${k},
                                         |we currently support ${RUN_SPEC_EXEC_POLICY_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
 
-        }
-
-        val restartOn = checkedParseMapStringInt(fields, "restartOn")
-        restartOn match {
-            case None => ()
-            case Some(restartOnPolicy) =>
-                for (k <- restartOnPolicy.keys)
-                    if (!(RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS contains k))
-                        throw new Exception(s"unknown field ${k} in restart policy")
-        }
-
-        val maxRestarts = checkedParseIntField(fields, "maxRestarts")
-        return Some(DxExecPolicy(restartOn, maxRestarts))
     }
 
-    private def parseAccess(jsv: JsValue) : Option[DxAccess] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
-        for (k <- fields.keys) {
-            if (!(RUN_SPEC_ACCESS_ATTRS contains k))
-                throw new Exception(s"""|Unsupported runSpec.access attribute ${k},
+    val restartOn = checkedParseMapStringInt(fields, "restartOn")
+    restartOn match {
+      case None => ()
+      case Some(restartOnPolicy) =>
+        for (k <- restartOnPolicy.keys)
+          if (!(RUN_SPEC_EXEC_POLICY_RESTART_ON_ATTRS contains k))
+            throw new Exception(s"unknown field ${k} in restart policy")
+    }
+
+    val maxRestarts = checkedParseIntField(fields, "maxRestarts")
+    return Some(DxExecPolicy(restartOn, maxRestarts))
+  }
+
+  private def parseAccess(jsv: JsValue): Option[DxAccess] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+    for (k <- fields.keys) {
+      if (!(RUN_SPEC_ACCESS_ATTRS contains k))
+        throw new Exception(s"""|Unsupported runSpec.access attribute ${k},
                                         |we currently support ${RUN_SPEC_ACCESS_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
 
-        }
-
-        return Some(DxAccess(checkedParseStringArrayField(fields, "network"),
-                             checkedParseAccessLevelField(fields, "project"),
-                             checkedParseAccessLevelField(fields, "allProjects"),
-                             checkedParseBooleanField(fields, "developer"),
-                             checkedParseBooleanField(fields, "projectCreation")))
     }
 
-    /* Only timeouts of the following format are supported:
+    return Some(
+      DxAccess(
+        checkedParseStringArrayField(fields, "network"),
+        checkedParseAccessLevelField(fields, "project"),
+        checkedParseAccessLevelField(fields, "allProjects"),
+        checkedParseBooleanField(fields, "developer"),
+        checkedParseBooleanField(fields, "projectCreation")
+      )
+    )
+  }
+
+  /* Only timeouts of the following format are supported:
          "timeoutPolicy": {
              "*": {
                  "hours": 12
              }
          },
-     */
-    private def parseTimeoutPolicy(jsv: JsValue) : Option[DxTimeout] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
-        if (fields.keys.size != 1)
-            throw new Exception("Exactly one entry-point timeout can be specified")
-        val key = fields.keys.head
-        if (key != "*")
-            throw new Exception("""Only a general timeout for all entry points is supported ("*")""")
-        val subObj = checkedParseObjectField(fields, "*")
-        if (subObj == JsNull)
-            return None
-        val subFields = subObj.asJsObject.fields
-        for (k <- subFields.keys) {
-            if (!(RUN_SPEC_TIMEOUT_ATTRS contains k))
-                throw new Exception(s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
+   */
+  private def parseTimeoutPolicy(jsv: JsValue): Option[DxTimeout] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+    if (fields.keys.size != 1)
+      throw new Exception("Exactly one entry-point timeout can be specified")
+    val key = fields.keys.head
+    if (key != "*")
+      throw new Exception("""Only a general timeout for all entry points is supported ("*")""")
+    val subObj = checkedParseObjectField(fields, "*")
+    if (subObj == JsNull)
+      return None
+    val subFields = subObj.asJsObject.fields
+    for (k <- subFields.keys) {
+      if (!(RUN_SPEC_TIMEOUT_ATTRS contains k))
+        throw new Exception(s"""|Unsupported runSpec.timeoutPolicy attribute ${k},
                                         |we currently support ${RUN_SPEC_TIMEOUT_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
 
-        }
-        return Some(DxTimeout(checkedParseIntField(subFields, "days"),
-                              checkedParseIntField(subFields, "hours"),
-                              checkedParseIntField(subFields, "minutes")))
     }
+    return Some(
+      DxTimeout(
+        checkedParseIntField(subFields, "days"),
+        checkedParseIntField(subFields, "hours"),
+        checkedParseIntField(subFields, "minutes")
+      )
+    )
+  }
 
-    private def parseRunSpec(jsv: JsValue) : Option[DxRunSpec] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
-        for (k <- fields.keys) {
-            if (!(RUN_SPEC_ATTRS contains k))
-                throw new Exception(s"""|Unsupported runSpec attribute ${k},
+  private def parseRunSpec(jsv: JsValue): Option[DxRunSpec] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+    for (k <- fields.keys) {
+      if (!(RUN_SPEC_ATTRS contains k))
+        throw new Exception(s"""|Unsupported runSpec attribute ${k},
                                         |we currently support ${RUN_SPEC_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
 
-        }
-
-        val restartable : Option[String] =
-            checkedParseStringField(fields, "restartableEntryPoints") match  {
-                case None => None
-                case Some(str) if List("all", "master") contains str => Some(str)
-                case Some(str) => throw new Exception(s"Unsupported restartableEntryPoints value ${str}")
-            }
-        return Some(DxRunSpec(
-                        parseAccess(checkedParseObjectField(fields, "access")),
-                        parseExecutionPolicy(checkedParseObjectField(fields, "executionPolicy")),
-                        restartable,
-                        parseTimeoutPolicy(checkedParseObjectField(fields, "timeoutPolicy"))
-                    ))
-
     }
 
-    private def parseUpstreamProjects(jsv: Option[JsValue]): Option[List[DxLicense]] = {
-        if (jsv == JsNull)
-            return None
+    val restartable: Option[String] =
+      checkedParseStringField(fields, "restartableEntryPoints") match {
+        case None                                            => None
+        case Some(str) if List("all", "master") contains str => Some(str)
+        case Some(str)                                       => throw new Exception(s"Unsupported restartableEntryPoints value ${str}")
+      }
+    return Some(
+      DxRunSpec(
+        parseAccess(checkedParseObjectField(fields, "access")),
+        parseExecutionPolicy(checkedParseObjectField(fields, "executionPolicy")),
+        restartable,
+        parseTimeoutPolicy(checkedParseObjectField(fields, "timeoutPolicy"))
+      )
+    )
 
-        implicit val dxLicenseFormat = jsonFormat6(DxLicense)
-        return Some(jsv.get.convertTo[List[DxLicense]])
+  }
 
-    }
+  private def parseUpstreamProjects(jsv: Option[JsValue]): Option[List[DxLicense]] = {
+    if (jsv == JsNull)
+      return None
 
-    private def parseDxDetails(jsv: JsValue): Option[DxDetails] = {
+    implicit val dxLicenseFormat = jsonFormat6(DxLicense)
+    return Some(jsv.get.convertTo[List[DxLicense]])
 
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
+  }
 
-        Some(DxDetails(parseUpstreamProjects(fields.get("upstreamProjects"))))
-    }
+  private def parseDxDetails(jsv: JsValue): Option[DxDetails] = {
 
-    private def parseTaskDxAttrs(jsv: JsValue,
-                                 verbose: Verbose) : Option[DxAttrs] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
 
-        for (k <- fields.keys) {
-            if (!(TASK_DX_ATTRS contains k))
-                throw new Exception(s"""|Unsupported runtime attribute ${k},
+    Some(DxDetails(parseUpstreamProjects(fields.get("upstreamProjects"))))
+  }
+
+  private def parseTaskDxAttrs(jsv: JsValue, verbose: Verbose): Option[DxAttrs] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+
+    for (k <- fields.keys) {
+      if (!(TASK_DX_ATTRS contains k))
+        throw new Exception(s"""|Unsupported runtime attribute ${k},
                                         |we currently support ${TASK_DX_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
-        }
-
-        val runSpec = parseRunSpec(checkedParseObjectField(fields, "runSpec"))
-        val details = parseDxDetails(checkedParseObjectField(fields, "details"))
-
-
-        return Some(DxAttrs(runSpec, details))
-
-
     }
 
-    private def parseDockerRegistry(jsv: JsValue,
-                                     verbose: Verbose) : Option[DockerRegistry] = {
-        if (jsv == JsNull)
-            return None
-        val fields = jsv.asJsObject.fields
-        for (k <- fields.keys) {
-            if (!(DOCKER_REGISTRY_ATTRS contains k))
-                throw new Exception(s"""|Unsupported docker registry attribute ${k},
+    val runSpec = parseRunSpec(checkedParseObjectField(fields, "runSpec"))
+    val details = parseDxDetails(checkedParseObjectField(fields, "details"))
+
+    return Some(DxAttrs(runSpec, details))
+
+  }
+
+  private def parseDockerRegistry(jsv: JsValue, verbose: Verbose): Option[DockerRegistry] = {
+    if (jsv == JsNull)
+      return None
+    val fields = jsv.asJsObject.fields
+    for (k <- fields.keys) {
+      if (!(DOCKER_REGISTRY_ATTRS contains k))
+        throw new Exception(s"""|Unsupported docker registry attribute ${k},
                                         |we currently support ${DOCKER_REGISTRY_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
 
-        }
-        def getSome(fieldName : String) : String = {
-            checkedParseStringField(fields, fieldName) match {
-                case None => throw new Exception(s"${fieldName} must be specified in the docker section")
-                case Some(x) => x
-            }
-        }
-        val registry = getSome("registry")
-        val username = getSome("username")
-        val credentials = getSome("credentials")
-        Some(DockerRegistry(registry, username, credentials))
     }
+    def getSome(fieldName: String): String = {
+      checkedParseStringField(fields, fieldName) match {
+        case None    => throw new Exception(s"${fieldName} must be specified in the docker section")
+        case Some(x) => x
+      }
+    }
+    val registry    = getSome("registry")
+    val username    = getSome("username")
+    val credentials = getSome("credentials")
+    Some(DockerRegistry(registry, username, credentials))
+  }
 
-    private def checkAttrs(fields: Map[String, JsValue]): (String, String) = {
+  private def checkAttrs(fields: Map[String, JsValue]): (String, String) = {
 
-        for (k <- fields.keys) {
-            if (!(CUSTOM_REORG_ATTRS contains k))
-                throw new IllegalArgumentException(
-                    s"""|Unsupported custom reorg attribute ${k},
+    for (k <- fields.keys) {
+      if (!(CUSTOM_REORG_ATTRS contains k))
+        throw new IllegalArgumentException(s"""|Unsupported custom reorg attribute ${k},
                         |we currently support ${CUSTOM_REORG_ATTRS}
                         |""".stripMargin.replaceAll("\n", ""))
-         }
-
-        val reorgAppId: String = checkedParseStringField(fields, "app_id") match {
-            case None => throw new IllegalArgumentException("app_id must be specified in the custom_reorg section.")
-            case Some(x) => x
-        }
-
-        val reorgConf: String = checkedParseStringFieldReplaceNull(fields, "conf") match {
-            case None => throw new IllegalArgumentException(
-                "conf must be specified in the custom_reorg section. " +
-                  "Please set the value to null if there is no conf file."
-            )
-            case Some(x) => x
-        }
-
-        return (reorgAppId, reorgConf)
-
     }
 
-    private def veryifyReorgApp(reorgAppId: String): Unit= {
+    val reorgAppId: String = checkedParseStringField(fields, "app_id") match {
+      case None =>
+        throw new IllegalArgumentException("app_id must be specified in the custom_reorg section.")
+      case Some(x) => x
+    }
 
-        val app_regex = "app-[0-9a-zA-Z]{24}"
-        val applet_regex = "applet-[0-9a-zA-Z]{24}"
+    val reorgConf: String = checkedParseStringFieldReplaceNull(fields, "conf") match {
+      case None =>
+        throw new IllegalArgumentException(
+          "conf must be specified in the custom_reorg section. " +
+            "Please set the value to null if there is no conf file."
+        )
+      case Some(x) => x
+    }
 
+    return (reorgAppId, reorgConf)
 
-        val isValidID: Boolean = reorgAppId.matches(app_regex) || reorgAppId.matches(applet_regex)
+  }
 
-        if (!isValidID) {
-            throw new IllegalArgumentException("dxId must match applet-[A-Za-z0-9]{24}")
-        }
+  private def veryifyReorgApp(reorgAppId: String): Unit = {
 
-        // FIXME: This needs to be done --without-- using dx. Use java/scala describe instead.
-/*        val dxUploadCmd = s"""dx describe ${reorgAppId} --json"""
+    val app_regex    = "app-[0-9a-zA-Z]{24}"
+    val applet_regex = "applet-[0-9a-zA-Z]{24}"
+
+    val isValidID: Boolean = reorgAppId.matches(app_regex) || reorgAppId.matches(applet_regex)
+
+    if (!isValidID) {
+      throw new IllegalArgumentException("dxId must match applet-[A-Za-z0-9]{24}")
+    }
+
+    // FIXME: This needs to be done --without-- using dx. Use java/scala describe instead.
+    /*        val dxUploadCmd = s"""dx describe ${reorgAppId} --json"""
 
         val (outmsg, errmsg) = Utils.execCommand(dxUploadCmd, None)
 
@@ -656,34 +694,34 @@ object Extras {
             throw new PermissionDeniedException(s"ERROR: App(let) for custom reorg stage ${reorgAppId } does not " +
               s"have CONTRIBUTOR or ADMINISTRATOR access and this is required.")
         }*/
+  }
+
+  private def verifyInputs(reorgConf: String): Unit = {
+
+    // if provided, check that the fileID is valid and present
+    if (reorgConf != "") {
+      // format dx file ID
+      val reorgFileID: String = reorgConf.replace("dx://", "")
+      // if input file  ID is invalid, DxFile.getInstance will thow an IllegalArgumentException
+      val file: DxFile = DxFile.getInstance(reorgFileID)
+      // if reorgFileID cannot be found, describe will throw a ResourceNotFoundException
+      file.describe()
     }
 
-    private def verifyInputs(reorgConf: String): Unit= {
+  }
 
-        // if provided, check that the fileID is valid and present
-        if (reorgConf != "") {
-            // format dx file ID
-            val reorgFileID: String = reorgConf.replace("dx://", "")
-            // if input file  ID is invalid, DxFile.getInstance will thow an IllegalArgumentException
-            val file: DxFile = DxFile.getInstance(reorgFileID)
-            // if reorgFileID cannot be found, describe will throw a ResourceNotFoundException
-            file.describe()
-        }
+  def parseCustomReorgAttrs(jsv: JsValue, verbose: Verbose): Option[ReorgAttrs] = {
+    if (jsv == JsNull)
+      return None
 
-    }
+    val fields                  = jsv.asJsObject.fields
+    val (reorgAppId, reorgConf) = checkAttrs(fields)
+    veryifyReorgApp(reorgAppId)
+    verifyInputs(reorgConf)
 
-    def parseCustomReorgAttrs(jsv: JsValue, verbose: Verbose): Option[ReorgAttrs] = {
-        if (jsv == JsNull)
-            return None
-
-        val fields = jsv.asJsObject.fields
-        val (reorgAppId, reorgConf) = checkAttrs(fields)
-        veryifyReorgApp(reorgAppId)
-        verifyInputs(reorgConf)
-
-        Utils.trace(
-            verbose.on,
-            s"""|Writing your own applet for reorganization purposes is tricky. If you are not careful,
+    Utils.trace(
+      verbose.on,
+      s"""|Writing your own applet for reorganization purposes is tricky. If you are not careful,
                 |it may misplace or outright delete files.
                 |The applet: ${reorgAppId} requires CONTRIBUTE project access,
                 |so it can move files and folders around and has to be idempotent, so that if the instance it runs on crashes, it can safely restart. It has to be careful about inputs that are also outputs. Normally, these should not be moved. It should use bulk object operations, so as not to overload the API server.'
@@ -691,59 +729,53 @@ object Extras {
                 |
                 |https://github.com/dnanexus/dxWDL/blob/master/doc/ExpertOptions.md#use-your-own-applet
             """.stripMargin.replaceAll("\n", " ")
-        )
-        Some(ReorgAttrs(reorgAppId, reorgConf))
+    )
+    Some(ReorgAttrs(reorgAppId, reorgConf))
+  }
+
+  def parse(jsv: JsValue, verbose: Verbose): Extras = {
+    val fields = jsv match {
+      case JsObject(fields) => fields
+      case _                => throw new Exception(s"malformed extras JSON ${jsv}")
     }
 
-    def parse(jsv: JsValue,
-              verbose: Verbose) : Extras = {
-        val fields = jsv match {
-            case JsObject(fields) => fields
-            case _ => throw new Exception(s"malformed extras JSON ${jsv}")
-        }
-
-        // Guardrail, check the fields are actually supported
-        for (k <- fields.keys) {
-            if (!(EXTRA_ATTRS contains k))
-                throw new Exception(s"""|Unsupported special option ${k},
+    // Guardrail, check the fields are actually supported
+    for (k <- fields.keys) {
+      if (!(EXTRA_ATTRS contains k))
+        throw new Exception(s"""|Unsupported special option ${k},
                                         |we currently support ${EXTRA_ATTRS}
                                         |""".stripMargin.replaceAll("\n", ""))
-        }
-
-        // parse the individual task dx attributes
-        val perTaskDxAttrs : Map[String, DxAttrs] =
-            checkedParseObjectField(fields, "per_task_dx_attributes") match {
-                case JsNull =>
-                    Map.empty
-                case jsObj =>
-                    val fields = jsObj.asJsObject.fields
-                    fields.foldLeft(Map.empty[String, DxAttrs]){
-                        case (accu, (name, jsValue)) =>
-                            val dxAttrs = parseTaskDxAttrs(jsValue, verbose)
-                            dxAttrs match {
-                                case None =>
-                                    accu
-                                case Some(attrs) =>
-                                    accu + (name -> attrs)
-                            }
-                    }
-            }
-
-        Extras(parseWdlRuntimeAttrs(
-                   checkedParseObjectField(fields, "default_runtime_attributes"),
-                   verbose),
-               parseTaskDxAttrs(
-                   checkedParseObjectField(fields, "default_task_dx_attributes"),
-                   verbose),
-               perTaskDxAttrs,
-               parseDockerRegistry(
-                   checkedParseObjectField(fields, "docker_registry"),
-                   verbose),
-                parseCustomReorgAttrs(
-                    checkedParseObjectField(fields, fieldName = "custom_reorg"), verbose
-                )
-        )
-
-
     }
+
+    // parse the individual task dx attributes
+    val perTaskDxAttrs: Map[String, DxAttrs] =
+      checkedParseObjectField(fields, "per_task_dx_attributes") match {
+        case JsNull =>
+          Map.empty
+        case jsObj =>
+          val fields = jsObj.asJsObject.fields
+          fields.foldLeft(Map.empty[String, DxAttrs]) {
+            case (accu, (name, jsValue)) =>
+              val dxAttrs = parseTaskDxAttrs(jsValue, verbose)
+              dxAttrs match {
+                case None =>
+                  accu
+                case Some(attrs) =>
+                  accu + (name -> attrs)
+              }
+          }
+      }
+
+    Extras(
+      parseWdlRuntimeAttrs(checkedParseObjectField(fields, "default_runtime_attributes"), verbose),
+      parseTaskDxAttrs(checkedParseObjectField(fields, "default_task_dx_attributes"), verbose),
+      perTaskDxAttrs,
+      parseDockerRegistry(checkedParseObjectField(fields, "docker_registry"), verbose),
+      parseCustomReorgAttrs(
+        checkedParseObjectField(fields, fieldName = "custom_reorg"),
+        verbose
+      )
+    )
+
+  }
 }

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -55,7 +55,8 @@ object Utils {
   // the regions live in dxWDL.conf
   def getRegions(): Map[String, String] = {
     val config = ConfigFactory.load(DX_WDL_RUNTIME_CONF_FILE)
-    val l: List[Config] = config.getConfigList("dxWDL.region2project").asScala.toList
+    val l: List[Config] =
+      config.getConfigList("dxWDL.region2project").asScala.toList
     val region2project: Map[String, String] = l.map { pair =>
       val r = pair.getString("region")
       val projName = pair.getString("path")
@@ -121,7 +122,9 @@ object Utils {
   // Dots are illegal in applet variable names.
   def encodeAppletVarName(varName: String): String = {
     if (varName contains ".")
-      throw new Exception(s"Variable ${varName} includes the illegal symbol \\.")
+      throw new Exception(
+        s"Variable ${varName} includes the illegal symbol \\."
+      )
     varName
   }
 
@@ -129,7 +132,10 @@ object Utils {
   //    http://stackoverflow.com/questions/25999255/delete-directory-recursively-in-scala
   def deleteRecursive(file: java.io.File): Unit = {
     if (file.isDirectory) {
-      Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(deleteRecursive(_))
+      Option(file.listFiles)
+        .map(_.toList)
+        .getOrElse(Nil)
+        .foreach(deleteRecursive(_))
     }
     file.delete
   }
@@ -274,7 +280,11 @@ object Utils {
   }
 
   // Logging output for applets at runtime
-  def appletLog(verbose: Boolean, msg: String, limit: Int = APPLET_LOG_MSG_LIMIT): Unit = {
+  def appletLog(
+      verbose: Boolean,
+      msg: String,
+      limit: Int = APPLET_LOG_MSG_LIMIT
+  ): Unit = {
     if (verbose) {
       val shortMsg =
         if (msg.length > limit)

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -21,28 +21,28 @@ class InvalidInputException(s: String) extends Exception(s) {}
 class IllegalArgumentException(s: String) extends Exception(s) {}
 
 object Utils {
-  val APPLET_LOG_MSG_LIMIT           = 1000
-  val CHECKSUM_PROP                  = "dxWDL_checksum"
-  val DEFAULT_RUNTIME_DEBUG_LEVEL    = 1
+  val APPLET_LOG_MSG_LIMIT = 1000
+  val CHECKSUM_PROP = "dxWDL_checksum"
+  val DEFAULT_RUNTIME_DEBUG_LEVEL = 1
   val DEFAULT_APPLET_TIMEOUT_IN_DAYS = 2
-  val DXFUSE_MAX_MEMORY_CONSUMPTION  = 300 * 1024 * 1024 // how much memory dxfuse takes
-  val DXAPI_NUM_OBJECTS_LIMIT        = 1000 // maximal number of objects in a single API request
-  val DX_WDL_ASSET                   = "dxWDLrt"
-  val DX_URL_PREFIX                  = "dx://"
-  val DX_WDL_RUNTIME_CONF_FILE       = "dxWDL_runtime.conf"
-  val FLAT_FILES_SUFFIX              = "___dxfiles"
-  val INTERMEDIATE_RESULTS_FOLDER    = "intermediate"
-  val LAST_STAGE                     = "last"
-  val LINK_INFO_FILENAME             = "linking.json"
-  val MAX_NUM_RENAME_TRIES           = 100
-  val MAX_STRING_LEN                 = 32 * 1024 // Long strings cause problems with bash and the UI
-  val MAX_STAGE_NAME_LEN             = 60 // maximal length of a workflow stage name
-  val MAX_NUM_FILES_MOVE_LIMIT       = 1000
-  val UBUNTU_VERSION                 = "16.04"
-  val VERSION_PROP                   = "dxWDL_version"
-  val REORG_CONFIG                   = "reorg_conf___"
-  val REORG_STATUS                   = "reorg_status___"
-  val REORG_STATUS_COMPLETE          = "completed"
+  val DXFUSE_MAX_MEMORY_CONSUMPTION = 300 * 1024 * 1024 // how much memory dxfuse takes
+  val DXAPI_NUM_OBJECTS_LIMIT = 1000 // maximal number of objects in a single API request
+  val DX_WDL_ASSET = "dxWDLrt"
+  val DX_URL_PREFIX = "dx://"
+  val DX_WDL_RUNTIME_CONF_FILE = "dxWDL_runtime.conf"
+  val FLAT_FILES_SUFFIX = "___dxfiles"
+  val INTERMEDIATE_RESULTS_FOLDER = "intermediate"
+  val LAST_STAGE = "last"
+  val LINK_INFO_FILENAME = "linking.json"
+  val MAX_NUM_RENAME_TRIES = 100
+  val MAX_STRING_LEN = 32 * 1024 // Long strings cause problems with bash and the UI
+  val MAX_STAGE_NAME_LEN = 60 // maximal length of a workflow stage name
+  val MAX_NUM_FILES_MOVE_LIMIT = 1000
+  val UBUNTU_VERSION = "16.04"
+  val VERSION_PROP = "dxWDL_version"
+  val REORG_CONFIG = "reorg_conf___"
+  val REORG_STATUS = "reorg_status___"
+  val REORG_STATUS_COMPLETE = "completed"
 
   var traceLevel = 0
 
@@ -54,10 +54,10 @@ object Utils {
 
   // the regions live in dxWDL.conf
   def getRegions(): Map[String, String] = {
-    val config          = ConfigFactory.load(DX_WDL_RUNTIME_CONF_FILE)
+    val config = ConfigFactory.load(DX_WDL_RUNTIME_CONF_FILE)
     val l: List[Config] = config.getConfigList("dxWDL.region2project").asScala.toList
     val region2project: Map[String, String] = l.map { pair =>
-      val r        = pair.getString("region")
+      val r = pair.getString("region")
       val projName = pair.getString("path")
       r -> projName
     }.toMap
@@ -94,7 +94,7 @@ object Utils {
   def readFileContent(path: Path): String = {
     // Java 8 Example - Uses UTF-8 character encoding
     val lines = Files.readAllLines(path, StandardCharsets.UTF_8).asScala.toList
-    val sb    = new StringBuilder(1024)
+    val sb = new StringBuilder(1024)
     lines.foreach { line =>
       sb.append(line)
       sb.append("\n")
@@ -161,7 +161,7 @@ object Utils {
 // By: owainlewis
 //
   def gzipCompress(input: Array[Byte]): Array[Byte] = {
-    val bos  = new ByteArrayOutputStream(input.length)
+    val bos = new ByteArrayOutputStream(input.length)
     val gzip = new GZIPOutputStream(bos)
     gzip.write(input)
     gzip.close()
@@ -176,7 +176,7 @@ object Utils {
   }
 
   def gzipAndBase64Encode(buf: String): String = {
-    val bytes   = buf.getBytes
+    val bytes = buf.getBytes
     val gzBytes = gzipCompress(bytes)
     Base64.getEncoder.encodeToString(gzBytes)
   }
@@ -189,10 +189,10 @@ object Utils {
   // Job input, output,  error, and info files are located relative to the home
   // directory
   def jobFilesOfHomeDir(homeDir: Path): (Path, Path, Path, Path) = {
-    val jobInputPath  = homeDir.resolve("job_input.json")
+    val jobInputPath = homeDir.resolve("job_input.json")
     val jobOutputPath = homeDir.resolve("job_output.json")
-    val jobErrorPath  = homeDir.resolve("job_error.json")
-    val jobInfoPath   = homeDir.resolve("dnanexus-job.json")
+    val jobErrorPath = homeDir.resolve("job_error.json")
+    val jobInfoPath = homeDir.resolve("dnanexus-job.json")
     (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath)
   }
 
@@ -202,7 +202,7 @@ object Utils {
       timeout: Option[Int] = None,
       quiet: Boolean = false
   ): (String, String) = {
-    val cmds      = Seq("/bin/sh", "-c", cmdLine)
+    val cmds = Seq("/bin/sh", "-c", cmdLine)
     val outStream = new StringBuilder()
     val errStream = new StringBuilder()
     val logger = ProcessLogger(

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -123,7 +123,7 @@ object Utils {
   def encodeAppletVarName(varName: String): String = {
     if (varName contains ".")
       throw new Exception(
-        s"Variable ${varName} includes the illegal symbol \\."
+          s"Variable ${varName} includes the illegal symbol \\."
       )
     varName
   }
@@ -212,8 +212,8 @@ object Utils {
     val outStream = new StringBuilder()
     val errStream = new StringBuilder()
     val logger = ProcessLogger(
-      (o: String) => { outStream.append(o ++ "\n") },
-      (e: String) => { errStream.append(e ++ "\n") }
+        (o: String) => { outStream.append(o ++ "\n") },
+        (e: String) => { errStream.append(e ++ "\n") }
     )
 
     val p: Process = Process(cmds).run(logger, false)

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -14,359 +14,353 @@ import ExecutionContext.Implicits.global
 import scala.sys.process._
 import wom.types._
 
+class PermissionDeniedException(s: String) extends Exception(s) {}
 
-class PermissionDeniedException(s:String) extends Exception(s){}
+class InvalidInputException(s: String) extends Exception(s) {}
 
-class InvalidInputException(s:String) extends Exception(s){}
-
-class IllegalArgumentException(s:String) extends Exception(s){}
+class IllegalArgumentException(s: String) extends Exception(s) {}
 
 object Utils {
-    val APPLET_LOG_MSG_LIMIT = 1000
-    val CHECKSUM_PROP = "dxWDL_checksum"
-    val DEFAULT_RUNTIME_DEBUG_LEVEL = 1
-    val DEFAULT_APPLET_TIMEOUT_IN_DAYS = 2
-    val DXFUSE_MAX_MEMORY_CONSUMPTION = 300 * 1024 * 1024 // how much memory dxfuse takes
-    val DXAPI_NUM_OBJECTS_LIMIT = 1000 // maximal number of objects in a single API request
-    val DX_WDL_ASSET = "dxWDLrt"
-    val DX_URL_PREFIX = "dx://"
-    val DX_WDL_RUNTIME_CONF_FILE = "dxWDL_runtime.conf"
-    val FLAT_FILES_SUFFIX = "___dxfiles"
-    val INTERMEDIATE_RESULTS_FOLDER = "intermediate"
-    val LAST_STAGE = "last"
-    val LINK_INFO_FILENAME = "linking.json"
-    val MAX_NUM_RENAME_TRIES = 100
-    val MAX_STRING_LEN = 32 * 1024     // Long strings cause problems with bash and the UI
-    val MAX_STAGE_NAME_LEN = 60       // maximal length of a workflow stage name
-    val MAX_NUM_FILES_MOVE_LIMIT = 1000
-    val UBUNTU_VERSION = "16.04"
-    val VERSION_PROP = "dxWDL_version"
-    val REORG_CONFIG = "reorg_conf___"
-    val REORG_STATUS = "reorg_status___"
-    val REORG_STATUS_COMPLETE = "completed"
+  val APPLET_LOG_MSG_LIMIT           = 1000
+  val CHECKSUM_PROP                  = "dxWDL_checksum"
+  val DEFAULT_RUNTIME_DEBUG_LEVEL    = 1
+  val DEFAULT_APPLET_TIMEOUT_IN_DAYS = 2
+  val DXFUSE_MAX_MEMORY_CONSUMPTION  = 300 * 1024 * 1024 // how much memory dxfuse takes
+  val DXAPI_NUM_OBJECTS_LIMIT        = 1000 // maximal number of objects in a single API request
+  val DX_WDL_ASSET                   = "dxWDLrt"
+  val DX_URL_PREFIX                  = "dx://"
+  val DX_WDL_RUNTIME_CONF_FILE       = "dxWDL_runtime.conf"
+  val FLAT_FILES_SUFFIX              = "___dxfiles"
+  val INTERMEDIATE_RESULTS_FOLDER    = "intermediate"
+  val LAST_STAGE                     = "last"
+  val LINK_INFO_FILENAME             = "linking.json"
+  val MAX_NUM_RENAME_TRIES           = 100
+  val MAX_STRING_LEN                 = 32 * 1024 // Long strings cause problems with bash and the UI
+  val MAX_STAGE_NAME_LEN             = 60 // maximal length of a workflow stage name
+  val MAX_NUM_FILES_MOVE_LIMIT       = 1000
+  val UBUNTU_VERSION                 = "16.04"
+  val VERSION_PROP                   = "dxWDL_version"
+  val REORG_CONFIG                   = "reorg_conf___"
+  val REORG_STATUS                   = "reorg_status___"
+  val REORG_STATUS_COMPLETE          = "completed"
 
+  var traceLevel = 0
 
-    var traceLevel = 0
+  // The version lives in application.conf
+  def getVersion(): String = {
+    val config = ConfigFactory.load("application.conf")
+    config.getString("dxWDL.version")
+  }
 
-    // The version lives in application.conf
-    def getVersion() : String = {
-        val config = ConfigFactory.load("application.conf")
-        config.getString("dxWDL.version")
+  // the regions live in dxWDL.conf
+  def getRegions(): Map[String, String] = {
+    val config          = ConfigFactory.load(DX_WDL_RUNTIME_CONF_FILE)
+    val l: List[Config] = config.getConfigList("dxWDL.region2project").asScala.toList
+    val region2project: Map[String, String] = l.map { pair =>
+      val r        = pair.getString("region")
+      val projName = pair.getString("path")
+      r -> projName
+    }.toMap
+    region2project
+  }
+
+  // Ignore a value. This is useful for avoiding warnings/errors
+  // on unused variables.
+  def ignore[A](value: A): Unit = {}
+
+  lazy val appCompileDirPath: Path = {
+    val p = Paths.get("/tmp/dxWDL_Compile")
+    safeMkdir(p)
+    p
+  }
+
+  // Convert a fully qualified name to a local name.
+  // Examples:
+  //   SOURCE         RESULT
+  //   lib.concat     concat
+  //   lib.sum_list   sum_list
+  def getUnqualifiedName(fqn: String): String = {
+    if (fqn contains ".")
+      fqn.split("\\.").last
+    else
+      fqn
+  }
+
+  // Create a file from a string
+  def writeFileContent(path: Path, str: String): Unit = {
+    Files.write(path, str.getBytes(StandardCharsets.UTF_8))
+  }
+
+  def readFileContent(path: Path): String = {
+    // Java 8 Example - Uses UTF-8 character encoding
+    val lines = Files.readAllLines(path, StandardCharsets.UTF_8).asScala.toList
+    val sb    = new StringBuilder(1024)
+    lines.foreach { line =>
+      sb.append(line)
+      sb.append("\n")
     }
+    sb.toString
+  }
 
-    // the regions live in dxWDL.conf
-    def getRegions() : Map[String, String] = {
-        val config = ConfigFactory.load(DX_WDL_RUNTIME_CONF_FILE)
-        val l: List[Config] = config.getConfigList("dxWDL.region2project").asScala.toList
-        val region2project:Map[String, String] = l.map{ pair =>
-            val r = pair.getString("region")
-            val projName = pair.getString("path")
-            r -> projName
-        }.toMap
-        region2project
+  def exceptionToString(e: Throwable): String = {
+    val sw = new java.io.StringWriter
+    e.printStackTrace(new java.io.PrintWriter(sw))
+    sw.toString
+  }
+
+  // dx does not allow dots in variable names, so we
+  // convert them to underscores.
+  def transformVarName(varName: String): String = {
+    varName.replaceAll("\\.", "___")
+  }
+
+  def revTransformVarName(varName: String): String = {
+    varName.replaceAll("___", "\\.")
+  }
+
+  // Dots are illegal in applet variable names.
+  def encodeAppletVarName(varName: String): String = {
+    if (varName contains ".")
+      throw new Exception(s"Variable ${varName} includes the illegal symbol \\.")
+    varName
+  }
+
+  // recursive directory delete
+  //    http://stackoverflow.com/questions/25999255/delete-directory-recursively-in-scala
+  def deleteRecursive(file: java.io.File): Unit = {
+    if (file.isDirectory) {
+      Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(deleteRecursive(_))
     }
+    file.delete
+  }
 
-    // Ignore a value. This is useful for avoiding warnings/errors
-    // on unused variables.
-    def ignore[A](value: A) : Unit = {}
-
-    lazy val appCompileDirPath : Path = {
-        val p = Paths.get("/tmp/dxWDL_Compile")
-        safeMkdir(p)
-        p
+  def safeMkdir(path: Path): Unit = {
+    if (!Files.exists(path)) {
+      Files.createDirectories(path)
+    } else {
+      // Path exists, make sure it is a directory, and not a file
+      if (!Files.isDirectory(path))
+        throw new Exception(s"Path ${path} exists, but is not a directory")
     }
+  }
 
-    // Convert a fully qualified name to a local name.
-    // Examples:
-    //   SOURCE         RESULT
-    //   lib.concat     concat
-    //   lib.sum_list   sum_list
-    def getUnqualifiedName(fqn: String) : String = {
-        if (fqn contains ".")
-            fqn.split("\\.").last
-        else
-            fqn
+  // Add a suffix to a filename, before the regular suffix. For example:
+  //  xxx.wdl -> xxx.simplified.wdl
+  def replaceFileSuffix(src: Path, suffix: String): String = {
+    val fName = src.toFile().getName()
+    val index = fName.lastIndexOf('.')
+    if (index == -1) {
+      fName + suffix
+    } else {
+      val prefix = fName.substring(0, index)
+      prefix + suffix
     }
-
-    // Create a file from a string
-    def writeFileContent(path : Path, str : String) : Unit = {
-        Files.write(path, str.getBytes(StandardCharsets.UTF_8))
-    }
-
-    def readFileContent(path : Path) : String = {
-        // Java 8 Example - Uses UTF-8 character encoding
-        val lines = Files.readAllLines(path, StandardCharsets.UTF_8).asScala.toList
-        val sb = new StringBuilder(1024)
-        lines.foreach{ line =>
-            sb.append(line)
-            sb.append("\n")
-        }
-        sb.toString
-    }
-
-    def exceptionToString(e : Throwable) : String = {
-        val sw = new java.io.StringWriter
-        e.printStackTrace(new java.io.PrintWriter(sw))
-        sw.toString
-    }
-
-
-    // dx does not allow dots in variable names, so we
-    // convert them to underscores.
-    def transformVarName(varName: String) : String = {
-        varName.replaceAll("\\.", "___")
-    }
-
-    def revTransformVarName(varName: String) : String = {
-        varName.replaceAll("___", "\\.")
-    }
-
-
-    // Dots are illegal in applet variable names.
-    def encodeAppletVarName(varName : String) : String = {
-        if (varName contains ".")
-            throw new Exception(s"Variable ${varName} includes the illegal symbol \\.")
-        varName
-    }
-
-    // recursive directory delete
-    //    http://stackoverflow.com/questions/25999255/delete-directory-recursively-in-scala
-    def deleteRecursive(file : java.io.File) : Unit = {
-        if (file.isDirectory) {
-            Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(deleteRecursive(_))
-        }
-        file.delete
-    }
-
-    def safeMkdir(path : Path) : Unit = {
-        if (!Files.exists(path)) {
-            Files.createDirectories(path)
-        } else {
-            // Path exists, make sure it is a directory, and not a file
-            if (!Files.isDirectory(path))
-                throw new Exception(s"Path ${path} exists, but is not a directory")
-        }
-    }
-
-    // Add a suffix to a filename, before the regular suffix. For example:
-    //  xxx.wdl -> xxx.simplified.wdl
-    def replaceFileSuffix(src: Path, suffix: String) : String = {
-        val fName = src.toFile().getName()
-        val index = fName.lastIndexOf('.')
-        if (index == -1) {
-            fName + suffix
-        }
-        else {
-            val prefix = fName.substring(0, index)
-            prefix + suffix
-        }
-    }
+  }
 
 // From: https://gist.github.com/owainlewis/1e7d1e68a6818ee4d50e
 // By: owainlewis
 //
-    def gzipCompress(input: Array[Byte]): Array[Byte] = {
-        val bos = new ByteArrayOutputStream(input.length)
-        val gzip = new GZIPOutputStream(bos)
-        gzip.write(input)
-        gzip.close()
-        val compressed = bos.toByteArray
-        bos.close()
-        compressed
-    }
+  def gzipCompress(input: Array[Byte]): Array[Byte] = {
+    val bos  = new ByteArrayOutputStream(input.length)
+    val gzip = new GZIPOutputStream(bos)
+    gzip.write(input)
+    gzip.close()
+    val compressed = bos.toByteArray
+    bos.close()
+    compressed
+  }
 
-    def gzipDecompress(compressed: Array[Byte]): String = {
-        val inputStream = new GZIPInputStream(new ByteArrayInputStream(compressed))
-        scala.io.Source.fromInputStream(inputStream).mkString
-    }
+  def gzipDecompress(compressed: Array[Byte]): String = {
+    val inputStream = new GZIPInputStream(new ByteArrayInputStream(compressed))
+    scala.io.Source.fromInputStream(inputStream).mkString
+  }
 
-    def gzipAndBase64Encode(buf: String) : String = {
-        val bytes = buf.getBytes
-        val gzBytes = gzipCompress(bytes)
-        Base64.getEncoder.encodeToString(gzBytes)
-    }
+  def gzipAndBase64Encode(buf: String): String = {
+    val bytes   = buf.getBytes
+    val gzBytes = gzipCompress(bytes)
+    Base64.getEncoder.encodeToString(gzBytes)
+  }
 
-    def base64DecodeAndGunzip(buf64: String) : String = {
-        val ba : Array[Byte] = Base64.getDecoder.decode(buf64.getBytes)
-        gzipDecompress(ba)
-    }
+  def base64DecodeAndGunzip(buf64: String): String = {
+    val ba: Array[Byte] = Base64.getDecoder.decode(buf64.getBytes)
+    gzipDecompress(ba)
+  }
 
-    // Job input, output,  error, and info files are located relative to the home
-    // directory
-    def jobFilesOfHomeDir(homeDir : Path) : (Path, Path, Path, Path) = {
-        val jobInputPath = homeDir.resolve("job_input.json")
-        val jobOutputPath = homeDir.resolve("job_output.json")
-        val jobErrorPath = homeDir.resolve("job_error.json")
-        val jobInfoPath = homeDir.resolve("dnanexus-job.json")
-        (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath)
-    }
+  // Job input, output,  error, and info files are located relative to the home
+  // directory
+  def jobFilesOfHomeDir(homeDir: Path): (Path, Path, Path, Path) = {
+    val jobInputPath  = homeDir.resolve("job_input.json")
+    val jobOutputPath = homeDir.resolve("job_output.json")
+    val jobErrorPath  = homeDir.resolve("job_error.json")
+    val jobInfoPath   = homeDir.resolve("dnanexus-job.json")
+    (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath)
+  }
 
+  // Run a child process and collect stdout and stderr into strings
+  def execCommand(
+      cmdLine: String,
+      timeout: Option[Int] = None,
+      quiet: Boolean = false
+  ): (String, String) = {
+    val cmds      = Seq("/bin/sh", "-c", cmdLine)
+    val outStream = new StringBuilder()
+    val errStream = new StringBuilder()
+    val logger = ProcessLogger(
+      (o: String) => { outStream.append(o ++ "\n") },
+      (e: String) => { errStream.append(e ++ "\n") }
+    )
 
-    // Run a child process and collect stdout and stderr into strings
-    def execCommand(cmdLine : String,
-                    timeout: Option[Int] = None,
-                    quiet: Boolean = false) : (String, String) = {
-        val cmds = Seq("/bin/sh", "-c", cmdLine)
-        val outStream = new StringBuilder()
-        val errStream = new StringBuilder()
-        val logger = ProcessLogger(
-            (o: String) => { outStream.append(o ++ "\n") },
-            (e: String) => { errStream.append(e ++ "\n") }
-        )
-
-        val p : Process = Process(cmds).run(logger, false)
-        timeout match {
-            case None =>
-                // blocks, and returns the exit code. Does NOT connect
-                // the standard in of the child job to the parent
-                val retcode = p.exitValue()
-                if (retcode != 0) {
-                    if (!quiet) {
-                        System.err.println(s"STDOUT: ${outStream.toString()}")
-                        System.err.println(s"STDERR: ${errStream.toString()}")
-                    }
-                    throw new Exception(s"Error running command ${cmdLine}")
-                }
-            case Some(nSec) =>
-                val f = Future(blocking(p.exitValue()))
-                try {
-                    Await.result(f, duration.Duration(nSec, "sec"))
-                } catch {
-                    case _: TimeoutException =>
-                        p.destroy()
-                        throw new Exception(s"Timeout exceeded (${nSec} seconds)")
-                }
+    val p: Process = Process(cmds).run(logger, false)
+    timeout match {
+      case None =>
+        // blocks, and returns the exit code. Does NOT connect
+        // the standard in of the child job to the parent
+        val retcode = p.exitValue()
+        if (retcode != 0) {
+          if (!quiet) {
+            System.err.println(s"STDOUT: ${outStream.toString()}")
+            System.err.println(s"STDERR: ${errStream.toString()}")
+          }
+          throw new Exception(s"Error running command ${cmdLine}")
         }
-        (outStream.toString(), errStream.toString())
-    }
-
-    // types
-    def isOptional(t: WomType) : Boolean = {
-        t match {
-            case WomOptionalType(_) => true
-            case t => false
+      case Some(nSec) =>
+        val f = Future(blocking(p.exitValue()))
+        try {
+          Await.result(f, duration.Duration(nSec, "sec"))
+        } catch {
+          case _: TimeoutException =>
+            p.destroy()
+            throw new Exception(s"Timeout exceeded (${nSec} seconds)")
         }
     }
+    (outStream.toString(), errStream.toString())
+  }
 
-    // We need to deal with types like:
-    //     Int??, Array[File]??
-    def stripOptional(t: WomType) : WomType = {
-        t match {
-            case WomOptionalType(x) => stripOptional(x)
-            case x => x
-        }
+  // types
+  def isOptional(t: WomType): Boolean = {
+    t match {
+      case WomOptionalType(_) => true
+      case t                  => false
     }
+  }
 
-    // Replace all special json characters from with a white space.
-    def sanitize(s : String) : String = {
-        def sanitizeChar(ch: Char) : String = ch match {
-            case '}' => " "
-            case '{' => " "
-            case '$' => " "
-            case '/' => " "
-            case '\\' => " "
-            case '\"' => " "
-            case '\'' => " "
-            case _ if (ch.isLetterOrDigit) => ch.toString
-            case _ if (ch.isControl) =>  " "
-            case _ => ch.toString
-        }
-        if (s != null)
-            s.flatMap(sanitizeChar)
+  // We need to deal with types like:
+  //     Int??, Array[File]??
+  def stripOptional(t: WomType): WomType = {
+    t match {
+      case WomOptionalType(x) => stripOptional(x)
+      case x                  => x
+    }
+  }
+
+  // Replace all special json characters from with a white space.
+  def sanitize(s: String): String = {
+    def sanitizeChar(ch: Char): String = ch match {
+      case '}'                       => " "
+      case '{'                       => " "
+      case '$'                       => " "
+      case '/'                       => " "
+      case '\\'                      => " "
+      case '\"'                      => " "
+      case '\''                      => " "
+      case _ if (ch.isLetterOrDigit) => ch.toString
+      case _ if (ch.isControl)       => " "
+      case _                         => ch.toString
+    }
+    if (s != null)
+      s.flatMap(sanitizeChar)
+    else
+      ""
+  }
+
+  // Logging output for applets at runtime
+  def appletLog(verbose: Boolean, msg: String, limit: Int = APPLET_LOG_MSG_LIMIT): Unit = {
+    if (verbose) {
+      val shortMsg =
+        if (msg.length > limit)
+          "Message is too long for logging"
         else
-            ""
+          msg
+      System.err.println(shortMsg)
     }
+  }
 
-    // Logging output for applets at runtime
-    def appletLog(verbose: Boolean,
-                  msg: String,
-                  limit: Int = APPLET_LOG_MSG_LIMIT) : Unit = {
-        if (verbose) {
-            val shortMsg =
-                if (msg.length > limit)
-                    "Message is too long for logging"
-                else
-                    msg
-            System.err.println(shortMsg)
+  def genNSpaces(n: Int) = s"${" " * n}"
+
+  def traceLevelSet(i: Int): Unit = {
+    traceLevel = i
+  }
+
+  def traceLevelInc(): Unit = {
+    traceLevel += 1
+  }
+
+  def traceLevelDec(): Unit = {
+    if (traceLevel > 0)
+      traceLevel -= 1
+  }
+
+  // Used by the compiler to provide more information to the user
+  def trace(verbose: Boolean, msg: String): Unit = {
+    if (!verbose)
+      return
+    val indent = genNSpaces(traceLevel * 2)
+    System.err.println(indent + msg)
+  }
+
+  // color warnings yellow
+  def warning(verbose: Verbose, msg: String): Unit = {
+    if (verbose.quiet)
+      return;
+    System.err.println(Console.YELLOW + msg + Console.RESET)
+  }
+
+  def error(msg: String): Unit = {
+    System.err.println(Console.RED + msg + Console.RESET)
+  }
+
+  // Make a JSON value deterministically sorted.  This is used to
+  // ensure that the checksum does not change when maps
+  // are ordered in different ways.
+  //
+  // Note: this does not handle the case where of arrays that
+  // may have different equivalent orderings.
+  def makeDeterministic(jsValue: JsValue): JsValue = {
+    jsValue match {
+      case JsObject(m: Map[String, JsValue]) =>
+        val m2 = m.map {
+          case (k, v) => k -> makeDeterministic(v)
+        }.toMap
+        val tree = TreeMap(m2.toArray: _*)
+        JsObject(tree)
+      case other =>
+        other
+    }
+  }
+
+  // Concatenate the elements, until hitting a size limit
+  def buildLimitedSizeName(elements: Seq[String], maxLen: Int): String = {
+    if (elements.isEmpty)
+      return "[]"
+    val (_, concat) = elements.tail.foldLeft((false, elements(0))) {
+      case ((true, accu), _) =>
+        // stopping condition reached, we have reached the size limit
+        (true, accu)
+
+      case ((false, accu), _) if accu.size >= maxLen =>
+        // move into stopping condition
+        (true, accu)
+
+      case ((false, accu), elem) =>
+        val tentative = accu + ", " + elem
+        if (tentative.size > maxLen) {
+          // not enough space
+          (true, accu)
+        } else {
+          // still have space
+          (false, tentative)
         }
     }
-
-    def genNSpaces(n: Int) = s"${" " * n}"
-
-    def traceLevelSet(i: Int) : Unit = {
-        traceLevel = i
-    }
-
-    def traceLevelInc() : Unit = {
-        traceLevel += 1
-    }
-
-    def traceLevelDec() : Unit = {
-        if (traceLevel > 0)
-            traceLevel -= 1
-    }
-
-        // Used by the compiler to provide more information to the user
-    def trace(verbose: Boolean, msg: String) : Unit = {
-        if (!verbose)
-            return
-        val indent = genNSpaces(traceLevel * 2)
-        System.err.println(indent + msg)
-    }
-
-    // color warnings yellow
-    def warning(verbose: Verbose, msg:String) : Unit = {
-        if (verbose.quiet)
-            return;
-        System.err.println(Console.YELLOW + msg + Console.RESET)
-    }
-
-    def error(msg: String) : Unit = {
-        System.err.println(Console.RED + msg + Console.RESET)
-    }
-
-    // Make a JSON value deterministically sorted.  This is used to
-    // ensure that the checksum does not change when maps
-    // are ordered in different ways.
-    //
-    // Note: this does not handle the case where of arrays that
-    // may have different equivalent orderings.
-    def makeDeterministic(jsValue : JsValue) : JsValue = {
-        jsValue match {
-            case JsObject(m : Map[String, JsValue]) =>
-                val m2 = m.map{
-                    case (k, v) => k -> makeDeterministic(v)
-                }.toMap
-                val tree = TreeMap(m2.toArray:_*)
-                JsObject(tree)
-            case other =>
-                other
-        }
-    }
-
-    // Concatenate the elements, until hitting a size limit
-    def buildLimitedSizeName(elements: Seq[String], maxLen: Int) : String = {
-        if (elements.isEmpty)
-            return "[]"
-        val (_, concat) = elements.tail.foldLeft((false, elements(0))){
-            case ((true, accu), _) =>
-                // stopping condition reached, we have reached the size limit
-                (true, accu)
-
-            case ((false, accu), _) if accu.size >= maxLen =>
-                // move into stopping condition
-                (true, accu)
-
-            case ((false, accu), elem) =>
-                val tentative = accu + ", " + elem
-                if (tentative.size > maxLen) {
-                    // not enough space
-                    (true, accu)
-                } else {
-                    // still have space
-                    (false, tentative)
-                }
-        }
-        "[" + concat + "]"
-    }
+    "[" + concat + "]"
+  }
 }

--- a/src/main/scala/dxWDL/base/WomTypeSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomTypeSerialization.scala
@@ -79,7 +79,7 @@ case class WomTypeSerialization(typeAliases: Map[String, WomType]) {
     }
     val centralCommaPos = find(0, 0)
 
-    val firstType  = s.substring(0, centralCommaPos)
+    val firstType = s.substring(0, centralCommaPos)
     val secondType = s.substring(centralCommaPos + 1)
     (firstType.trim, secondType.trim)
   }
@@ -94,24 +94,24 @@ case class WomTypeSerialization(typeAliases: Map[String, WomType]) {
       case "String"     => WomStringType
       case "SingleFile" => WomSingleFileType
       case _ if str.contains("[") && str.contains("]") =>
-        val openParen  = str.indexOf("[")
+        val openParen = str.indexOf("[")
         val closeParen = str.lastIndexOf("]")
-        val outer      = str.substring(0, openParen)
-        val inner      = str.substring(openParen + 1, closeParen)
+        val outer = str.substring(0, openParen)
+        val inner = str.substring(openParen + 1, closeParen)
         outer match {
           case "MaybeEmptyArray" => WomMaybeEmptyArrayType(fromString(inner))
           case "Map"             =>
             // split a string like "KK, VV" into (KK, VV)
             val (ks, vs) = splitInTwo(inner)
-            val kt       = fromString(ks)
-            val vt       = fromString(vs)
+            val kt = fromString(ks)
+            val vt = fromString(vs)
             WomMapType(kt, vt)
           case "NonEmptyArray" => WomNonEmptyArrayType(fromString(inner))
           case "Option"        => WomOptionalType(fromString(inner))
           case "Pair" =>
             val (ls, rs) = splitInTwo(inner)
-            val lt       = fromString(ls)
-            val rt       = fromString(rs)
+            val lt = fromString(ls)
+            val rt = fromString(rs)
             WomPairType(lt, rt)
         }
       case name if typeAliases contains name =>

--- a/src/main/scala/dxWDL/base/WomTypeSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomTypeSerialization.scala
@@ -5,168 +5,166 @@ import wom.types._
 // Write a wom type as a string, and be able to convert back.
 case class WomTypeSerialization(typeAliases: Map[String, WomType]) {
 
-    def toString(t:WomType) : String = {
-        t match {
-            // Base case: primitive types.
-            case WomNothingType => "Nothing"
-            case WomBooleanType => "Boolean"
-            case WomIntegerType => "Integer"
-            case WomLongType => "Long"
-            case WomFloatType => "Float"
-            case WomStringType => "String"
-            case WomSingleFileType => "SingleFile"
+  def toString(t: WomType): String = {
+    t match {
+      // Base case: primitive types.
+      case WomNothingType    => "Nothing"
+      case WomBooleanType    => "Boolean"
+      case WomIntegerType    => "Integer"
+      case WomLongType       => "Long"
+      case WomFloatType      => "Float"
+      case WomStringType     => "String"
+      case WomSingleFileType => "SingleFile"
 
-            // compound types
-            case WomMaybeEmptyArrayType(memberType) =>
-                val inner = toString(memberType)
-                s"MaybeEmptyArray[${inner}]"
-            case WomMapType(keyType, valueType) =>
-                val k = toString(keyType)
-                val v = toString(valueType)
-                s"Map[$k, $v]"
-            case WomNonEmptyArrayType(memberType) =>
-                val inner = toString(memberType)
-                s"NonEmptyArray[${inner}]"
-            case WomOptionalType(memberType) =>
-                val inner = toString(memberType)
-                s"Option[$inner]"
-            case WomPairType(lType, rType) =>
-                val ls = toString(lType)
-                val rs = toString(rType)
-                s"Pair[$ls, $rs]"
+      // compound types
+      case WomMaybeEmptyArrayType(memberType) =>
+        val inner = toString(memberType)
+        s"MaybeEmptyArray[${inner}]"
+      case WomMapType(keyType, valueType) =>
+        val k = toString(keyType)
+        val v = toString(valueType)
+        s"Map[$k, $v]"
+      case WomNonEmptyArrayType(memberType) =>
+        val inner = toString(memberType)
+        s"NonEmptyArray[${inner}]"
+      case WomOptionalType(memberType) =>
+        val inner = toString(memberType)
+        s"Option[$inner]"
+      case WomPairType(lType, rType) =>
+        val ls = toString(lType)
+        val rs = toString(rType)
+        s"Pair[$ls, $rs]"
 
-            // structs
-            case WomCompositeType(_, Some(structName)) =>
-                structName
+      // structs
+      case WomCompositeType(_, Some(structName)) =>
+        structName
 
-            // catch-all for other types not currently supported
-            case _ =>
-                throw new Exception(s"Unsupported WOM type ${t}, ${t.stableName}")
-        }
+      // catch-all for other types not currently supported
+      case _ =>
+        throw new Exception(s"Unsupported WOM type ${t}, ${t.stableName}")
     }
+  }
 
-
-    // Split a string like "KK, VV" into the pair ("KK", "VV").
-    // These types appear in maps, for example:
-    //   1. Map[Int, String]
-    // More complex examples are:
-    //   2. Map[File, Map[String, File]]
-    //   3. Map[Map[String, File], Int]
-    //
-    // The difficultly is that we can't just search for the first comma, we
-    // need to find the "central comma". The one that splits the string
-    // into to complete types.
-    //
-    // The inputs handed to this method, in the above examples are:
-    //   1. Int, String
-    //   2. File, Map[String, File]
-    //   3. Map[String, File], Int
-    private def splitInTwo(s: String) : (String, String) = {
-        // find the central comma, it is in the one location where
-        // the square brackets even out.
-        val letters = s.toArray
-        def find(crntPos : Int,
-                 numOpenBrackets : Int) : Int = {
-            if (crntPos >= letters.length)
-                throw new Exception("out of bounds")
-            if (numOpenBrackets < 0)
-                throw new Exception("number of open brackets cannot go below zero")
-            letters(crntPos) match {
-                case '[' => find(crntPos+1, numOpenBrackets+1)
-                case ']' => find(crntPos+1, numOpenBrackets-1)
-                case ',' if (numOpenBrackets == 0) =>
-                    crntPos
-                case _ => find(crntPos+1, numOpenBrackets)
-            }
-        }
-        val centralCommaPos = find(0, 0)
-
-        val firstType = s.substring(0, centralCommaPos)
-        val secondType = s.substring(centralCommaPos + 1)
-        (firstType.trim, secondType.trim)
+  // Split a string like "KK, VV" into the pair ("KK", "VV").
+  // These types appear in maps, for example:
+  //   1. Map[Int, String]
+  // More complex examples are:
+  //   2. Map[File, Map[String, File]]
+  //   3. Map[Map[String, File], Int]
+  //
+  // The difficultly is that we can't just search for the first comma, we
+  // need to find the "central comma". The one that splits the string
+  // into to complete types.
+  //
+  // The inputs handed to this method, in the above examples are:
+  //   1. Int, String
+  //   2. File, Map[String, File]
+  //   3. Map[String, File], Int
+  private def splitInTwo(s: String): (String, String) = {
+    // find the central comma, it is in the one location where
+    // the square brackets even out.
+    val letters = s.toArray
+    def find(crntPos: Int, numOpenBrackets: Int): Int = {
+      if (crntPos >= letters.length)
+        throw new Exception("out of bounds")
+      if (numOpenBrackets < 0)
+        throw new Exception("number of open brackets cannot go below zero")
+      letters(crntPos) match {
+        case '[' => find(crntPos + 1, numOpenBrackets + 1)
+        case ']' => find(crntPos + 1, numOpenBrackets - 1)
+        case ',' if (numOpenBrackets == 0) =>
+          crntPos
+        case _ => find(crntPos + 1, numOpenBrackets)
+      }
     }
+    val centralCommaPos = find(0, 0)
 
-    def fromString(str: String) : WomType = {
-        str match {
-            case "Nothing" => WomNothingType
-            case "Boolean" => WomBooleanType
-            case "Integer" => WomIntegerType
-            case "Long" => WomLongType
-            case "Float" => WomFloatType
-            case "String" => WomStringType
-            case "SingleFile" => WomSingleFileType
-            case _ if str.contains("[") && str.contains("]") =>
-                val openParen = str.indexOf("[")
-                val closeParen = str.lastIndexOf("]")
-                val outer = str.substring(0, openParen)
-                val inner = str.substring(openParen+1, closeParen)
-                outer match {
-                    case "MaybeEmptyArray" => WomMaybeEmptyArrayType(fromString(inner))
-                    case "Map" =>
-                        // split a string like "KK, VV" into (KK, VV)
-                        val (ks, vs) = splitInTwo(inner)
-                        val kt = fromString(ks)
-                        val vt = fromString(vs)
-                        WomMapType(kt, vt)
-                    case "NonEmptyArray" => WomNonEmptyArrayType(fromString(inner))
-                    case "Option" => WomOptionalType(fromString(inner))
-                    case "Pair" =>
-                        val (ls, rs) = splitInTwo(inner)
-                        val lt = fromString(ls)
-                        val rt = fromString(rs)
-                        WomPairType(lt, rt)
-                }
-            case name if typeAliases contains name =>
-                // This must be a user defined type, look in the type-aliases.
-                typeAliases(name)
+    val firstType  = s.substring(0, centralCommaPos)
+    val secondType = s.substring(centralCommaPos + 1)
+    (firstType.trim, secondType.trim)
+  }
 
-            case _ =>
-                throw new Exception(s"Cannot convert ${str} to a wom type")
+  def fromString(str: String): WomType = {
+    str match {
+      case "Nothing"    => WomNothingType
+      case "Boolean"    => WomBooleanType
+      case "Integer"    => WomIntegerType
+      case "Long"       => WomLongType
+      case "Float"      => WomFloatType
+      case "String"     => WomStringType
+      case "SingleFile" => WomSingleFileType
+      case _ if str.contains("[") && str.contains("]") =>
+        val openParen  = str.indexOf("[")
+        val closeParen = str.lastIndexOf("]")
+        val outer      = str.substring(0, openParen)
+        val inner      = str.substring(openParen + 1, closeParen)
+        outer match {
+          case "MaybeEmptyArray" => WomMaybeEmptyArrayType(fromString(inner))
+          case "Map"             =>
+            // split a string like "KK, VV" into (KK, VV)
+            val (ks, vs) = splitInTwo(inner)
+            val kt       = fromString(ks)
+            val vt       = fromString(vs)
+            WomMapType(kt, vt)
+          case "NonEmptyArray" => WomNonEmptyArrayType(fromString(inner))
+          case "Option"        => WomOptionalType(fromString(inner))
+          case "Pair" =>
+            val (ls, rs) = splitInTwo(inner)
+            val lt       = fromString(ls)
+            val rt       = fromString(rs)
+            WomPairType(lt, rt)
         }
+      case name if typeAliases contains name =>
+        // This must be a user defined type, look in the type-aliases.
+        typeAliases(name)
+
+      case _ =>
+        throw new Exception(s"Cannot convert ${str} to a wom type")
     }
+  }
 }
 
 object WomTypeSerialization {
-    // Get a human readable type name
-    // Int ->   "Int"
-    // Array[Int] -> "Array[Int]"
-    def typeName(t: WomType) : String = {
-        t match {
-            // Base case: primitive types.
-            case WomNothingType => "Nothing"
-            case WomBooleanType => "Boolean"
-            case WomIntegerType => "Int"
-            case WomLongType => "Long"
-            case WomFloatType => "Float"
-            case WomStringType => "String"
-            case WomSingleFileType => "File"
+  // Get a human readable type name
+  // Int ->   "Int"
+  // Array[Int] -> "Array[Int]"
+  def typeName(t: WomType): String = {
+    t match {
+      // Base case: primitive types.
+      case WomNothingType    => "Nothing"
+      case WomBooleanType    => "Boolean"
+      case WomIntegerType    => "Int"
+      case WomLongType       => "Long"
+      case WomFloatType      => "Float"
+      case WomStringType     => "String"
+      case WomSingleFileType => "File"
 
-            // compound types
-            case WomMaybeEmptyArrayType(memberType) =>
-                val inner = typeName(memberType)
-                s"Array[${inner}]"
-            case WomMapType(keyType, valueType) =>
-                val k = typeName(keyType)
-                val v = typeName(valueType)
-                s"Map[$k, $v]"
-            case WomNonEmptyArrayType(memberType) =>
-                val inner = typeName(memberType)
-                s"Array[${inner}]+"
-            case WomOptionalType(memberType) =>
-                val inner = typeName(memberType)
-                s"$inner?"
-            case WomPairType(lType, rType) =>
-                val ls = typeName(lType)
-                val rs = typeName(rType)
-                s"Pair[$ls, $rs]"
+      // compound types
+      case WomMaybeEmptyArrayType(memberType) =>
+        val inner = typeName(memberType)
+        s"Array[${inner}]"
+      case WomMapType(keyType, valueType) =>
+        val k = typeName(keyType)
+        val v = typeName(valueType)
+        s"Map[$k, $v]"
+      case WomNonEmptyArrayType(memberType) =>
+        val inner = typeName(memberType)
+        s"Array[${inner}]+"
+      case WomOptionalType(memberType) =>
+        val inner = typeName(memberType)
+        s"$inner?"
+      case WomPairType(lType, rType) =>
+        val ls = typeName(lType)
+        val rs = typeName(rType)
+        s"Pair[$ls, $rs]"
 
-            // structs
-            case WomCompositeType(_, Some(structName)) =>
-                structName
+      // structs
+      case WomCompositeType(_, Some(structName)) =>
+        structName
 
-            // catch-all for other types not currently supported
-            case _ =>
-                throw new Exception(s"Unsupported WOM type ${t}, ${t.stableName}")
-        }
+      // catch-all for other types not currently supported
+      case _ =>
+        throw new Exception(s"Unsupported WOM type ${t}, ${t.stableName}")
     }
+  }
 }

--- a/src/main/scala/dxWDL/base/WomValueSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomValueSerialization.scala
@@ -6,156 +6,157 @@ import wom.types._
 
 case class WomValueSerialization(typeAliases: Map[String, WomType]) {
 
-    // Serialization of a WOM value to JSON
-    private def womToJSON(t:WomType, w:WomValue) : JsValue = {
-        (t, w)  match {
-            // Base case: primitive types.
-            // Files are encoded as their full path.
-            case (WomBooleanType, WomBoolean(b)) => JsBoolean(b)
-            case (WomIntegerType, WomInteger(n)) => JsNumber(n)
-            case (WomFloatType, WomFloat(x)) => JsNumber(x)
-            case (WomStringType, WomString(s)) => JsString(s)
-            case (WomStringType, WomSingleFile(path)) => JsString(path)
-            case (WomSingleFileType, WomSingleFile(path)) => JsString(path)
-            case (WomSingleFileType, WomString(path)) => JsString(path)
+  // Serialization of a WOM value to JSON
+  private def womToJSON(t: WomType, w: WomValue): JsValue = {
+    (t, w) match {
+      // Base case: primitive types.
+      // Files are encoded as their full path.
+      case (WomBooleanType, WomBoolean(b))          => JsBoolean(b)
+      case (WomIntegerType, WomInteger(n))          => JsNumber(n)
+      case (WomFloatType, WomFloat(x))              => JsNumber(x)
+      case (WomStringType, WomString(s))            => JsString(s)
+      case (WomStringType, WomSingleFile(path))     => JsString(path)
+      case (WomSingleFileType, WomSingleFile(path)) => JsString(path)
+      case (WomSingleFileType, WomString(path))     => JsString(path)
 
-            // arrays
-            // Base case: empty array
-            case (_, WomArray(_, ar)) if ar.length == 0 =>
-                JsArray(Vector.empty)
+      // arrays
+      // Base case: empty array
+      case (_, WomArray(_, ar)) if ar.length == 0 =>
+        JsArray(Vector.empty)
 
-            // Non empty array
-            case (WomArrayType(t), WomArray(_, elems)) =>
-                val jsVals = elems.map(e => womToJSON(t, e))
-                JsArray(jsVals.toVector)
+      // Non empty array
+      case (WomArrayType(t), WomArray(_, elems)) =>
+        val jsVals = elems.map(e => womToJSON(t, e))
+        JsArray(jsVals.toVector)
 
-            // Maps. These are projections from a key to value, where
-            // the key and value types are statically known.
-            //
-            // keys are strings, we can use JSON objects
-            case (WomMapType(WomStringType, valueType), WomMap(_, m)) =>
-                JsObject(m.map{
-                         case (WomString(k), v) =>
-                             k -> womToJSON(valueType, v)
-                         case (k,_) =>
-                             throw new Exception(s"key ${k.toWomString} should be a WomStringType")
-                    }.toMap)
+      // Maps. These are projections from a key to value, where
+      // the key and value types are statically known.
+      //
+      // keys are strings, we can use JSON objects
+      case (WomMapType(WomStringType, valueType), WomMap(_, m)) =>
+        JsObject(m.map {
+          case (WomString(k), v) =>
+            k -> womToJSON(valueType, v)
+          case (k, _) =>
+            throw new Exception(s"key ${k.toWomString} should be a WomStringType")
+        }.toMap)
 
-            // general case, the keys are not strings.
-            case (WomMapType(keyType, valueType), WomMap(_, m)) =>
-                val keys:WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
-                val kJs = womToJSON(keys.womType, keys)
-                val values:WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
-                val vJs = womToJSON(values.womType, values)
-                JsObject("keys" -> kJs, "values" -> vJs)
+      // general case, the keys are not strings.
+      case (WomMapType(keyType, valueType), WomMap(_, m)) =>
+        val keys: WomValue   = WomArray(WomArrayType(keyType), m.keys.toVector)
+        val kJs              = womToJSON(keys.womType, keys)
+        val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
+        val vJs              = womToJSON(values.womType, values)
+        JsObject("keys" -> kJs, "values" -> vJs)
 
-            case (WomPairType(lType, rType), WomPair(l,r)) =>
-                val lJs = womToJSON(lType, l)
-                val rJs = womToJSON(rType, r)
-                JsObject("left" -> lJs, "right" -> rJs)
+      case (WomPairType(lType, rType), WomPair(l, r)) =>
+        val lJs = womToJSON(lType, l)
+        val rJs = womToJSON(rType, r)
+        JsObject("left" -> lJs, "right" -> rJs)
 
-            // Strip optional type
-            case (WomOptionalType(t), WomOptionalValue(_,Some(w))) =>
-                womToJSON(t, w)
+      // Strip optional type
+      case (WomOptionalType(t), WomOptionalValue(_, Some(w))) =>
+        womToJSON(t, w)
 
-            // missing value
-            case (_, WomOptionalValue(_,None)) => JsNull
+      // missing value
+      case (_, WomOptionalValue(_, None)) => JsNull
 
-            // keys are strings, requiring no conversion. We do
-            // need to carry the types are runtime.
-            case (WomCompositeType(typeMap, _), WomObject(m: Map[String, WomValue], _)) =>
-                val mJs : Map[String, JsValue] = m.map{
-                    case (key, v) =>
-                        val t: WomType = typeMap(key)
-                        key -> womToJSON(t, v)
-                }.toMap
-                JsObject(mJs)
+      // keys are strings, requiring no conversion. We do
+      // need to carry the types are runtime.
+      case (WomCompositeType(typeMap, _), WomObject(m: Map[String, WomValue], _)) =>
+        val mJs: Map[String, JsValue] = m.map {
+          case (key, v) =>
+            val t: WomType = typeMap(key)
+            key -> womToJSON(t, v)
+        }.toMap
+        JsObject(mJs)
 
-            case (_,_) => throw new Exception(
-                s"""|Unsupported combination type=(${t.stableName},${t})
-                    |value=(${w.toWomString}, ${w})"""
-                    .stripMargin.replaceAll("\n", " "))
+      case (_, _) => throw new Exception(s"""|Unsupported combination type=(${t.stableName},${t})
+                    |value=(${w.toWomString}, ${w})""".stripMargin.replaceAll("\n", " "))
+    }
+  }
+
+  private def womFromJSON(t: WomType, jsv: JsValue): WomValue = {
+    (t, jsv) match {
+      // base case: primitive types
+      case (WomBooleanType, JsBoolean(b))      => WomBoolean(b.booleanValue)
+      case (WomIntegerType, JsNumber(bnm))     => WomInteger(bnm.intValue)
+      case (WomFloatType, JsNumber(bnm))       => WomFloat(bnm.doubleValue)
+      case (WomStringType, JsString(s))        => WomString(s)
+      case (WomSingleFileType, JsString(path)) => WomSingleFile(path)
+
+      // arrays
+      case (WomArrayType(t), JsArray(vec)) =>
+        WomArray(WomArrayType(t), vec.map { elem =>
+          womFromJSON(t, elem)
+        })
+
+      // maps with string keys
+      case (WomMapType(WomStringType, valueType), JsObject(fields)) =>
+        val m: Map[WomValue, WomValue] = fields.map {
+          case (k, v) =>
+            WomString(k) -> womFromJSON(valueType, v)
+        }.toMap
+        WomMap(WomMapType(WomStringType, valueType), m)
+
+      // General maps. These are serialized as an object with a keys array and
+      // a values array.
+      case (WomMapType(keyType, valueType), JsObject(_)) =>
+        jsv.asJsObject.getFields("keys", "values") match {
+          case Seq(JsArray(kJs), JsArray(vJs)) =>
+            val m = (kJs zip vJs).map {
+              case (k, v) =>
+                val kWom = womFromJSON(keyType, k)
+                val vWom = womFromJSON(valueType, v)
+                kWom -> vWom
+            }.toMap
+            WomMap(WomMapType(keyType, valueType), m)
+          case _ => throw new Exception(s"Malformed serialized map ${jsv}")
         }
-    }
 
-    private def womFromJSON(t:WomType, jsv:JsValue) : WomValue = {
-        (t, jsv)  match {
-            // base case: primitive types
-            case (WomBooleanType, JsBoolean(b)) => WomBoolean(b.booleanValue)
-            case (WomIntegerType, JsNumber(bnm)) => WomInteger(bnm.intValue)
-            case (WomFloatType, JsNumber(bnm)) => WomFloat(bnm.doubleValue)
-            case (WomStringType, JsString(s)) => WomString(s)
-            case (WomSingleFileType, JsString(path)) => WomSingleFile(path)
-
-            // arrays
-            case (WomArrayType(t), JsArray(vec)) =>
-                WomArray(WomArrayType(t),
-                         vec.map{ elem => womFromJSON(t, elem) })
-
-
-            // maps with string keys
-            case (WomMapType(WomStringType, valueType), JsObject(fields)) =>
-                val m: Map[WomValue, WomValue] = fields.map {
-                    case (k,v) =>
-                        WomString(k) -> womFromJSON(valueType, v)
-                }.toMap
-                WomMap(WomMapType(WomStringType, valueType), m)
-
-            // General maps. These are serialized as an object with a keys array and
-            // a values array.
-            case (WomMapType(keyType, valueType), JsObject(_)) =>
-                jsv.asJsObject.getFields("keys", "values") match {
-                    case Seq(JsArray(kJs), JsArray(vJs)) =>
-                        val m = (kJs zip vJs).map{ case (k, v) =>
-                            val kWom = womFromJSON(keyType, k)
-                            val vWom = womFromJSON(valueType, v)
-                            kWom -> vWom
-                        }.toMap
-                        WomMap(WomMapType(keyType, valueType), m)
-                    case _ => throw new Exception(s"Malformed serialized map ${jsv}")
-                }
-
-            case (WomPairType(lType, rType), JsObject(_)) =>
-                jsv.asJsObject.getFields("left", "right") match {
-                    case Seq(lJs, rJs) =>
-                        val left = womFromJSON(lType, lJs)
-                        val right = womFromJSON(rType, rJs)
-                        WomPair(left, right)
-                    case _ => throw new Exception(s"Malformed serialized par ${jsv}")
-                }
-
-            case (WomOptionalType(t), JsNull) =>
-                WomOptionalValue(t, None)
-            case (WomOptionalType(t), _) =>
-                WomOptionalValue(womFromJSON(t, jsv))
-
-            // structs
-            case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
-                val m: Map[String, WomValue] = fields.map{
-                    case (key, elemValue) =>
-                        val t : WomType = typeMap(key)
-                        val elem:WomValue = womFromJSON(t, elemValue)
-                        key -> elem
-                }.toMap
-                WomObject(m, WomCompositeType(typeMap, Some(structName)))
-
-            case _ =>
-                throw new Exception(s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}")
+      case (WomPairType(lType, rType), JsObject(_)) =>
+        jsv.asJsObject.getFields("left", "right") match {
+          case Seq(lJs, rJs) =>
+            val left  = womFromJSON(lType, lJs)
+            val right = womFromJSON(rType, rJs)
+            WomPair(left, right)
+          case _ => throw new Exception(s"Malformed serialized par ${jsv}")
         }
-    }
 
-    // serialization routines
-    def toJSON(w:WomValue) : JsValue = {
-        JsObject("womType" -> JsString(WomTypeSerialization(typeAliases).toString(w.womType)),
-                 "womValue" -> womToJSON(w.womType, w))
-    }
+      case (WomOptionalType(t), JsNull) =>
+        WomOptionalValue(t, None)
+      case (WomOptionalType(t), _) =>
+        WomOptionalValue(womFromJSON(t, jsv))
 
-    def fromJSON(jsv:JsValue) : WomValue = {
-        jsv.asJsObject.getFields("womType", "womValue") match {
-            case Seq(JsString(typeStr), wValue) =>
-                val womType = WomTypeSerialization(typeAliases).fromString(typeStr)
-                womFromJSON(womType, wValue)
-            case other => throw new DeserializationException(s"WomValue unexpected ${other}")
-        }
+      // structs
+      case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
+        val m: Map[String, WomValue] = fields.map {
+          case (key, elemValue) =>
+            val t: WomType     = typeMap(key)
+            val elem: WomValue = womFromJSON(t, elemValue)
+            key -> elem
+        }.toMap
+        WomObject(m, WomCompositeType(typeMap, Some(structName)))
+
+      case _ =>
+        throw new Exception(s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}")
     }
+  }
+
+  // serialization routines
+  def toJSON(w: WomValue): JsValue = {
+    JsObject(
+      "womType"  -> JsString(WomTypeSerialization(typeAliases).toString(w.womType)),
+      "womValue" -> womToJSON(w.womType, w)
+    )
+  }
+
+  def fromJSON(jsv: JsValue): WomValue = {
+    jsv.asJsObject.getFields("womType", "womValue") match {
+      case Seq(JsString(typeStr), wValue) =>
+        val womType = WomTypeSerialization(typeAliases).fromString(typeStr)
+        womFromJSON(womType, wValue)
+      case other => throw new DeserializationException(s"WomValue unexpected ${other}")
+    }
+  }
 }

--- a/src/main/scala/dxWDL/base/WomValueSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomValueSerialization.scala
@@ -39,7 +39,7 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
             k -> womToJSON(valueType, v)
           case (k, _) =>
             throw new Exception(
-              s"key ${k.toWomString} should be a WomStringType"
+                s"key ${k.toWomString} should be a WomStringType"
             )
         }.toMap)
 
@@ -79,9 +79,9 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
 
       case (_, _) =>
         throw new Exception(
-          s"""|Unsupported combination type=(${t.stableName},${t})
+            s"""|Unsupported combination type=(${t.stableName},${t})
                     |value=(${w.toWomString}, ${w})""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
   }
@@ -150,7 +150,7 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
 
       case _ =>
         throw new Exception(
-          s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}"
+            s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}"
         )
     }
   }
@@ -158,10 +158,10 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
   // serialization routines
   def toJSON(w: WomValue): JsValue = {
     JsObject(
-      "womType" -> JsString(
-        WomTypeSerialization(typeAliases).toString(w.womType)
-      ),
-      "womValue" -> womToJSON(w.womType, w)
+        "womType" -> JsString(
+            WomTypeSerialization(typeAliases).toString(w.womType)
+        ),
+        "womValue" -> womToJSON(w.womType, w)
     )
   }
 

--- a/src/main/scala/dxWDL/base/WomValueSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomValueSerialization.scala
@@ -43,10 +43,10 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
 
       // general case, the keys are not strings.
       case (WomMapType(keyType, valueType), WomMap(_, m)) =>
-        val keys: WomValue   = WomArray(WomArrayType(keyType), m.keys.toVector)
-        val kJs              = womToJSON(keys.womType, keys)
+        val keys: WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
+        val kJs = womToJSON(keys.womType, keys)
         val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
-        val vJs              = womToJSON(values.womType, values)
+        val vJs = womToJSON(values.womType, values)
         JsObject("keys" -> kJs, "values" -> vJs)
 
       case (WomPairType(lType, rType), WomPair(l, r)) =>
@@ -117,7 +117,7 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
       case (WomPairType(lType, rType), JsObject(_)) =>
         jsv.asJsObject.getFields("left", "right") match {
           case Seq(lJs, rJs) =>
-            val left  = womFromJSON(lType, lJs)
+            val left = womFromJSON(lType, lJs)
             val right = womFromJSON(rType, rJs)
             WomPair(left, right)
           case _ => throw new Exception(s"Malformed serialized par ${jsv}")
@@ -132,7 +132,7 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
       case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
         val m: Map[String, WomValue] = fields.map {
           case (key, elemValue) =>
-            val t: WomType     = typeMap(key)
+            val t: WomType = typeMap(key)
             val elem: WomValue = womFromJSON(t, elemValue)
             key -> elem
         }.toMap
@@ -146,7 +146,7 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
   // serialization routines
   def toJSON(w: WomValue): JsValue = {
     JsObject(
-      "womType"  -> JsString(WomTypeSerialization(typeAliases).toString(w.womType)),
+      "womType" -> JsString(WomTypeSerialization(typeAliases).toString(w.womType)),
       "womValue" -> womToJSON(w.womType, w)
     )
   }

--- a/src/main/scala/dxWDL/base/WomValueSerialization.scala
+++ b/src/main/scala/dxWDL/base/WomValueSerialization.scala
@@ -38,14 +38,17 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
           case (WomString(k), v) =>
             k -> womToJSON(valueType, v)
           case (k, _) =>
-            throw new Exception(s"key ${k.toWomString} should be a WomStringType")
+            throw new Exception(
+              s"key ${k.toWomString} should be a WomStringType"
+            )
         }.toMap)
 
       // general case, the keys are not strings.
       case (WomMapType(keyType, valueType), WomMap(_, m)) =>
         val keys: WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
         val kJs = womToJSON(keys.womType, keys)
-        val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
+        val values: WomValue =
+          WomArray(WomArrayType(valueType), m.values.toVector)
         val vJs = womToJSON(values.womType, values)
         JsObject("keys" -> kJs, "values" -> vJs)
 
@@ -63,7 +66,10 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
 
       // keys are strings, requiring no conversion. We do
       // need to carry the types are runtime.
-      case (WomCompositeType(typeMap, _), WomObject(m: Map[String, WomValue], _)) =>
+      case (
+          WomCompositeType(typeMap, _),
+          WomObject(m: Map[String, WomValue], _)
+          ) =>
         val mJs: Map[String, JsValue] = m.map {
           case (key, v) =>
             val t: WomType = typeMap(key)
@@ -71,8 +77,12 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
         }.toMap
         JsObject(mJs)
 
-      case (_, _) => throw new Exception(s"""|Unsupported combination type=(${t.stableName},${t})
-                    |value=(${w.toWomString}, ${w})""".stripMargin.replaceAll("\n", " "))
+      case (_, _) =>
+        throw new Exception(
+          s"""|Unsupported combination type=(${t.stableName},${t})
+                    |value=(${w.toWomString}, ${w})""".stripMargin
+            .replaceAll("\n", " ")
+        )
     }
   }
 
@@ -139,14 +149,18 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
         WomObject(m, WomCompositeType(typeMap, Some(structName)))
 
       case _ =>
-        throw new Exception(s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}")
+        throw new Exception(
+          s"Unsupported combination ${t.stableName} ${jsv.prettyPrint}"
+        )
     }
   }
 
   // serialization routines
   def toJSON(w: WomValue): JsValue = {
     JsObject(
-      "womType" -> JsString(WomTypeSerialization(typeAliases).toString(w.womType)),
+      "womType" -> JsString(
+        WomTypeSerialization(typeAliases).toString(w.womType)
+      ),
       "womValue" -> womToJSON(w.womType, w)
     )
   }
@@ -156,7 +170,8 @@ case class WomValueSerialization(typeAliases: Map[String, WomType]) {
       case Seq(JsString(typeStr), wValue) =>
         val womType = WomTypeSerialization(typeAliases).fromString(typeStr)
         womFromJSON(womType, wValue)
-      case other => throw new DeserializationException(s"WomValue unexpected ${other}")
+      case other =>
+        throw new DeserializationException(s"WomValue unexpected ${other}")
     }
   }
 }

--- a/src/main/scala/dxWDL/base/package.scala
+++ b/src/main/scala/dxWDL/base/package.scala
@@ -3,66 +3,63 @@ package dxWDL.base
 import java.nio.file.Path
 
 // Exception used for AppInternError
-class AppInternalException private(ex: RuntimeException) extends RuntimeException(ex) {
-    def this(message:String) = this(new RuntimeException(message))
+class AppInternalException private (ex: RuntimeException) extends RuntimeException(ex) {
+  def this(message: String) = this(new RuntimeException(message))
 }
 
 // Exception used for AppError
-class AppException private(ex: RuntimeException) extends RuntimeException(ex) {
-    def this(message:String) = this(new RuntimeException(message))
+class AppException private (ex: RuntimeException) extends RuntimeException(ex) {
+  def this(message: String) = this(new RuntimeException(message))
 }
 
 object IORef extends Enumeration {
-    val Input, Output = Value
+  val Input, Output = Value
 }
 
 object CompilerFlag extends Enumeration {
-    val All, IR, NativeWithoutRuntimeAsset = Value
+  val All, IR, NativeWithoutRuntimeAsset = Value
 }
-
 
 // Encapsulation of verbosity flags.
 //  on --       is the overall setting true/false
 //  keywords -- specific words to trace
 //  quiet:      if true, do not print warnings and informational messages
-case class Verbose(on: Boolean,
-                   quiet: Boolean,
-                   keywords: Set[String]) {
-    lazy val keywordsLo = keywords.map(_.toLowerCase).toSet
+case class Verbose(on: Boolean, quiet: Boolean, keywords: Set[String]) {
+  lazy val keywordsLo = keywords.map(_.toLowerCase).toSet
 
-    // check in a case insensitive fashion
-    def containsKey(word: String) : Boolean = {
-        keywordsLo contains word.toLowerCase
-    }
+  // check in a case insensitive fashion
+  def containsKey(word: String): Boolean = {
+    keywordsLo contains word.toLowerCase
+  }
 }
-
 
 // Packing of all compiler flags in an easy to digest
 // format
-case class CompilerOptions(archive: Boolean,
-                           compileMode: CompilerFlag.Value,
-                           defaults: Option[Path],
-                           extras: Option[Extras],
-                           fatalValidationWarnings: Boolean,
-                           force: Boolean,
-                           importDirs: List[Path],
-                           inputs: List[Path],
-                           leaveWorkflowsOpen: Boolean,
-                           locked: Boolean,
-                           projectWideReuse: Boolean,
-                           reorg: Boolean,
-                           streamAllFiles: Boolean,
-                           runtimeDebugLevel: Option[Int],
-                           verbose: Verbose)
-
+case class CompilerOptions(
+    archive: Boolean,
+    compileMode: CompilerFlag.Value,
+    defaults: Option[Path],
+    extras: Option[Extras],
+    fatalValidationWarnings: Boolean,
+    force: Boolean,
+    importDirs: List[Path],
+    inputs: List[Path],
+    leaveWorkflowsOpen: Boolean,
+    locked: Boolean,
+    projectWideReuse: Boolean,
+    reorg: Boolean,
+    streamAllFiles: Boolean,
+    runtimeDebugLevel: Option[Int],
+    verbose: Verbose
+)
 
 // Different ways of using the mini-workflow runner.
 //   Launch:     there are WDL calls, lanuch the dx:executables.
 //   Collect:    the dx:exucutables are done, collect the results.
 object RunnerWfFragmentMode extends Enumeration {
-    val Launch, Collect = Value
+  val Launch, Collect = Value
 }
 
 object Language extends Enumeration {
-    val WDLvDraft2, WDLv1_0, WDLv2_0, CWLv1_0 = Value
+  val WDLvDraft2, WDLv1_0, WDLv2_0, CWLv1_0 = Value
 }

--- a/src/main/scala/dxWDL/compiler/DxNI.scala
+++ b/src/main/scala/dxWDL/compiler/DxNI.scala
@@ -53,320 +53,343 @@ import wom.types._
 import dxWDL.base._
 import dxWDL.dx._
 
-case class DxNI(verbose: Verbose,
-                language: Language.Value) {
+case class DxNI(verbose: Verbose, language: Language.Value) {
 
-    private def wdlTypeOfIOClass(appletName:String,
-                                 argName: String,
-                                 ioClass: DxIOClass.Value,
-                                 isOptional: Boolean) : WomType = {
-        if (isOptional) {
-            ioClass match {
-            case DxIOClass.BOOLEAN => WomOptionalType(WomBooleanType)
-            case DxIOClass.INT => WomOptionalType(WomIntegerType)
-            case DxIOClass.FLOAT => WomOptionalType(WomFloatType)
-            case DxIOClass.STRING => WomOptionalType(WomStringType)
-            case DxIOClass.FILE => WomOptionalType(WomSingleFileType)
-            case DxIOClass.ARRAY_OF_BOOLEANS => WomMaybeEmptyArrayType(WomBooleanType)
-            case DxIOClass.ARRAY_OF_INTS => WomMaybeEmptyArrayType(WomIntegerType)
-            case DxIOClass.ARRAY_OF_FLOATS => WomMaybeEmptyArrayType(WomFloatType)
-            case DxIOClass.ARRAY_OF_STRINGS => WomMaybeEmptyArrayType(WomStringType)
-            case DxIOClass.ARRAY_OF_FILES => WomMaybeEmptyArrayType(WomSingleFileType)
-            case _ => throw new Exception(
-                s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+  private def wdlTypeOfIOClass(
+      appletName: String,
+      argName: String,
+      ioClass: DxIOClass.Value,
+      isOptional: Boolean
+  ): WomType = {
+    if (isOptional) {
+      ioClass match {
+        case DxIOClass.BOOLEAN           => WomOptionalType(WomBooleanType)
+        case DxIOClass.INT               => WomOptionalType(WomIntegerType)
+        case DxIOClass.FLOAT             => WomOptionalType(WomFloatType)
+        case DxIOClass.STRING            => WomOptionalType(WomStringType)
+        case DxIOClass.FILE              => WomOptionalType(WomSingleFileType)
+        case DxIOClass.ARRAY_OF_BOOLEANS => WomMaybeEmptyArrayType(WomBooleanType)
+        case DxIOClass.ARRAY_OF_INTS     => WomMaybeEmptyArrayType(WomIntegerType)
+        case DxIOClass.ARRAY_OF_FLOATS   => WomMaybeEmptyArrayType(WomFloatType)
+        case DxIOClass.ARRAY_OF_STRINGS  => WomMaybeEmptyArrayType(WomStringType)
+        case DxIOClass.ARRAY_OF_FILES    => WomMaybeEmptyArrayType(WomSingleFileType)
+        case _ =>
+          throw new Exception(s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
                     |has IO class ${ioClass}""".stripMargin.replaceAll("\n", " "))
-            }
-        } else {
-            ioClass match {
-                case DxIOClass.BOOLEAN => WomBooleanType
-                case DxIOClass.INT => WomIntegerType
-                case DxIOClass.FLOAT => WomFloatType
-                case DxIOClass.STRING => WomStringType
-                case DxIOClass.FILE => WomSingleFileType
-                case DxIOClass.ARRAY_OF_BOOLEANS => WomNonEmptyArrayType(WomBooleanType)
-                case DxIOClass.ARRAY_OF_INTS => WomNonEmptyArrayType(WomIntegerType)
-                case DxIOClass.ARRAY_OF_FLOATS => WomNonEmptyArrayType(WomFloatType)
-                case DxIOClass.ARRAY_OF_STRINGS => WomNonEmptyArrayType(WomStringType)
-                case DxIOClass.ARRAY_OF_FILES => WomNonEmptyArrayType(WomSingleFileType)
-                case _ => throw new Exception(
-                    s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+      }
+    } else {
+      ioClass match {
+        case DxIOClass.BOOLEAN           => WomBooleanType
+        case DxIOClass.INT               => WomIntegerType
+        case DxIOClass.FLOAT             => WomFloatType
+        case DxIOClass.STRING            => WomStringType
+        case DxIOClass.FILE              => WomSingleFileType
+        case DxIOClass.ARRAY_OF_BOOLEANS => WomNonEmptyArrayType(WomBooleanType)
+        case DxIOClass.ARRAY_OF_INTS     => WomNonEmptyArrayType(WomIntegerType)
+        case DxIOClass.ARRAY_OF_FLOATS   => WomNonEmptyArrayType(WomFloatType)
+        case DxIOClass.ARRAY_OF_STRINGS  => WomNonEmptyArrayType(WomStringType)
+        case DxIOClass.ARRAY_OF_FILES    => WomNonEmptyArrayType(WomSingleFileType)
+        case _ =>
+          throw new Exception(s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
                         |has IO class ${ioClass}""".stripMargin.replaceAll("\n", " "))
+      }
+    }
+  }
+
+  // Convert an applet to a WDL task with an empty body
+  //
+  // We can translate with primitive types, and their arrays. Hashes cannot
+  // be translated; applets that have them cannot be converted.
+  private def wdlTypesOfDxApplet(
+      aplName: String,
+      desc: DxAppletDescribe
+  ): (Map[String, WomType], Map[String, WomType]) = {
+    Utils.trace(verbose.on, s"analyzing applet ${aplName}")
+    val inputSpec: Map[String, WomType] =
+      desc.inputSpec.get.map { iSpec =>
+        iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+      }.toMap
+    val outputSpec: Map[String, WomType] =
+      desc.outputSpec.get.map { iSpec =>
+        iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+      }.toMap
+    (inputSpec, outputSpec)
+  }
+
+  // Search a platform path for all applets in it. Use
+  // one API call for efficiency. Return a list of tasks, and their
+  // applet-ids.
+  //
+  // If the folder is not a valid path, an empty list will be returned.
+  private def search(dxProject: DxProject, folder: String, recursive: Boolean): Vector[String] = {
+    val dxObjectsInFolder: Map[DxDataObject, DxObjectDescribe] =
+      DxFindDataObjects(None, verbose).apply(
+        dxProject,
+        Some(folder),
+        recursive,
+        None,
+        Vector.empty,
+        Vector.empty,
+        true
+      )
+
+    // we just want the applets
+    val dxAppletsInFolder: Map[DxApplet, DxAppletDescribe] = dxObjectsInFolder.collect {
+      case (dxobj, desc) if dxobj.isInstanceOf[DxApplet] =>
+        (dxobj.asInstanceOf[DxApplet], desc.asInstanceOf[DxAppletDescribe])
+    }
+
+    // Filter out applets that are WDL tasks
+    val nativeApplets: Map[DxApplet, DxAppletDescribe] = dxAppletsInFolder.flatMap {
+      case (apl, desc) =>
+        desc.properties match {
+          case None => None
+          case Some(props) =>
+            props.get(Utils.CHECKSUM_PROP) match {
+              case Some(_) => None
+              case None    => Some(apl -> desc)
             }
         }
-    }
+    }.toMap
 
-    // Convert an applet to a WDL task with an empty body
-    //
-    // We can translate with primitive types, and their arrays. Hashes cannot
-    // be translated; applets that have them cannot be converted.
-    private def wdlTypesOfDxApplet(aplName: String,
-                                   desc: DxAppletDescribe) :
-            (Map[String, WomType], Map[String, WomType]) = {
-        Utils.trace(verbose.on, s"analyzing applet ${aplName}")
-        val inputSpec:Map[String, WomType] =
-            desc.inputSpec.get.map{ iSpec =>
-                iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name,
-                                               iSpec.ioClass, iSpec.optional)
-            }.toMap
-        val outputSpec:Map[String, WomType] =
-            desc.outputSpec.get.map{ iSpec =>
-                iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name,
-                                               iSpec.ioClass, iSpec.optional)
-            }.toMap
-        (inputSpec, outputSpec)
-    }
-
-    // Search a platform path for all applets in it. Use
-    // one API call for efficiency. Return a list of tasks, and their
-    // applet-ids.
-    //
-    // If the folder is not a valid path, an empty list will be returned.
-    private def search(dxProject: DxProject,
-                       folder: String,
-                       recursive: Boolean) : Vector[String] = {
-        val dxObjectsInFolder : Map[DxDataObject, DxObjectDescribe] =
-            DxFindDataObjects(None, verbose).apply(dxProject, Some(folder), recursive, None,
-                                                   Vector.empty, Vector.empty, true)
-
-        // we just want the applets
-        val dxAppletsInFolder : Map[DxApplet, DxAppletDescribe]= dxObjectsInFolder.collect{
-            case (dxobj, desc) if dxobj.isInstanceOf[DxApplet] =>
-                (dxobj.asInstanceOf[DxApplet], desc.asInstanceOf[DxAppletDescribe])
-        }
-
-        // Filter out applets that are WDL tasks
-        val nativeApplets: Map[DxApplet, DxAppletDescribe] = dxAppletsInFolder.flatMap{
-            case (apl, desc) =>
-                desc.properties match {
-                    case None => None
-                    case Some(props) =>
-                        props.get(Utils.CHECKSUM_PROP) match {
-                            case Some(_) => None
-                            case None => Some(apl -> desc)
-                        }
-                }
-        }.toMap
-
-        nativeApplets.map{ case (apl, desc) =>
-            val aplName = desc.name
-            try {
-                val (inputSpec, outputSpec) = wdlTypesOfDxApplet(aplName, desc)
-                // DNAx applets allow the same variable name to be used for inputs and outputs.
-                // This is illegal in WDL.
-                val allInputNames = inputSpec.keys.toSet
-                val allOutputNames = outputSpec.keys.toSet
-                val both = allInputNames.intersect(allOutputNames)
-                if (!both.isEmpty) {
-                    val bothStr = "[" + both.mkString(", ") + "]"
-                    throw new Exception(s"""Parameters ${bothStr} used as both input and output in applet ${aplName}""")
-                }
-                val WdlCodeSnippet(taskCode) =
-                    WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
-                        apl.getId, aplName,
-                        inputSpec, outputSpec)
-                Some(taskCode)
-            } catch {
-                case e : Throwable =>
-                    Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${aplName}")
-                    Utils.warning(verbose, e.getMessage)
-                    None
+    nativeApplets
+      .map {
+        case (apl, desc) =>
+          val aplName = desc.name
+          try {
+            val (inputSpec, outputSpec) = wdlTypesOfDxApplet(aplName, desc)
+            // DNAx applets allow the same variable name to be used for inputs and outputs.
+            // This is illegal in WDL.
+            val allInputNames  = inputSpec.keys.toSet
+            val allOutputNames = outputSpec.keys.toSet
+            val both           = allInputNames.intersect(allOutputNames)
+            if (!both.isEmpty) {
+              val bothStr = "[" + both.mkString(", ") + "]"
+              throw new Exception(
+                s"""Parameters ${bothStr} used as both input and output in applet ${aplName}"""
+              )
             }
-        }.flatten.toVector
-    }
+            val WdlCodeSnippet(taskCode) =
+              WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
+                apl.getId,
+                aplName,
+                inputSpec,
+                outputSpec
+              )
+            Some(taskCode)
+          } catch {
+            case e: Throwable =>
+              Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${aplName}")
+              Utils.warning(verbose, e.getMessage)
+              None
+          }
+      }
+      .flatten
+      .toVector
+  }
 
-    private def checkedGetJsString(jsv: JsValue,
-                                   fieldName: String) : String = {
-        val fields = jsv.asJsObject.fields
-        fields.get(fieldName) match {
-            case Some(JsString(x)) => x
-            case other => throw new Exception(s"malformed field ${fieldName} (${other})")
+  private def checkedGetJsString(jsv: JsValue, fieldName: String): String = {
+    val fields = jsv.asJsObject.fields
+    fields.get(fieldName) match {
+      case Some(JsString(x)) => x
+      case other             => throw new Exception(s"malformed field ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedGetJsObject(jsv: JsValue, fieldName: String): JsObject = {
+    val fields = jsv.asJsObject.fields
+    fields.get(fieldName) match {
+      case Some(JsObject(x)) => JsObject(x)
+      case other             => throw new Exception(s"malformed field ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedGetJsArray(jsv: JsValue, fieldName: String): Vector[JsValue] = {
+    val fields = jsv.asJsObject.fields
+    fields.get(fieldName) match {
+      case Some(JsArray(x)) => x.toVector
+      case other            => throw new Exception(s"malformed field ${fieldName} (${other})")
+    }
+  }
+
+  private def checkedGetIoSpec(appName: String, jsv: JsValue): IOParameter = {
+    val ioParam = DxObject.parseIoParam(jsv)
+    if (ioParam.ioClass == DxIOClass.HASH)
+      throw new Exception(
+        s"""|app ${appName} has field ${ioParam.name}
+                                    |with non WDL-native io class HASH""".stripMargin
+          .replaceAll("\n", " ")
+      )
+    ioParam
+  }
+
+  // App names can have characters that are illegal in WDL.
+  // 1) Leave only number, letters, and underscores
+  // 2) If the name starts with a number, add the prefix "app_"
+  private val taskNameRegex: Regex = raw"""[a-zA-Z][a-zA-Z0-9_.]*""".r
+  private def normalizeAppName(name: String): String = {
+    def sanitizeChar(ch: Char): String = ch match {
+      case '_'                       => "_"
+      case _ if (ch.isLetterOrDigit) => ch.toString
+      case _                         => "_"
+    }
+    name match {
+      case taskNameRegex(_*) =>
+        // legal in WDL
+        name
+      case _ =>
+        // remove all illegal characeters
+        val nameClean = name.flatMap(sanitizeChar)
+
+        // add a prefix if needed
+        val prefix = nameClean(0) match {
+          case x if x.isLetter => ""
+          case '_'             => "app"
+          case _               => "app_"
         }
+        if (!prefix.isEmpty)
+          Utils.warning(
+            verbose,
+            s"""|app ${nameClean} does not start
+                                               |with a letter, adding the prefix '${prefix}'""".stripMargin
+              .replaceAll("\n", " ")
+          )
+        s"${prefix}${nameClean}"
     }
+  }
 
-    private def checkedGetJsObject(jsv: JsValue,
-                                   fieldName: String) : JsObject = {
-        val fields = jsv.asJsObject.fields
-        fields.get(fieldName) match {
-            case Some(JsObject(x)) => JsObject(x)
-            case other => throw new Exception(s"malformed field ${fieldName} (${other})")
-        }
+  private def checkedGetApp(jsv: JsValue): DxAppDescribe = {
+    val id: String     = checkedGetJsString(jsv, "id")
+    val desc: JsObject = checkedGetJsObject(jsv, "describe")
+    val name: String   = checkedGetJsString(desc, "name")
+    val inputSpecJs    = checkedGetJsArray(desc, "inputSpec")
+    val outputSpecJs   = checkedGetJsArray(desc, "outputSpec")
+
+    val inputSpec = inputSpecJs.map { x =>
+      checkedGetIoSpec(name, x)
+    }.toVector
+    val outputSpec = outputSpecJs.map { x =>
+      checkedGetIoSpec(name, x)
+    }.toVector
+    val normName = normalizeAppName(name)
+    DxAppDescribe(id, normName, 0, 0, None, None, Some(inputSpec), Some(outputSpec))
+  }
+
+  private def appToWdlInterface(dxApp: DxAppDescribe): String = {
+    val inputSpec: Map[String, WomType] =
+      dxApp.inputSpec.get.map { ioSpec =>
+        ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional)
+      }.toMap
+    val outputSpec: Map[String, WomType] =
+      dxApp.outputSpec.get.map { ioSpec =>
+        ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional)
+      }.toMap
+
+    // DNAx applets allow the same variable name to be used for inputs and outputs.
+    // This is illegal in WDL.
+    val allInputNames  = inputSpec.keys.toSet
+    val allOutputNames = outputSpec.keys.toSet
+    val both           = allInputNames.intersect(allOutputNames)
+    if (!both.isEmpty) {
+      val bothStr = "[" + both.mkString(", ") + "]"
+      throw new Exception(
+        s"""|Parameters ${bothStr} used as both input and
+                                    |output in applet ${dxApp.name}""".stripMargin
+          .replaceAll("\n", " ")
+      )
     }
+    val WdlCodeSnippet(taskCode) =
+      WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
+        dxApp.id,
+        dxApp.name,
+        inputSpec,
+        outputSpec
+      )
+    taskCode
+  }
 
-    private def checkedGetJsArray(jsv: JsValue,
-                                  fieldName: String) : Vector[JsValue] = {
-        val fields = jsv.asJsObject.fields
-        fields.get(fieldName) match {
-            case Some(JsArray(x)) => x.toVector
-            case other => throw new Exception(s"malformed field ${fieldName} (${other})")
-        }
-    }
-
-    private def checkedGetIoSpec(appName: String,
-                                 jsv: JsValue) : IOParameter = {
-        val ioParam = DxObject.parseIoParam(jsv)
-        if (ioParam.ioClass == DxIOClass.HASH)
-            throw new Exception(s"""|app ${appName} has field ${ioParam.name}
-                                    |with non WDL-native io class HASH"""
-                                    .stripMargin.replaceAll("\n", " "))
-        ioParam
-    }
-
-    // App names can have characters that are illegal in WDL.
-    // 1) Leave only number, letters, and underscores
-    // 2) If the name starts with a number, add the prefix "app_"
-    private val taskNameRegex:Regex = raw"""[a-zA-Z][a-zA-Z0-9_.]*""".r
-    private def normalizeAppName(name: String) : String = {
-        def sanitizeChar(ch: Char) : String = ch match {
-            case '_' => "_"
-            case _ if (ch.isLetterOrDigit) => ch.toString
-            case _ => "_"
-        }
-        name match {
-            case taskNameRegex(_*) =>
-                // legal in WDL
-                name
-            case _ =>
-                // remove all illegal characeters
-                val nameClean = name.flatMap(sanitizeChar)
-
-                // add a prefix if needed
-                val prefix = nameClean(0) match {
-                    case x if x.isLetter => ""
-                    case '_' => "app"
-                    case _ => "app_"
-                }
-                if (!prefix.isEmpty)
-                    Utils.warning(verbose, s"""|app ${nameClean} does not start
-                                               |with a letter, adding the prefix '${prefix}'"""
-                                      .stripMargin.replaceAll("\n", " "))
-                s"${prefix}${nameClean}"
-        }
-    }
-
-    private def checkedGetApp(jsv: JsValue) : DxAppDescribe = {
-        val id: String = checkedGetJsString(jsv, "id")
-        val desc: JsObject = checkedGetJsObject(jsv, "describe")
-        val name: String = checkedGetJsString(desc, "name")
-        val inputSpecJs = checkedGetJsArray(desc, "inputSpec")
-        val outputSpecJs = checkedGetJsArray(desc, "outputSpec")
-
-        val inputSpec = inputSpecJs.map{ x =>
-            checkedGetIoSpec(name, x)
-        }.toVector
-        val outputSpec = outputSpecJs.map{ x =>
-            checkedGetIoSpec(name, x)
-        }.toVector
-        val normName = normalizeAppName(name)
-        DxAppDescribe(id, normName, 0, 0, None, None, Some(inputSpec), Some(outputSpec))
-    }
-
-    private def appToWdlInterface(dxApp: DxAppDescribe) : String = {
-        val inputSpec:Map[String, WomType] =
-            dxApp.inputSpec.get.map{ ioSpec =>
-                ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name,
-                                                ioSpec.ioClass, ioSpec.optional)
-            }.toMap
-        val outputSpec:Map[String, WomType] =
-            dxApp.outputSpec.get.map{ ioSpec =>
-                ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name,
-                                                ioSpec.ioClass, ioSpec.optional)
-            }.toMap
-
-        // DNAx applets allow the same variable name to be used for inputs and outputs.
-        // This is illegal in WDL.
-        val allInputNames = inputSpec.keys.toSet
-        val allOutputNames = outputSpec.keys.toSet
-        val both = allInputNames.intersect(allOutputNames)
-        if (!both.isEmpty) {
-            val bothStr = "[" + both.mkString(", ") + "]"
-            throw new Exception(s"""|Parameters ${bothStr} used as both input and
-                                    |output in applet ${dxApp.name}""".stripMargin.replaceAll("\n", " "))
-        }
-        val WdlCodeSnippet(taskCode) =
-            WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
-                dxApp.id, dxApp.name,
-                inputSpec, outputSpec)
-        taskCode
-    }
-
-    // Search for global apps
-    def searchApps: Vector[String] = {
-        val req = JsObject("published" -> JsBoolean(true),
-                           "describe" -> JsObject("inputSpec" -> JsBoolean(true),
-                                                  "outputSpec" -> JsBoolean(true)),
-                           "limit" -> JsNumber(1000))
-        val rep = DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req),
-                                       classOf[JsonNode])
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(rep)
-        val appsJs = repJs.asJsObject.fields.get("results") match {
-            case Some(JsArray(apps)) => apps
-            case _ => throw new Exception(s"""|malformed reply to findApps
+  // Search for global apps
+  def searchApps: Vector[String] = {
+    val req = JsObject(
+      "published" -> JsBoolean(true),
+      "describe"  -> JsObject("inputSpec" -> JsBoolean(true), "outputSpec" -> JsBoolean(true)),
+      "limit"     -> JsNumber(1000)
+    )
+    val rep            = DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
+    val appsJs = repJs.asJsObject.fields.get("results") match {
+      case Some(JsArray(apps)) => apps
+      case _                   => throw new Exception(s"""|malformed reply to findApps
                                               |
                                               |${repJs}""".stripMargin)
-        }
-        if (appsJs.length == 1000)
-            throw new Exception("There are probably more than 1000 accessible apps")
-
-        val taskHeaders = appsJs.flatMap{ jsv =>
-            val desc: JsObject = checkedGetJsObject(jsv, "describe")
-            val appName = checkedGetJsString(desc, "name")
-            try {
-                val dxApp = checkedGetApp(jsv)
-                Some(appToWdlInterface(dxApp))
-            } catch {
-                case e : Throwable =>
-                    Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${appName}")
-                    Utils.warning(verbose, e.getMessage)
-                    None
-            }
-        }
-        taskHeaders.toVector
     }
+    if (appsJs.length == 1000)
+      throw new Exception("There are probably more than 1000 accessible apps")
+
+    val taskHeaders = appsJs.flatMap { jsv =>
+      val desc: JsObject = checkedGetJsObject(jsv, "describe")
+      val appName        = checkedGetJsString(desc, "name")
+      try {
+        val dxApp = checkedGetApp(jsv)
+        Some(appToWdlInterface(dxApp))
+      } catch {
+        case e: Throwable =>
+          Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${appName}")
+          Utils.warning(verbose, e.getMessage)
+          None
+      }
+    }
+    taskHeaders.toVector
+  }
 }
 
-
 object DxNI {
-    private def writeHeadersToFile(header: String,
-                                   tasks : Vector[String],
-                                   outputPath: Path,
-                                   force: Boolean) : Unit = {
-        if (Files.exists(outputPath)) {
-            if (!force) {
-                throw new Exception(s"""|Output file ${outputPath.toString} already exists,
-                                        |use -force to overwrite it"""
-                                        .stripMargin.replaceAll("\n", " "))
-            }
-            outputPath.toFile().delete
-        }
-
-        // pretty print into a buffer
-        val lines = tasks.mkString("\n\n")
-        val allLines = header + "\n" + lines
-        Utils.writeFileContent(outputPath, allLines)
+  private def writeHeadersToFile(
+      header: String,
+      tasks: Vector[String],
+      outputPath: Path,
+      force: Boolean
+  ): Unit = {
+    if (Files.exists(outputPath)) {
+      if (!force) {
+        throw new Exception(
+          s"""|Output file ${outputPath.toString} already exists,
+                                        |use -force to overwrite it""".stripMargin
+            .replaceAll("\n", " ")
+        )
+      }
+      outputPath.toFile().delete
     }
 
+    // pretty print into a buffer
+    val lines    = tasks.mkString("\n\n")
+    val allLines = header + "\n" + lines
+    Utils.writeFileContent(outputPath, allLines)
+  }
 
-    // create headers for calling dx:applets and dx:workflows
-    // We assume the folder is valid.
-    def apply(dxProject: DxProject,
-              folder: String,
-              output: Path,
-              recursive: Boolean,
-              force: Boolean,
-              language: Language.Value,
-              verbose: Verbose) : Unit = {
-        val dxni = new DxNI(verbose, language)
-        val dxNativeTasks: Vector[String] = dxni.search(dxProject, folder, recursive)
-        if (dxNativeTasks.isEmpty) {
-            Utils.warning(verbose, s"Found no DX native applets in ${folder}")
-            return
-        }
-        val projName = dxProject.describe().name
+  // create headers for calling dx:applets and dx:workflows
+  // We assume the folder is valid.
+  def apply(
+      dxProject: DxProject,
+      folder: String,
+      output: Path,
+      recursive: Boolean,
+      force: Boolean,
+      language: Language.Value,
+      verbose: Verbose
+  ): Unit = {
+    val dxni                          = new DxNI(verbose, language)
+    val dxNativeTasks: Vector[String] = dxni.search(dxProject, folder, recursive)
+    if (dxNativeTasks.isEmpty) {
+      Utils.warning(verbose, s"Found no DX native applets in ${folder}")
+      return
+    }
+    val projName = dxProject.describe().name
 
-        // add comment describing how the file was created
-        val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
-        val header =
-            s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
+    // add comment describing how the file was created
+    val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
+    val header =
+      s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
                 |# project name = ${projName}
                 |# project ID = ${dxProject.getId}
                 |# folder = ${folder}
@@ -374,34 +397,31 @@ object DxNI {
                 |${languageHeader}
                 |""".stripMargin
 
-        writeHeadersToFile(header, dxNativeTasks, output, force)
+    writeHeadersToFile(header, dxNativeTasks, output, force)
+  }
+
+  def applyApps(output: Path, force: Boolean, language: Language.Value, verbose: Verbose): Unit = {
+    val dxni                          = new DxNI(verbose, language)
+    val dxAppsAsTasks: Vector[String] = dxni.searchApps
+    if (dxAppsAsTasks.isEmpty) {
+      Utils.warning(verbose, s"Found no DX global apps")
+      return
     }
 
-    def applyApps(output: Path,
-                  force: Boolean,
-                  language: Language.Value,
-                  verbose: Verbose) : Unit = {
-        val dxni = new DxNI(verbose, language)
-        val dxAppsAsTasks: Vector[String] = dxni.searchApps
-        if (dxAppsAsTasks.isEmpty) {
-            Utils.warning(verbose, s"Found no DX global apps")
-            return
-        }
+    // If there are many apps, we might end up with multiple definitions of
+    // the same task. This gets rid of duplicates.
+    val uniqueTasks = dxAppsAsTasks.toSet.toVector
 
-        // If there are many apps, we might end up with multiple definitions of
-        // the same task. This gets rid of duplicates.
-        val uniqueTasks = dxAppsAsTasks.toSet.toVector
-
-        // add comment describing how the file was created
-        val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
-        val header =
-            s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
+    // add comment describing how the file was created
+    val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
+    val header =
+      s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
                 |# These are interfaces to apps.
                 |#
                 |${languageHeader}
                 |""".stripMargin
 
-        writeHeadersToFile(header, uniqueTasks, output, force)
-    }
+    writeHeadersToFile(header, uniqueTasks, output, force)
+  }
 
 }

--- a/src/main/scala/dxWDL/compiler/DxNI.scala
+++ b/src/main/scala/dxWDL/compiler/DxNI.scala
@@ -63,19 +63,24 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   ): WomType = {
     if (isOptional) {
       ioClass match {
-        case DxIOClass.BOOLEAN           => WomOptionalType(WomBooleanType)
-        case DxIOClass.INT               => WomOptionalType(WomIntegerType)
-        case DxIOClass.FLOAT             => WomOptionalType(WomFloatType)
-        case DxIOClass.STRING            => WomOptionalType(WomStringType)
-        case DxIOClass.FILE              => WomOptionalType(WomSingleFileType)
-        case DxIOClass.ARRAY_OF_BOOLEANS => WomMaybeEmptyArrayType(WomBooleanType)
-        case DxIOClass.ARRAY_OF_INTS     => WomMaybeEmptyArrayType(WomIntegerType)
-        case DxIOClass.ARRAY_OF_FLOATS   => WomMaybeEmptyArrayType(WomFloatType)
-        case DxIOClass.ARRAY_OF_STRINGS  => WomMaybeEmptyArrayType(WomStringType)
-        case DxIOClass.ARRAY_OF_FILES    => WomMaybeEmptyArrayType(WomSingleFileType)
+        case DxIOClass.BOOLEAN => WomOptionalType(WomBooleanType)
+        case DxIOClass.INT     => WomOptionalType(WomIntegerType)
+        case DxIOClass.FLOAT   => WomOptionalType(WomFloatType)
+        case DxIOClass.STRING  => WomOptionalType(WomStringType)
+        case DxIOClass.FILE    => WomOptionalType(WomSingleFileType)
+        case DxIOClass.ARRAY_OF_BOOLEANS =>
+          WomMaybeEmptyArrayType(WomBooleanType)
+        case DxIOClass.ARRAY_OF_INTS    => WomMaybeEmptyArrayType(WomIntegerType)
+        case DxIOClass.ARRAY_OF_FLOATS  => WomMaybeEmptyArrayType(WomFloatType)
+        case DxIOClass.ARRAY_OF_STRINGS => WomMaybeEmptyArrayType(WomStringType)
+        case DxIOClass.ARRAY_OF_FILES =>
+          WomMaybeEmptyArrayType(WomSingleFileType)
         case _ =>
-          throw new Exception(s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
-                    |has IO class ${ioClass}""".stripMargin.replaceAll("\n", " "))
+          throw new Exception(
+            s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+                    |has IO class ${ioClass}""".stripMargin
+              .replaceAll("\n", " ")
+          )
       }
     } else {
       ioClass match {
@@ -90,8 +95,11 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
         case DxIOClass.ARRAY_OF_STRINGS  => WomNonEmptyArrayType(WomStringType)
         case DxIOClass.ARRAY_OF_FILES    => WomNonEmptyArrayType(WomSingleFileType)
         case _ =>
-          throw new Exception(s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
-                        |has IO class ${ioClass}""".stripMargin.replaceAll("\n", " "))
+          throw new Exception(
+            s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+                        |has IO class ${ioClass}""".stripMargin
+              .replaceAll("\n", " ")
+          )
       }
     }
   }
@@ -107,11 +115,21 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     Utils.trace(verbose.on, s"analyzing applet ${aplName}")
     val inputSpec: Map[String, WomType] =
       desc.inputSpec.get.map { iSpec =>
-        iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+        iSpec.name -> wdlTypeOfIOClass(
+          aplName,
+          iSpec.name,
+          iSpec.ioClass,
+          iSpec.optional
+        )
       }.toMap
     val outputSpec: Map[String, WomType] =
       desc.outputSpec.get.map { iSpec =>
-        iSpec.name -> wdlTypeOfIOClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+        iSpec.name -> wdlTypeOfIOClass(
+          aplName,
+          iSpec.name,
+          iSpec.ioClass,
+          iSpec.optional
+        )
       }.toMap
     (inputSpec, outputSpec)
   }
@@ -121,7 +139,11 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   // applet-ids.
   //
   // If the folder is not a valid path, an empty list will be returned.
-  private def search(dxProject: DxProject, folder: String, recursive: Boolean): Vector[String] = {
+  private def search(
+      dxProject: DxProject,
+      folder: String,
+      recursive: Boolean
+  ): Vector[String] = {
     val dxObjectsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose).apply(
         dxProject,
@@ -134,23 +156,25 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
       )
 
     // we just want the applets
-    val dxAppletsInFolder: Map[DxApplet, DxAppletDescribe] = dxObjectsInFolder.collect {
-      case (dxobj, desc) if dxobj.isInstanceOf[DxApplet] =>
-        (dxobj.asInstanceOf[DxApplet], desc.asInstanceOf[DxAppletDescribe])
-    }
+    val dxAppletsInFolder: Map[DxApplet, DxAppletDescribe] =
+      dxObjectsInFolder.collect {
+        case (dxobj, desc) if dxobj.isInstanceOf[DxApplet] =>
+          (dxobj.asInstanceOf[DxApplet], desc.asInstanceOf[DxAppletDescribe])
+      }
 
     // Filter out applets that are WDL tasks
-    val nativeApplets: Map[DxApplet, DxAppletDescribe] = dxAppletsInFolder.flatMap {
-      case (apl, desc) =>
-        desc.properties match {
-          case None => None
-          case Some(props) =>
-            props.get(Utils.CHECKSUM_PROP) match {
-              case Some(_) => None
-              case None    => Some(apl -> desc)
-            }
-        }
-    }.toMap
+    val nativeApplets: Map[DxApplet, DxAppletDescribe] =
+      dxAppletsInFolder.flatMap {
+        case (apl, desc) =>
+          desc.properties match {
+            case None => None
+            case Some(props) =>
+              props.get(Utils.CHECKSUM_PROP) match {
+                case Some(_) => None
+                case None    => Some(apl -> desc)
+              }
+          }
+      }.toMap
 
     nativeApplets
       .map {
@@ -179,7 +203,10 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
             Some(taskCode)
           } catch {
             case e: Throwable =>
-              Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${aplName}")
+              Utils.warning(
+                verbose,
+                s"Unable to construct a WDL interface for applet ${aplName}"
+              )
               Utils.warning(verbose, e.getMessage)
               None
           }
@@ -192,7 +219,8 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     val fields = jsv.asJsObject.fields
     fields.get(fieldName) match {
       case Some(JsString(x)) => x
-      case other             => throw new Exception(s"malformed field ${fieldName} (${other})")
+      case other =>
+        throw new Exception(s"malformed field ${fieldName} (${other})")
     }
   }
 
@@ -200,15 +228,20 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     val fields = jsv.asJsObject.fields
     fields.get(fieldName) match {
       case Some(JsObject(x)) => JsObject(x)
-      case other             => throw new Exception(s"malformed field ${fieldName} (${other})")
+      case other =>
+        throw new Exception(s"malformed field ${fieldName} (${other})")
     }
   }
 
-  private def checkedGetJsArray(jsv: JsValue, fieldName: String): Vector[JsValue] = {
+  private def checkedGetJsArray(
+      jsv: JsValue,
+      fieldName: String
+  ): Vector[JsValue] = {
     val fields = jsv.asJsObject.fields
     fields.get(fieldName) match {
       case Some(JsArray(x)) => x.toVector
-      case other            => throw new Exception(s"malformed field ${fieldName} (${other})")
+      case other =>
+        throw new Exception(s"malformed field ${fieldName} (${other})")
     }
   }
 
@@ -272,17 +305,36 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
       checkedGetIoSpec(name, x)
     }.toVector
     val normName = normalizeAppName(name)
-    DxAppDescribe(id, normName, 0, 0, None, None, Some(inputSpec), Some(outputSpec))
+    DxAppDescribe(
+      id,
+      normName,
+      0,
+      0,
+      None,
+      None,
+      Some(inputSpec),
+      Some(outputSpec)
+    )
   }
 
   private def appToWdlInterface(dxApp: DxAppDescribe): String = {
     val inputSpec: Map[String, WomType] =
       dxApp.inputSpec.get.map { ioSpec =>
-        ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional)
+        ioSpec.name -> wdlTypeOfIOClass(
+          dxApp.name,
+          ioSpec.name,
+          ioSpec.ioClass,
+          ioSpec.optional
+        )
       }.toMap
     val outputSpec: Map[String, WomType] =
       dxApp.outputSpec.get.map { ioSpec =>
-        ioSpec.name -> wdlTypeOfIOClass(dxApp.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional)
+        ioSpec.name -> wdlTypeOfIOClass(
+          dxApp.name,
+          ioSpec.name,
+          ioSpec.ioClass,
+          ioSpec.optional
+        )
       }.toMap
 
     // DNAx applets allow the same variable name to be used for inputs and outputs.
@@ -312,10 +364,14 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   def searchApps: Vector[String] = {
     val req = JsObject(
       "published" -> JsBoolean(true),
-      "describe" -> JsObject("inputSpec" -> JsBoolean(true), "outputSpec" -> JsBoolean(true)),
+      "describe" -> JsObject(
+        "inputSpec" -> JsBoolean(true),
+        "outputSpec" -> JsBoolean(true)
+      ),
       "limit" -> JsNumber(1000)
     )
-    val rep = DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+    val rep =
+      DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
     val appsJs = repJs.asJsObject.fields.get("results") match {
       case Some(JsArray(apps)) => apps
@@ -334,7 +390,10 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
         Some(appToWdlInterface(dxApp))
       } catch {
         case e: Throwable =>
-          Utils.warning(verbose, s"Unable to construct a WDL interface for applet ${appName}")
+          Utils.warning(
+            verbose,
+            s"Unable to construct a WDL interface for applet ${appName}"
+          )
           Utils.warning(verbose, e.getMessage)
           None
       }
@@ -379,7 +438,8 @@ object DxNI {
       verbose: Verbose
   ): Unit = {
     val dxni = new DxNI(verbose, language)
-    val dxNativeTasks: Vector[String] = dxni.search(dxProject, folder, recursive)
+    val dxNativeTasks: Vector[String] =
+      dxni.search(dxProject, folder, recursive)
     if (dxNativeTasks.isEmpty) {
       Utils.warning(verbose, s"Found no DX native applets in ${folder}")
       return
@@ -387,7 +447,8 @@ object DxNI {
     val projName = dxProject.describe().name
 
     // add comment describing how the file was created
-    val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
+    val languageHeader =
+      new WdlCodeGen(verbose, Map.empty, language).versionString()
     val header =
       s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
                 |# project name = ${projName}
@@ -400,7 +461,12 @@ object DxNI {
     writeHeadersToFile(header, dxNativeTasks, output, force)
   }
 
-  def applyApps(output: Path, force: Boolean, language: Language.Value, verbose: Verbose): Unit = {
+  def applyApps(
+      output: Path,
+      force: Boolean,
+      language: Language.Value,
+      verbose: Verbose
+  ): Unit = {
     val dxni = new DxNI(verbose, language)
     val dxAppsAsTasks: Vector[String] = dxni.searchApps
     if (dxAppsAsTasks.isEmpty) {
@@ -413,7 +479,8 @@ object DxNI {
     val uniqueTasks = dxAppsAsTasks.toSet.toVector
 
     // add comment describing how the file was created
-    val languageHeader = new WdlCodeGen(verbose, Map.empty, language).versionString()
+    val languageHeader =
+      new WdlCodeGen(verbose, Map.empty, language).versionString()
     val header =
       s"""|# This file was generated by the Dx Native Interface (DxNI) tool.
                 |# These are interfaces to apps.

--- a/src/main/scala/dxWDL/compiler/DxNI.scala
+++ b/src/main/scala/dxWDL/compiler/DxNI.scala
@@ -160,9 +160,9 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
             val (inputSpec, outputSpec) = wdlTypesOfDxApplet(aplName, desc)
             // DNAx applets allow the same variable name to be used for inputs and outputs.
             // This is illegal in WDL.
-            val allInputNames  = inputSpec.keys.toSet
+            val allInputNames = inputSpec.keys.toSet
             val allOutputNames = outputSpec.keys.toSet
-            val both           = allInputNames.intersect(allOutputNames)
+            val both = allInputNames.intersect(allOutputNames)
             if (!both.isEmpty) {
               val bothStr = "[" + both.mkString(", ") + "]"
               throw new Exception(
@@ -259,11 +259,11 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   }
 
   private def checkedGetApp(jsv: JsValue): DxAppDescribe = {
-    val id: String     = checkedGetJsString(jsv, "id")
+    val id: String = checkedGetJsString(jsv, "id")
     val desc: JsObject = checkedGetJsObject(jsv, "describe")
-    val name: String   = checkedGetJsString(desc, "name")
-    val inputSpecJs    = checkedGetJsArray(desc, "inputSpec")
-    val outputSpecJs   = checkedGetJsArray(desc, "outputSpec")
+    val name: String = checkedGetJsString(desc, "name")
+    val inputSpecJs = checkedGetJsArray(desc, "inputSpec")
+    val outputSpecJs = checkedGetJsArray(desc, "outputSpec")
 
     val inputSpec = inputSpecJs.map { x =>
       checkedGetIoSpec(name, x)
@@ -287,9 +287,9 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
 
     // DNAx applets allow the same variable name to be used for inputs and outputs.
     // This is illegal in WDL.
-    val allInputNames  = inputSpec.keys.toSet
+    val allInputNames = inputSpec.keys.toSet
     val allOutputNames = outputSpec.keys.toSet
-    val both           = allInputNames.intersect(allOutputNames)
+    val both = allInputNames.intersect(allOutputNames)
     if (!both.isEmpty) {
       val bothStr = "[" + both.mkString(", ") + "]"
       throw new Exception(
@@ -312,10 +312,10 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   def searchApps: Vector[String] = {
     val req = JsObject(
       "published" -> JsBoolean(true),
-      "describe"  -> JsObject("inputSpec" -> JsBoolean(true), "outputSpec" -> JsBoolean(true)),
-      "limit"     -> JsNumber(1000)
+      "describe" -> JsObject("inputSpec" -> JsBoolean(true), "outputSpec" -> JsBoolean(true)),
+      "limit" -> JsNumber(1000)
     )
-    val rep            = DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+    val rep = DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
     val appsJs = repJs.asJsObject.fields.get("results") match {
       case Some(JsArray(apps)) => apps
@@ -328,7 +328,7 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
 
     val taskHeaders = appsJs.flatMap { jsv =>
       val desc: JsObject = checkedGetJsObject(jsv, "describe")
-      val appName        = checkedGetJsString(desc, "name")
+      val appName = checkedGetJsString(desc, "name")
       try {
         val dxApp = checkedGetApp(jsv)
         Some(appToWdlInterface(dxApp))
@@ -362,7 +362,7 @@ object DxNI {
     }
 
     // pretty print into a buffer
-    val lines    = tasks.mkString("\n\n")
+    val lines = tasks.mkString("\n\n")
     val allLines = header + "\n" + lines
     Utils.writeFileContent(outputPath, allLines)
   }
@@ -378,7 +378,7 @@ object DxNI {
       language: Language.Value,
       verbose: Verbose
   ): Unit = {
-    val dxni                          = new DxNI(verbose, language)
+    val dxni = new DxNI(verbose, language)
     val dxNativeTasks: Vector[String] = dxni.search(dxProject, folder, recursive)
     if (dxNativeTasks.isEmpty) {
       Utils.warning(verbose, s"Found no DX native applets in ${folder}")
@@ -401,7 +401,7 @@ object DxNI {
   }
 
   def applyApps(output: Path, force: Boolean, language: Language.Value, verbose: Verbose): Unit = {
-    val dxni                          = new DxNI(verbose, language)
+    val dxni = new DxNI(verbose, language)
     val dxAppsAsTasks: Vector[String] = dxni.searchApps
     if (dxAppsAsTasks.isEmpty) {
       Utils.warning(verbose, s"Found no DX global apps")

--- a/src/main/scala/dxWDL/compiler/DxNI.scala
+++ b/src/main/scala/dxWDL/compiler/DxNI.scala
@@ -77,9 +77,9 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
           WomMaybeEmptyArrayType(WomSingleFileType)
         case _ =>
           throw new Exception(
-            s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+              s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
                     |has IO class ${ioClass}""".stripMargin
-              .replaceAll("\n", " ")
+                .replaceAll("\n", " ")
           )
       }
     } else {
@@ -96,9 +96,9 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
         case DxIOClass.ARRAY_OF_FILES    => WomNonEmptyArrayType(WomSingleFileType)
         case _ =>
           throw new Exception(
-            s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+              s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
                         |has IO class ${ioClass}""".stripMargin
-              .replaceAll("\n", " ")
+                .replaceAll("\n", " ")
           )
       }
     }
@@ -116,19 +116,19 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     val inputSpec: Map[String, WomType] =
       desc.inputSpec.get.map { iSpec =>
         iSpec.name -> wdlTypeOfIOClass(
-          aplName,
-          iSpec.name,
-          iSpec.ioClass,
-          iSpec.optional
+            aplName,
+            iSpec.name,
+            iSpec.ioClass,
+            iSpec.optional
         )
       }.toMap
     val outputSpec: Map[String, WomType] =
       desc.outputSpec.get.map { iSpec =>
         iSpec.name -> wdlTypeOfIOClass(
-          aplName,
-          iSpec.name,
-          iSpec.ioClass,
-          iSpec.optional
+            aplName,
+            iSpec.name,
+            iSpec.ioClass,
+            iSpec.optional
         )
       }.toMap
     (inputSpec, outputSpec)
@@ -146,13 +146,13 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   ): Vector[String] = {
     val dxObjectsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose).apply(
-        dxProject,
-        Some(folder),
-        recursive,
-        None,
-        Vector.empty,
-        Vector.empty,
-        true
+          dxProject,
+          Some(folder),
+          recursive,
+          None,
+          Vector.empty,
+          Vector.empty,
+          true
       )
 
     // we just want the applets
@@ -190,22 +190,22 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
             if (!both.isEmpty) {
               val bothStr = "[" + both.mkString(", ") + "]"
               throw new Exception(
-                s"""Parameters ${bothStr} used as both input and output in applet ${aplName}"""
+                  s"""Parameters ${bothStr} used as both input and output in applet ${aplName}"""
               )
             }
             val WdlCodeSnippet(taskCode) =
               WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
-                apl.getId,
-                aplName,
-                inputSpec,
-                outputSpec
+                  apl.getId,
+                  aplName,
+                  inputSpec,
+                  outputSpec
               )
             Some(taskCode)
           } catch {
             case e: Throwable =>
               Utils.warning(
-                verbose,
-                s"Unable to construct a WDL interface for applet ${aplName}"
+                  verbose,
+                  s"Unable to construct a WDL interface for applet ${aplName}"
               )
               Utils.warning(verbose, e.getMessage)
               None
@@ -249,9 +249,9 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     val ioParam = DxObject.parseIoParam(jsv)
     if (ioParam.ioClass == DxIOClass.HASH)
       throw new Exception(
-        s"""|app ${appName} has field ${ioParam.name}
+          s"""|app ${appName} has field ${ioParam.name}
                                     |with non WDL-native io class HASH""".stripMargin
-          .replaceAll("\n", " ")
+            .replaceAll("\n", " ")
       )
     ioParam
   }
@@ -282,10 +282,10 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
         }
         if (!prefix.isEmpty)
           Utils.warning(
-            verbose,
-            s"""|app ${nameClean} does not start
+              verbose,
+              s"""|app ${nameClean} does not start
                                                |with a letter, adding the prefix '${prefix}'""".stripMargin
-              .replaceAll("\n", " ")
+                .replaceAll("\n", " ")
           )
         s"${prefix}${nameClean}"
     }
@@ -306,14 +306,14 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     }.toVector
     val normName = normalizeAppName(name)
     DxAppDescribe(
-      id,
-      normName,
-      0,
-      0,
-      None,
-      None,
-      Some(inputSpec),
-      Some(outputSpec)
+        id,
+        normName,
+        0,
+        0,
+        None,
+        None,
+        Some(inputSpec),
+        Some(outputSpec)
     )
   }
 
@@ -321,19 +321,19 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     val inputSpec: Map[String, WomType] =
       dxApp.inputSpec.get.map { ioSpec =>
         ioSpec.name -> wdlTypeOfIOClass(
-          dxApp.name,
-          ioSpec.name,
-          ioSpec.ioClass,
-          ioSpec.optional
+            dxApp.name,
+            ioSpec.name,
+            ioSpec.ioClass,
+            ioSpec.optional
         )
       }.toMap
     val outputSpec: Map[String, WomType] =
       dxApp.outputSpec.get.map { ioSpec =>
         ioSpec.name -> wdlTypeOfIOClass(
-          dxApp.name,
-          ioSpec.name,
-          ioSpec.ioClass,
-          ioSpec.optional
+            dxApp.name,
+            ioSpec.name,
+            ioSpec.ioClass,
+            ioSpec.optional
         )
       }.toMap
 
@@ -345,17 +345,17 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
     if (!both.isEmpty) {
       val bothStr = "[" + both.mkString(", ") + "]"
       throw new Exception(
-        s"""|Parameters ${bothStr} used as both input and
+          s"""|Parameters ${bothStr} used as both input and
                                     |output in applet ${dxApp.name}""".stripMargin
-          .replaceAll("\n", " ")
+            .replaceAll("\n", " ")
       )
     }
     val WdlCodeSnippet(taskCode) =
       WdlCodeGen(verbose, Map.empty, language).genDnanexusAppletStub(
-        dxApp.id,
-        dxApp.name,
-        inputSpec,
-        outputSpec
+          dxApp.id,
+          dxApp.name,
+          inputSpec,
+          outputSpec
       )
     taskCode
   }
@@ -363,12 +363,12 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   // Search for global apps
   def searchApps: Vector[String] = {
     val req = JsObject(
-      "published" -> JsBoolean(true),
-      "describe" -> JsObject(
-        "inputSpec" -> JsBoolean(true),
-        "outputSpec" -> JsBoolean(true)
-      ),
-      "limit" -> JsNumber(1000)
+        "published" -> JsBoolean(true),
+        "describe" -> JsObject(
+            "inputSpec" -> JsBoolean(true),
+            "outputSpec" -> JsBoolean(true)
+        ),
+        "limit" -> JsNumber(1000)
     )
     val rep =
       DXAPI.systemFindApps(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
@@ -391,8 +391,8 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
       } catch {
         case e: Throwable =>
           Utils.warning(
-            verbose,
-            s"Unable to construct a WDL interface for applet ${appName}"
+              verbose,
+              s"Unable to construct a WDL interface for applet ${appName}"
           )
           Utils.warning(verbose, e.getMessage)
           None
@@ -412,9 +412,9 @@ object DxNI {
     if (Files.exists(outputPath)) {
       if (!force) {
         throw new Exception(
-          s"""|Output file ${outputPath.toString} already exists,
+            s"""|Output file ${outputPath.toString} already exists,
                                         |use -force to overwrite it""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
       }
       outputPath.toFile().delete

--- a/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
+++ b/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
@@ -78,7 +78,7 @@ case class DxObjectDirectory(
         allExecutableNames.toVector,
         false
       )
-    val t1       = System.nanoTime()
+    val t1 = System.nanoTime()
     var diffMSec = (t1 - t0) / (1000 * 1000)
     Utils.trace(
       verbose.on,
@@ -163,8 +163,8 @@ case class DxObjectDirectory(
         false
       )
     val nrApplets = dxAppletsInProject.size
-    val t1        = System.nanoTime()
-    val diffMSec  = (t1 - t0) / (1000 * 1000)
+    val t1 = System.nanoTime()
+    val diffMSec = (t1 - t0) / (1000 * 1000)
     Utils.trace(
       verbose.on,
       s"Found ${nrApplets} applets matching expected names in project ${dxProject.getId} (${diffMSec} millisec)"
@@ -245,7 +245,7 @@ case class DxObjectDirectory(
   def archiveDxObject(objInfo: DxObjectInfo): Unit = {
     Utils.trace(verbose.on, s"Archiving ${objInfo.name} ${objInfo.dxObj.getId}")
     val dxClass: String = objInfo.dxClass
-    val destFolder      = folder ++ "/." ++ dxClass + "_archive"
+    val destFolder = folder ++ "/." ++ dxClass + "_archive"
 
     // move the object to the new location
     newFolder(destFolder)
@@ -256,7 +256,7 @@ case class DxObjectDirectory(
     val crDateStr = objInfo.crDate.format(formatter)
     val req = JsObject(
       "project" -> JsString(dxProject.getId),
-      "name"    -> JsString(s"${objInfo.name} ${crDateStr}")
+      "name" -> JsString(s"${objInfo.name} ${crDateStr}")
     )
 
     dxClass match {

--- a/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
+++ b/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
@@ -15,228 +15,256 @@ import dxWDL.base.Utils.CHECKSUM_PROP
 import dxWDL.dx._
 
 // Keep all the information about an applet in packaged form
-case class DxObjectInfo(name :String,
-                        crDate : LocalDateTime,
-                        dxObj : DxDataObject,
-                        digest : Option[String]) {
-    lazy val dxClass:String =
-        dxObj.getClass.getSimpleName match {
-            case "DxWorkflow" => "Workflow"
-            case "DxApplet" => "Applet"
-            case other => other
-        }
+case class DxObjectInfo(
+    name: String,
+    crDate: LocalDateTime,
+    dxObj: DxDataObject,
+    digest: Option[String]
+) {
+  lazy val dxClass: String =
+    dxObj.getClass.getSimpleName match {
+      case "DxWorkflow" => "Workflow"
+      case "DxApplet"   => "Applet"
+      case other        => other
+    }
 }
 
 // Take a snapshot of the platform target path before the build starts.
 // Make an efficient directory of all the applets that exist there. Update
 // the directory when an applet is compiled.
-case class DxObjectDirectory(ns: IR.Bundle,
-                             dxProject:DxProject,
-                             folder: String,
-                             projectWideReuse: Boolean,
-                             verbose: Verbose) {
-    // a list of all dx:workflow and dx:applet names used in this WDL workflow
-    private val allExecutableNames: Set[String] = ns.allCallables.keys.toSet
+case class DxObjectDirectory(
+    ns: IR.Bundle,
+    dxProject: DxProject,
+    folder: String,
+    projectWideReuse: Boolean,
+    verbose: Verbose
+) {
+  // a list of all dx:workflow and dx:applet names used in this WDL workflow
+  private val allExecutableNames: Set[String] = ns.allCallables.keys.toSet
 
-    // A map from an applet/workflow that is part of the namespace to its dx:object
-    // on the target path (project/folder)
-    private val objDir : HashMap[String, Vector[DxObjectInfo]] = bulkLookup()
+  // A map from an applet/workflow that is part of the namespace to its dx:object
+  // on the target path (project/folder)
+  private val objDir: HashMap[String, Vector[DxObjectInfo]] = bulkLookup()
 
-    // A map from checksum to dx:executable, across the entire
-    // project.  It allows reusing dx:executables across the entire
-    // project, at the cost of a potentially expensive API call. It is
-    // not clear this is useful to the majority of users, so it is
-    // gated by the [projectWideReuse] flag.
-    private val projectWideExecutableDir :
-            Map[String, Vector[(DxDataObject, DxObjectDescribe)]] =
-        if (projectWideReuse) projectBulkLookup()
-        else Map.empty
+  // A map from checksum to dx:executable, across the entire
+  // project.  It allows reusing dx:executables across the entire
+  // project, at the cost of a potentially expensive API call. It is
+  // not clear this is useful to the majority of users, so it is
+  // gated by the [projectWideReuse] flag.
+  private val projectWideExecutableDir: Map[String, Vector[(DxDataObject, DxObjectDescribe)]] =
+    if (projectWideReuse) projectBulkLookup()
+    else Map.empty
 
-    private val folders = HashSet.empty[String]
+  private val folders = HashSet.empty[String]
 
-    // Instead of looking up applets/workflows one by one, perform a bulk lookup, and
-    // find all the objects in the target directory. Setup an easy to
-    // use map with information on each name.
-    //
-    // findDataObjects can be an expensive call, both on the server and client sides.
-    // We limit it by filtering on the CHECKSUM property, which is attached only to generated
-    // applets and workflows. This runs the risk of missing cases where an applet name is already in
-    // use by a regular dnanexus applet/workflow.
-    private def bulkLookup() : HashMap[String, Vector[DxObjectInfo]] = {
-        // find applets
-        val t0 = System.nanoTime()
-        val dxAppletsInFolder: Map[DxDataObject, DxObjectDescribe] =
-            DxFindDataObjects(None, verbose).apply(dxProject, Some(folder), false, Some("applet"),
-                                                   Vector(CHECKSUM_PROP),
-                                                   allExecutableNames.toVector,
-                                                   false)
-        val t1 = System.nanoTime()
-        var diffMSec = (t1 -t0) / (1000 * 1000)
-        Utils.trace(verbose.on,
-                    s"""|Found ${dxAppletsInFolder.size} applets
-                        |in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)"""
-                        .stripMargin.replaceAll("\n", " "))
+  // Instead of looking up applets/workflows one by one, perform a bulk lookup, and
+  // find all the objects in the target directory. Setup an easy to
+  // use map with information on each name.
+  //
+  // findDataObjects can be an expensive call, both on the server and client sides.
+  // We limit it by filtering on the CHECKSUM property, which is attached only to generated
+  // applets and workflows. This runs the risk of missing cases where an applet name is already in
+  // use by a regular dnanexus applet/workflow.
+  private def bulkLookup(): HashMap[String, Vector[DxObjectInfo]] = {
+    // find applets
+    val t0 = System.nanoTime()
+    val dxAppletsInFolder: Map[DxDataObject, DxObjectDescribe] =
+      DxFindDataObjects(None, verbose).apply(
+        dxProject,
+        Some(folder),
+        false,
+        Some("applet"),
+        Vector(CHECKSUM_PROP),
+        allExecutableNames.toVector,
+        false
+      )
+    val t1       = System.nanoTime()
+    var diffMSec = (t1 - t0) / (1000 * 1000)
+    Utils.trace(
+      verbose.on,
+      s"""|Found ${dxAppletsInFolder.size} applets
+                        |in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)""".stripMargin
+        .replaceAll("\n", " ")
+    )
 
-        // find workflows
-        val t2 = System.nanoTime()
-        val dxWorkflowsInFolder: Map[DxDataObject, DxObjectDescribe] =
-            DxFindDataObjects(None, verbose).apply(dxProject, Some(folder), false, Some("workflow"),
-                                                   Vector(CHECKSUM_PROP),
-                                                   allExecutableNames.toVector,
-                                                   false)
-        val t3 = System.nanoTime()
-        diffMSec = (t3 -t2) / (1000 * 1000)
-        Utils.trace(verbose.on,
-                    s"""|Found ${dxWorkflowsInFolder.size} workflows
-                        | in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)"""
-                        .stripMargin.replaceAll("\n", " "))
+    // find workflows
+    val t2 = System.nanoTime()
+    val dxWorkflowsInFolder: Map[DxDataObject, DxObjectDescribe] =
+      DxFindDataObjects(None, verbose).apply(
+        dxProject,
+        Some(folder),
+        false,
+        Some("workflow"),
+        Vector(CHECKSUM_PROP),
+        allExecutableNames.toVector,
+        false
+      )
+    val t3 = System.nanoTime()
+    diffMSec = (t3 - t2) / (1000 * 1000)
+    Utils.trace(
+      verbose.on,
+      s"""|Found ${dxWorkflowsInFolder.size} workflows
+                        | in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)""".stripMargin
+        .replaceAll("\n", " ")
+    )
 
-        val dxObjects = dxAppletsInFolder ++ dxWorkflowsInFolder
+    val dxObjects = dxAppletsInFolder ++ dxWorkflowsInFolder
 
-        val dxObjectList: List[DxObjectInfo] = dxObjects.map{
-            case (dxObj, desc) =>
-                val creationDate = new java.util.Date(desc.created)
-                val crLdt:LocalDateTime = LocalDateTime.ofInstant(creationDate.toInstant(),
-                                                                  ZoneId.systemDefault())
-                val chksum = desc.properties.flatMap{ p => p.get(CHECKSUM_PROP) }
-                DxObjectInfo(desc.name, crLdt, dxObj, chksum)
-        }.toList
-
-        // There could be multiple versions of the same applet/workflow, collect their
-        // information in vectors
-        val hm = HashMap.empty[String, Vector[DxObjectInfo]]
-        dxObjectList.foreach{ case dxObjInfo =>
-            val name = dxObjInfo.name
-            hm.get(name) match {
-                case None =>
-                    // first time we have seen this dx:object
-                    hm(name) = Vector(dxObjInfo)
-                case Some(vec) =>
-                    // there is already at least one dx:object by this name
-                    hm(name) = hm(name) :+ dxObjInfo
-            }
+    val dxObjectList: List[DxObjectInfo] = dxObjects.map {
+      case (dxObj, desc) =>
+        val creationDate = new java.util.Date(desc.created)
+        val crLdt: LocalDateTime =
+          LocalDateTime.ofInstant(creationDate.toInstant(), ZoneId.systemDefault())
+        val chksum = desc.properties.flatMap { p =>
+          p.get(CHECKSUM_PROP)
         }
-        hm
-    }
+        DxObjectInfo(desc.name, crLdt, dxObj, chksum)
+    }.toList
 
-
-    // Scan the entire project for dx:workflows and dx:applets that we
-    // already created, and may be reused, instead of recompiling.
-    //
-    // Note: This could be expensive, and the maximal number of replies
-    // is (by default) 1000. Since the index is limited, we may miss
-    // miss matches when we search. The cost would be creating a
-    // dx:executable again, which is acceptable.
-    //
-    // findDataObjects can be an expensive call, both on the server and client sides.
-    // We limit it by filtering on the CHECKSUM property, which is attached only to generated
-    // applets and workflows.
-    private def projectBulkLookup() : Map[String, Vector[(DxDataObject, DxObjectDescribe)]] = {
-        val t0 = System.nanoTime()
-        val dxAppletsInProject: Map[DxDataObject, DxObjectDescribe] =
-            DxFindDataObjects(None, verbose).apply(dxProject, None, true, Some("applet"),
-                                                   Vector(CHECKSUM_PROP),
-                                                   allExecutableNames.toVector,
-                                                   false)
-        val nrApplets = dxAppletsInProject.size
-        val t1 = System.nanoTime()
-        val diffMSec = (t1 -t0) / (1000 * 1000)
-        Utils.trace(verbose.on,
-                    s"Found ${nrApplets} applets matching expected names in project ${dxProject.getId} (${diffMSec} millisec)")
-
-        val hm = HashMap.empty[String, Vector[(DxDataObject, DxObjectDescribe)]]
-        dxAppletsInProject.foreach{ case (dxObj, desc) =>
-            val chksum = desc.properties.flatMap{ p => p.get(CHECKSUM_PROP) }
-            chksum match {
-                case None => ()
-                case Some(digest) =>
-                    if (hm contains digest)
-                        // Digest collision
-                        hm(digest) :+ (dxObj, desc)
-                    else
-                        hm(digest) = Vector((dxObj, desc))
-            }
-        }
-        hm.toMap
-    }
-
-    def lookup(execName: String) : Vector[DxObjectInfo] = {
-        objDir.get(execName) match {
-            case None => Vector.empty
-            case Some(v) => v
+    // There could be multiple versions of the same applet/workflow, collect their
+    // information in vectors
+    val hm = HashMap.empty[String, Vector[DxObjectInfo]]
+    dxObjectList.foreach {
+      case dxObjInfo =>
+        val name = dxObjInfo.name
+        hm.get(name) match {
+          case None =>
+            // first time we have seen this dx:object
+            hm(name) = Vector(dxObjInfo)
+          case Some(vec) =>
+            // there is already at least one dx:object by this name
+            hm(name) = hm(name) :+ dxObjInfo
         }
     }
+    hm
+  }
 
-    // Search for an executable named [execName], with a specific
-    // checksum anywhere in the project. This could save recompilation.
-    //
-    // Note: in case of checksum collision, there could be several hits.
-    // Return only the one that starts with the name we are looking for.
-    def lookupOtherVersions(execName: String, digest: String)
-            : Option[(DxDataObject, DxObjectDescribe)] = {
-        val checksumMatches = projectWideExecutableDir.get(digest) match {
-            case None => return None
-            case Some(vec) => vec
+  // Scan the entire project for dx:workflows and dx:applets that we
+  // already created, and may be reused, instead of recompiling.
+  //
+  // Note: This could be expensive, and the maximal number of replies
+  // is (by default) 1000. Since the index is limited, we may miss
+  // miss matches when we search. The cost would be creating a
+  // dx:executable again, which is acceptable.
+  //
+  // findDataObjects can be an expensive call, both on the server and client sides.
+  // We limit it by filtering on the CHECKSUM property, which is attached only to generated
+  // applets and workflows.
+  private def projectBulkLookup(): Map[String, Vector[(DxDataObject, DxObjectDescribe)]] = {
+    val t0 = System.nanoTime()
+    val dxAppletsInProject: Map[DxDataObject, DxObjectDescribe] =
+      DxFindDataObjects(None, verbose).apply(
+        dxProject,
+        None,
+        true,
+        Some("applet"),
+        Vector(CHECKSUM_PROP),
+        allExecutableNames.toVector,
+        false
+      )
+    val nrApplets = dxAppletsInProject.size
+    val t1        = System.nanoTime()
+    val diffMSec  = (t1 - t0) / (1000 * 1000)
+    Utils.trace(
+      verbose.on,
+      s"Found ${nrApplets} applets matching expected names in project ${dxProject.getId} (${diffMSec} millisec)"
+    )
+
+    val hm = HashMap.empty[String, Vector[(DxDataObject, DxObjectDescribe)]]
+    dxAppletsInProject.foreach {
+      case (dxObj, desc) =>
+        val chksum = desc.properties.flatMap { p =>
+          p.get(CHECKSUM_PROP)
         }
-        val checksumAndNameMatches = checksumMatches.filter{ case (dxObj, dxDesc) =>
-            dxDesc.name.startsWith(execName)
-        }
-        if (checksumAndNameMatches.isEmpty)
-            return None
-        return Some(checksumAndNameMatches.head)
-    }
-
-    def insert(name:String, dxObj:DxDataObject, digest: String) : Unit = {
-        val aInfo = DxObjectInfo(name, LocalDateTime.now, dxObj, Some(digest))
-        objDir(name) = Vector(aInfo)
-    }
-
-    // create a folder, if it does not already exist.
-    private def newFolder(fullPath:String) : Unit = {
-        if (!(folders contains fullPath)) {
-            dxProject.newFolder(fullPath, true)
-            folders.add(fullPath)
-        }
-    }
-
-    // Move an object into an archive directory. If the object
-    // is an applet, for example /A/B/C/GLnexus, move it to
-    //     /A/B/C/Applet_archive/GLnexus (Day Mon DD hh:mm:ss year)
-    // If the object is a workflow, move it to
-    //     /A/B/C/Workflow_archive/GLnexus (Day Mon DD hh:mm:ss year)
-    //
-    // Examples:
-    //   GLnexus (Fri Aug 19 18:01:02 2016)
-    //   GLnexus (Mon Mar  7 15:18:14 2016)
-    //
-    // Note: 'dx build' does not support workflow archiving at the moment.
-    def archiveDxObject(objInfo:DxObjectInfo) : Unit = {
-        Utils.trace(verbose.on, s"Archiving ${objInfo.name} ${objInfo.dxObj.getId}")
-        val dxClass:String = objInfo.dxClass
-        val destFolder = folder ++ "/." ++ dxClass + "_archive"
-
-        // move the object to the new location
-        newFolder(destFolder)
-        dxProject.moveObjects(Vector(objInfo.dxObj), destFolder)
-
-        // add the date to the object name
-        val formatter = DateTimeFormatter.ofPattern("EE MMM dd kk:mm:ss yyyy")
-        val crDateStr = objInfo.crDate.format(formatter)
-        val req = JsObject(
-            "project" -> JsString(dxProject.getId),
-            "name" -> JsString(s"${objInfo.name} ${crDateStr}")
-        )
-
-        dxClass match {
-            case "Workflow" =>
-                DXAPI.workflowRename(objInfo.dxObj.getId,
-                                     DxUtils.jsonNodeOfJsValue(req),
-                                     classOf[JsonNode])
-            case "Applet" =>
-                DXAPI.appletRename(objInfo.dxObj.getId,
-                                   DxUtils.jsonNodeOfJsValue(req),
-                                   classOf[JsonNode])
-            case other => throw new Exception(s"Unkown class ${other}")
+        chksum match {
+          case None => ()
+          case Some(digest) =>
+            if (hm contains digest)
+              // Digest collision
+              hm(digest) :+ (dxObj, desc)
+            else
+              hm(digest) = Vector((dxObj, desc))
         }
     }
+    hm.toMap
+  }
+
+  def lookup(execName: String): Vector[DxObjectInfo] = {
+    objDir.get(execName) match {
+      case None    => Vector.empty
+      case Some(v) => v
+    }
+  }
+
+  // Search for an executable named [execName], with a specific
+  // checksum anywhere in the project. This could save recompilation.
+  //
+  // Note: in case of checksum collision, there could be several hits.
+  // Return only the one that starts with the name we are looking for.
+  def lookupOtherVersions(
+      execName: String,
+      digest: String
+  ): Option[(DxDataObject, DxObjectDescribe)] = {
+    val checksumMatches = projectWideExecutableDir.get(digest) match {
+      case None      => return None
+      case Some(vec) => vec
+    }
+    val checksumAndNameMatches = checksumMatches.filter {
+      case (dxObj, dxDesc) =>
+        dxDesc.name.startsWith(execName)
+    }
+    if (checksumAndNameMatches.isEmpty)
+      return None
+    return Some(checksumAndNameMatches.head)
+  }
+
+  def insert(name: String, dxObj: DxDataObject, digest: String): Unit = {
+    val aInfo = DxObjectInfo(name, LocalDateTime.now, dxObj, Some(digest))
+    objDir(name) = Vector(aInfo)
+  }
+
+  // create a folder, if it does not already exist.
+  private def newFolder(fullPath: String): Unit = {
+    if (!(folders contains fullPath)) {
+      dxProject.newFolder(fullPath, true)
+      folders.add(fullPath)
+    }
+  }
+
+  // Move an object into an archive directory. If the object
+  // is an applet, for example /A/B/C/GLnexus, move it to
+  //     /A/B/C/Applet_archive/GLnexus (Day Mon DD hh:mm:ss year)
+  // If the object is a workflow, move it to
+  //     /A/B/C/Workflow_archive/GLnexus (Day Mon DD hh:mm:ss year)
+  //
+  // Examples:
+  //   GLnexus (Fri Aug 19 18:01:02 2016)
+  //   GLnexus (Mon Mar  7 15:18:14 2016)
+  //
+  // Note: 'dx build' does not support workflow archiving at the moment.
+  def archiveDxObject(objInfo: DxObjectInfo): Unit = {
+    Utils.trace(verbose.on, s"Archiving ${objInfo.name} ${objInfo.dxObj.getId}")
+    val dxClass: String = objInfo.dxClass
+    val destFolder      = folder ++ "/." ++ dxClass + "_archive"
+
+    // move the object to the new location
+    newFolder(destFolder)
+    dxProject.moveObjects(Vector(objInfo.dxObj), destFolder)
+
+    // add the date to the object name
+    val formatter = DateTimeFormatter.ofPattern("EE MMM dd kk:mm:ss yyyy")
+    val crDateStr = objInfo.crDate.format(formatter)
+    val req = JsObject(
+      "project" -> JsString(dxProject.getId),
+      "name"    -> JsString(s"${objInfo.name} ${crDateStr}")
+    )
+
+    dxClass match {
+      case "Workflow" =>
+        DXAPI.workflowRename(objInfo.dxObj.getId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+      case "Applet" =>
+        DXAPI.appletRename(objInfo.dxObj.getId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+      case other => throw new Exception(s"Unkown class ${other}")
+    }
+  }
 }

--- a/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
+++ b/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
@@ -70,42 +70,42 @@ case class DxObjectDirectory(
     val t0 = System.nanoTime()
     val dxAppletsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose).apply(
-        dxProject,
-        Some(folder),
-        false,
-        Some("applet"),
-        Vector(CHECKSUM_PROP),
-        allExecutableNames.toVector,
-        false
+          dxProject,
+          Some(folder),
+          false,
+          Some("applet"),
+          Vector(CHECKSUM_PROP),
+          allExecutableNames.toVector,
+          false
       )
     val t1 = System.nanoTime()
     var diffMSec = (t1 - t0) / (1000 * 1000)
     Utils.trace(
-      verbose.on,
-      s"""|Found ${dxAppletsInFolder.size} applets
+        verbose.on,
+        s"""|Found ${dxAppletsInFolder.size} applets
                         |in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)""".stripMargin
-        .replaceAll("\n", " ")
+          .replaceAll("\n", " ")
     )
 
     // find workflows
     val t2 = System.nanoTime()
     val dxWorkflowsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose).apply(
-        dxProject,
-        Some(folder),
-        false,
-        Some("workflow"),
-        Vector(CHECKSUM_PROP),
-        allExecutableNames.toVector,
-        false
+          dxProject,
+          Some(folder),
+          false,
+          Some("workflow"),
+          Vector(CHECKSUM_PROP),
+          allExecutableNames.toVector,
+          false
       )
     val t3 = System.nanoTime()
     diffMSec = (t3 - t2) / (1000 * 1000)
     Utils.trace(
-      verbose.on,
-      s"""|Found ${dxWorkflowsInFolder.size} workflows
+        verbose.on,
+        s"""|Found ${dxWorkflowsInFolder.size} workflows
                         | in ${dxProject.getId} folder=${folder} (${diffMSec} millisec)""".stripMargin
-        .replaceAll("\n", " ")
+          .replaceAll("\n", " ")
     )
 
     val dxObjects = dxAppletsInFolder ++ dxWorkflowsInFolder
@@ -115,8 +115,8 @@ case class DxObjectDirectory(
         val creationDate = new java.util.Date(desc.created)
         val crLdt: LocalDateTime =
           LocalDateTime.ofInstant(
-            creationDate.toInstant(),
-            ZoneId.systemDefault()
+              creationDate.toInstant(),
+              ZoneId.systemDefault()
           )
         val chksum = desc.properties.flatMap { p =>
           p.get(CHECKSUM_PROP)
@@ -157,20 +157,20 @@ case class DxObjectDirectory(
     val t0 = System.nanoTime()
     val dxAppletsInProject: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose).apply(
-        dxProject,
-        None,
-        true,
-        Some("applet"),
-        Vector(CHECKSUM_PROP),
-        allExecutableNames.toVector,
-        false
+          dxProject,
+          None,
+          true,
+          Some("applet"),
+          Vector(CHECKSUM_PROP),
+          allExecutableNames.toVector,
+          false
       )
     val nrApplets = dxAppletsInProject.size
     val t1 = System.nanoTime()
     val diffMSec = (t1 - t0) / (1000 * 1000)
     Utils.trace(
-      verbose.on,
-      s"Found ${nrApplets} applets matching expected names in project ${dxProject.getId} (${diffMSec} millisec)"
+        verbose.on,
+        s"Found ${nrApplets} applets matching expected names in project ${dxProject.getId} (${diffMSec} millisec)"
     )
 
     val hm = HashMap.empty[String, Vector[(DxDataObject, DxObjectDescribe)]]
@@ -258,22 +258,22 @@ case class DxObjectDirectory(
     val formatter = DateTimeFormatter.ofPattern("EE MMM dd kk:mm:ss yyyy")
     val crDateStr = objInfo.crDate.format(formatter)
     val req = JsObject(
-      "project" -> JsString(dxProject.getId),
-      "name" -> JsString(s"${objInfo.name} ${crDateStr}")
+        "project" -> JsString(dxProject.getId),
+        "name" -> JsString(s"${objInfo.name} ${crDateStr}")
     )
 
     dxClass match {
       case "Workflow" =>
         DXAPI.workflowRename(
-          objInfo.dxObj.getId,
-          DxUtils.jsonNodeOfJsValue(req),
-          classOf[JsonNode]
+            objInfo.dxObj.getId,
+            DxUtils.jsonNodeOfJsValue(req),
+            classOf[JsonNode]
         )
       case "Applet" =>
         DXAPI.appletRename(
-          objInfo.dxObj.getId,
-          DxUtils.jsonNodeOfJsValue(req),
-          classOf[JsonNode]
+            objInfo.dxObj.getId,
+            DxUtils.jsonNodeOfJsValue(req),
+            classOf[JsonNode]
         )
       case other => throw new Exception(s"Unkown class ${other}")
     }

--- a/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
+++ b/src/main/scala/dxWDL/compiler/DxObjectDirectory.scala
@@ -114,7 +114,10 @@ case class DxObjectDirectory(
       case (dxObj, desc) =>
         val creationDate = new java.util.Date(desc.created)
         val crLdt: LocalDateTime =
-          LocalDateTime.ofInstant(creationDate.toInstant(), ZoneId.systemDefault())
+          LocalDateTime.ofInstant(
+            creationDate.toInstant(),
+            ZoneId.systemDefault()
+          )
         val chksum = desc.properties.flatMap { p =>
           p.get(CHECKSUM_PROP)
         }
@@ -261,9 +264,17 @@ case class DxObjectDirectory(
 
     dxClass match {
       case "Workflow" =>
-        DXAPI.workflowRename(objInfo.dxObj.getId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+        DXAPI.workflowRename(
+          objInfo.dxObj.getId,
+          DxUtils.jsonNodeOfJsValue(req),
+          classOf[JsonNode]
+        )
       case "Applet" =>
-        DXAPI.appletRename(objInfo.dxObj.getId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+        DXAPI.appletRename(
+          objInfo.dxObj.getId,
+          DxUtils.jsonNodeOfJsValue(req),
+          classOf[JsonNode]
+        )
       case other => throw new Exception(s"Unkown class ${other}")
     }
   }

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -10,245 +10,262 @@ import wom.types._
 import dxWDL.base._
 import dxWDL.util._
 
-case class GenerateIR(verbose: Verbose,
-                      defaultRuntimeAttrs: WdlRuntimeAttrs) {
-    val verbose2 : Boolean = verbose.containsKey("GenerateIR")
+case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
+  val verbose2: Boolean = verbose.containsKey("GenerateIR")
 
-    def sortByDependencies(allCallables: Vector[Callable]) : Vector[Callable] = {
-        // figure out, for each element, what it depends on.
-        // tasks don't depend on anything else. They are at the bottom of the dependency
-        // tree.
-        val immediateDeps : Map[String, Set[String]] = allCallables.map{ callable =>
-            val deps = callable match {
-                case _ : ExecutableTaskDefinition => Set.empty[String]
-                case _ : CallableTaskDefinition => Set.empty[String]
-                case wf: WorkflowDefinition =>
-                    val nodes = wf.innerGraph.allNodes
-                    val callNodes : Vector[CallNode] = nodes.collect{
-                        case cNode: CallNode => cNode
-                    }.toVector
+  def sortByDependencies(allCallables: Vector[Callable]): Vector[Callable] = {
+    // figure out, for each element, what it depends on.
+    // tasks don't depend on anything else. They are at the bottom of the dependency
+    // tree.
+    val immediateDeps: Map[String, Set[String]] = allCallables.map { callable =>
+      val deps = callable match {
+        case _: ExecutableTaskDefinition => Set.empty[String]
+        case _: CallableTaskDefinition   => Set.empty[String]
+        case wf: WorkflowDefinition =>
+          val nodes = wf.innerGraph.allNodes
+          val callNodes: Vector[CallNode] = nodes.collect {
+            case cNode: CallNode => cNode
+          }.toVector
 
-                    callNodes.collect{
-                        case cNode : WorkflowCallNode =>
-                            // We need to ignore calls to scatters that converted by
-                            // wdl to internal workflows.
-                            val name = Utils.getUnqualifiedName(cNode.callable.name)
-                            if (name.startsWith("Scatter"))
-                                throw new Exception("nested scatters")
-                            name
+          callNodes.collect {
+            case cNode: WorkflowCallNode =>
+              // We need to ignore calls to scatters that converted by
+              // wdl to internal workflows.
+              val name = Utils.getUnqualifiedName(cNode.callable.name)
+              if (name.startsWith("Scatter"))
+                throw new Exception("nested scatters")
+              name
 
-                        case cNode : CallNode =>
-                            // The name is fully qualified, for example, lib.add, lib.concat.
-                            // We need the task/workflow itself ("add", "concat"). We are
-                            // assuming that the namespace can be flattened; there are
-                            // no lib.add and lib2.add.
-                            Utils.getUnqualifiedName(cNode.callable.name)
-                    }.toSet
-                case other =>
-                    throw new Exception(s"Don't know how to deal with class ${other.getClass.getSimpleName}")
-            }
-            Utils.getUnqualifiedName(callable.name) -> deps
+            case cNode: CallNode =>
+              // The name is fully qualified, for example, lib.add, lib.concat.
+              // We need the task/workflow itself ("add", "concat"). We are
+              // assuming that the namespace can be flattened; there are
+              // no lib.add and lib2.add.
+              Utils.getUnqualifiedName(cNode.callable.name)
+          }.toSet
+        case other =>
+          throw new Exception(s"Don't know how to deal with class ${other.getClass.getSimpleName}")
+      }
+      Utils.getUnqualifiedName(callable.name) -> deps
+    }.toMap
+
+    // Find executables such that all of their dependencies are
+    // satisfied. These can be compiled.
+    def next(callables: Vector[Callable], ready: Vector[Callable]): Vector[Callable] = {
+      val readyNames = ready.map(_.name).toSet
+      val satisfiedCallables = callables.filter { c =>
+        val deps = immediateDeps(c.name)
+        Utils.trace(verbose2, s"immediateDeps(${c.name}) = ${deps}")
+        deps.subsetOf(readyNames)
+      }
+      if (satisfiedCallables.isEmpty) {
+        val stuck = callables.map(_.name).toSet -- readyNames
+        val stuckWaitingOn: Map[String, Set[String]] = stuck.map { name =>
+          name -> (immediateDeps(name) -- readyNames)
         }.toMap
-
-        // Find executables such that all of their dependencies are
-        // satisfied. These can be compiled.
-        def next(callables: Vector[Callable],
-                 ready: Vector[Callable]) : Vector[Callable] = {
-            val readyNames = ready.map(_.name).toSet
-            val satisfiedCallables = callables.filter{ c =>
-                val deps = immediateDeps(c.name)
-                Utils.trace(verbose2, s"immediateDeps(${c.name}) = ${deps}")
-                deps.subsetOf(readyNames)
-            }
-            if (satisfiedCallables.isEmpty) {
-                val stuck = callables.map(_.name).toSet -- readyNames
-                val stuckWaitingOn : Map[String, Set[String]] = stuck.map{ name =>
-                    name -> (immediateDeps(name) -- readyNames)
-                }.toMap
-                val explanationLines = stuckWaitingOn.mkString("\n")
-                throw new Exception(s"""|Sanity: cannot find the next callable to compile.
+        val explanationLines = stuckWaitingOn.mkString("\n")
+        throw new Exception(s"""|Sanity: cannot find the next callable to compile.
                                         |ready = ${readyNames}
                                         |stuck = ${stuck}
                                         |stuckWaitingOn =
                                         |${explanationLines}
                                         |""".stripMargin)
-            }
-            satisfiedCallables
-        }
-
-        var accu = Vector.empty[Callable]
-        var crnt = allCallables
-        while (!crnt.isEmpty) {
-            Utils.trace(verbose2, s"accu=${accu.map(_.name)}")
-            Utils.trace(verbose2, s"crnt=${crnt.map(_.name)}")
-            val execsToCompile = next(crnt, accu)
-            accu = accu ++ execsToCompile
-            val alreadyCompiled: Set[String] = accu.map(_.name).toSet
-            crnt = crnt.filter{ exec => !(alreadyCompiled contains exec.name) }
-        }
-        assert(accu.length == allCallables.length)
-        accu
+      }
+      satisfiedCallables
     }
 
-    private def compileWorkflow(wf : WorkflowDefinition,
-                                typeAliases: Map[String, WomType],
-                                wfSource: String,
-                                callables: Map[String, IR.Callable],
-                                language: Language.Value,
-                                locked : Boolean,
-                                reorg : Either[Boolean, ReorgAttrs]) : (IR.Workflow, Vector[IR.Callable]) = {
-        // sort from low to high according to the source lines.
-        val callsLoToHi = ParseWomSourceFile(verbose.on).scanForCalls(wf.innerGraph, wfSource)
+    var accu = Vector.empty[Callable]
+    var crnt = allCallables
+    while (!crnt.isEmpty) {
+      Utils.trace(verbose2, s"accu=${accu.map(_.name)}")
+      Utils.trace(verbose2, s"crnt=${crnt.map(_.name)}")
+      val execsToCompile = next(crnt, accu)
+      accu = accu ++ execsToCompile
+      val alreadyCompiled: Set[String] = accu.map(_.name).toSet
+      crnt = crnt.filter { exec =>
+        !(alreadyCompiled contains exec.name)
+      }
+    }
+    assert(accu.length == allCallables.length)
+    accu
+  }
 
-        // Make a list of all task/workflow calls made inside the block. We will need to link
-        // to the equivalent dx:applets and dx:workflows.
-        val callablesUsedInWorkflow : Vector[IR.Callable] =
-            wf.graph.allNodes.collect {
-                case cNode : WorkflowCallNode =>
-                    // We need to ignore calls to scatters that converted by
-                    // wdl to internal workflows.
-                    val localName = Utils.getUnqualifiedName(cNode.callable.name)
-                    if (localName.startsWith("Scatter"))
-                        throw new Exception("""|The workflow contains a nested scatter, it is not
+  private def compileWorkflow(
+      wf: WorkflowDefinition,
+      typeAliases: Map[String, WomType],
+      wfSource: String,
+      callables: Map[String, IR.Callable],
+      language: Language.Value,
+      locked: Boolean,
+      reorg: Either[Boolean, ReorgAttrs]
+  ): (IR.Workflow, Vector[IR.Callable]) = {
+    // sort from low to high according to the source lines.
+    val callsLoToHi = ParseWomSourceFile(verbose.on).scanForCalls(wf.innerGraph, wfSource)
+
+    // Make a list of all task/workflow calls made inside the block. We will need to link
+    // to the equivalent dx:applets and dx:workflows.
+    val callablesUsedInWorkflow: Vector[IR.Callable] =
+      wf.graph.allNodes.collect {
+        case cNode: WorkflowCallNode =>
+          // We need to ignore calls to scatters that converted by
+          // wdl to internal workflows.
+          val localName = Utils.getUnqualifiedName(cNode.callable.name)
+          if (localName.startsWith("Scatter"))
+            throw new Exception("""|The workflow contains a nested scatter, it is not
                                                |handled currently due to a cromwell WOM library issue
                                                |""".stripMargin.replaceAll("\n", " "))
-                    callables(localName)
-                case cNode : CallNode =>
-                    val localname = Utils.getUnqualifiedName(cNode.callable.name)
-                    callables(localname)
-            }.toVector
+          callables(localName)
+        case cNode: CallNode =>
+          val localname = Utils.getUnqualifiedName(cNode.callable.name)
+          callables(localname)
+      }.toVector
 
-        val WdlCodeSnippet(wfSourceStandAlone) =
-            WdlCodeGen(verbose, typeAliases, language).standAloneWorkflow(wfSource,
-                                                                          callablesUsedInWorkflow)
+    val WdlCodeSnippet(wfSourceStandAlone) =
+      WdlCodeGen(verbose, typeAliases, language)
+        .standAloneWorkflow(wfSource, callablesUsedInWorkflow)
 
-        val gir = new GenerateIRWorkflow(
-            wf, wfSource, wfSourceStandAlone, callsLoToHi, callables, language, verbose, locked, reorg)
-        gir.apply()
+    val gir = new GenerateIRWorkflow(
+      wf,
+      wfSource,
+      wfSourceStandAlone,
+      callsLoToHi,
+      callables,
+      language,
+      verbose,
+      locked,
+      reorg
+    )
+    gir.apply()
+  }
+
+  // Entry point for compiling tasks and workflows into IR
+  private def compileCallable(
+      callable: Callable,
+      typeAliases: Map[String, WomType],
+      taskDir: Map[String, String],
+      workflowDir: Map[String, String],
+      callables: Map[String, IR.Callable],
+      language: Language.Value,
+      locked: Boolean,
+      reorg: Either[Boolean, ReorgAttrs]
+  ): (IR.Callable, Vector[IR.Callable]) = {
+    def compileTask2(task: CallableTaskDefinition) = {
+      val taskSourceCode = taskDir.get(task.name) match {
+        case None    => throw new Exception(s"Did not find task ${task.name}")
+        case Some(x) => x
+      }
+      GenerateIRTask(verbose, typeAliases, language, defaultRuntimeAttrs)
+        .apply(task, taskSourceCode)
     }
-
-    // Entry point for compiling tasks and workflows into IR
-    private def compileCallable(callable: Callable,
-                                typeAliases: Map[String, WomType],
-                                taskDir: Map[String, String],
-                                workflowDir: Map[String, String],
-                                callables: Map[String, IR.Callable],
-                                language: Language.Value,
-                                locked: Boolean,
-                                reorg: Either[Boolean, ReorgAttrs]) : (IR.Callable, Vector[IR.Callable]) = {
-        def compileTask2(task : CallableTaskDefinition) = {
-            val taskSourceCode = taskDir.get(task.name) match {
-                case None => throw new Exception(s"Did not find task ${task.name}")
-                case Some(x) => x
-            }
-            GenerateIRTask(verbose, typeAliases,
-                           language, defaultRuntimeAttrs).apply(task, taskSourceCode)
+    callable match {
+      case exec: ExecutableTaskDefinition =>
+        val task = exec.callableTaskDefinition
+        (compileTask2(task), Vector.empty)
+      case task: CallableTaskDefinition =>
+        (compileTask2(task), Vector.empty)
+      case wf: WorkflowDefinition =>
+        workflowDir.get(wf.name) match {
+          case None =>
+            throw new Exception(s"Did not find sources for workflow ${wf.name}")
+          case Some(wfSource) =>
+            compileWorkflow(wf, typeAliases, wfSource, callables, language, locked, reorg)
         }
-        callable match {
-            case exec : ExecutableTaskDefinition =>
-                val task = exec.callableTaskDefinition
-                (compileTask2(task), Vector.empty)
-            case task : CallableTaskDefinition =>
-                (compileTask2(task), Vector.empty)
-            case wf: WorkflowDefinition =>
-                workflowDir.get(wf.name) match {
-                    case None =>
-                        throw new Exception(s"Did not find sources for workflow ${wf.name}")
-                    case Some(wfSource) =>
-                        compileWorkflow(wf, typeAliases, wfSource, callables, language, locked, reorg)
-                }
-            case x =>
-                throw new Exception(s"""|Can't compile: ${callable.name}, class=${callable.getClass}
+      case x =>
+        throw new Exception(s"""|Can't compile: ${callable.name}, class=${callable.getClass}
                                         |${x}
                                         |""".stripMargin.replaceAll("\n", " "))
+    }
+  }
+
+  // Entrypoint
+  def apply(
+      womBundle: wom.executable.WomBundle,
+      allSources: Map[String, WorkflowSource],
+      language: Language.Value,
+      locked: Boolean,
+      reorg: Either[Boolean, ReorgAttrs]
+  ): IR.Bundle = {
+    Utils.trace(verbose.on, s"IR pass")
+    Utils.traceLevelInc()
+
+    // Scan the source files and extract the tasks. It is hard
+    // to generate WDL from the abstract syntax tree (AST). One
+    // issue is that tabs and special characters have to preserved.
+    // There is no built-in method for this.
+    val taskDir = allSources.foldLeft(Map.empty[String, String]) {
+      case (accu, (filename, srcCode)) =>
+        val d = ParseWomSourceFile(verbose.on).scanForTasks(srcCode)
+        accu ++ d
+    }
+    Utils.trace(verbose.on, s"tasks=${taskDir.keys}")
+
+    val workflowDir = allSources.foldLeft(Map.empty[String, String]) {
+      case (accu, (filename, srcCode)) =>
+        ParseWomSourceFile(verbose.on).scanForWorkflow(srcCode) match {
+          case None =>
+            accu
+          case Some((wfName, wfSource)) =>
+            accu + (wfName -> wfSource)
         }
     }
+    Utils.trace(verbose.on, s"sortByDependencies ${womBundle.allCallables.values.map { _.name }}")
+    Utils.traceLevelInc()
+    val depOrder: Vector[Callable] = sortByDependencies(womBundle.allCallables.values.toVector)
+    Utils.trace(verbose.on, s"depOrder =${depOrder.map { _.name }}")
+    Utils.traceLevelDec()
 
-    // Entrypoint
-    def apply(womBundle : wom.executable.WomBundle,
-              allSources: Map[String, WorkflowSource],
-              language: Language.Value,
-              locked: Boolean,
-              reorg: Either[Boolean, ReorgAttrs]) : IR.Bundle = {
-        Utils.trace(verbose.on, s"IR pass")
-        Utils.traceLevelInc()
+    // compile the tasks/workflows from bottom to top.
+    var allCallables       = Map.empty[String, IR.Callable]
+    var allCallablesSorted = Vector.empty[IR.Callable]
 
-        // Scan the source files and extract the tasks. It is hard
-        // to generate WDL from the abstract syntax tree (AST). One
-        // issue is that tabs and special characters have to preserved.
-        // There is no built-in method for this.
-        val taskDir = allSources.foldLeft(Map.empty[String, String]) {
-            case (accu, (filename, srcCode)) =>
-                val d = ParseWomSourceFile(verbose.on).scanForTasks(srcCode)
-                accu ++ d
-        }
-        Utils.trace(verbose.on, s"tasks=${taskDir.keys}")
-
-        val workflowDir = allSources.foldLeft(Map.empty[String, String]) {
-            case (accu, (filename, srcCode)) =>
-                ParseWomSourceFile(verbose.on).scanForWorkflow(srcCode) match {
-                    case None =>
-                        accu
-                    case Some((wfName, wfSource)) =>
-                        accu + (wfName -> wfSource)
-                }
-        }
-        Utils.trace(verbose.on,
-                    s"sortByDependencies ${womBundle.allCallables.values.map{_.name}}")
-        Utils.traceLevelInc()
-        val depOrder : Vector[Callable] = sortByDependencies(womBundle.allCallables.values.toVector)
-        Utils.trace(verbose.on,
-                    s"depOrder =${depOrder.map{_.name}}")
-        Utils.traceLevelDec()
-
-        // compile the tasks/workflows from bottom to top.
-        var allCallables = Map.empty[String, IR.Callable]
-        var allCallablesSorted = Vector.empty[IR.Callable]
-
-        // Only the toplevel workflow may be unlocked. This happens
-        // only if the user specifically compiles it as "unlocked".
-        def isLocked(callable: Callable): Boolean = {
-            (callable, womBundle.primaryCallable) match {
-                case (wf: WorkflowDefinition, Some(wf2: WorkflowDefinition)) =>
-                    if (wf.name == wf2.name)
-                        locked
-                    else
-                        true
-                case (_, _) =>
-                    true
-            }
-        }
-
-        for (callable <- depOrder) {
-            val (exec, auxCallables) = compileCallable(callable,
-                                                       womBundle.typeAliases,
-                                                       taskDir,
-                                                       workflowDir,
-                                                       allCallables,
-                                                       language,
-                                                       isLocked(callable),
-                                                       reorg)
-            allCallables = allCallables ++ (auxCallables.map{ apl => apl.name -> apl}.toMap)
-            allCallables = allCallables + (exec.name -> exec)
-
-            // Add the auxiliary applets while preserving the dependency order
-            allCallablesSorted = allCallablesSorted ++ auxCallables :+ exec
-        }
-
-        // There could be duplicates, remove them here
-        allCallablesSorted = allCallablesSorted.distinct
-
-        // We already compiled all the individual wdl:tasks and
-        // wdl:workflows, let's find the entrypoint.
-        val primary = womBundle.primaryCallable.map{ callable =>
-            allCallables(Utils.getUnqualifiedName(callable.name))
-        }
-        val allCallablesSortedNames = allCallablesSorted.map{_.name}
-        Utils.trace(verbose.on, s"allCallables=${allCallables.map(_._1)}")
-        Utils.trace(verbose.on, s"allCallablesSorted=${allCallablesSortedNames}")
-        assert(allCallables.size == allCallablesSortedNames.size)
-
-        Utils.traceLevelDec()
-        IR.Bundle(primary, allCallables, allCallablesSortedNames, womBundle.typeAliases)
+    // Only the toplevel workflow may be unlocked. This happens
+    // only if the user specifically compiles it as "unlocked".
+    def isLocked(callable: Callable): Boolean = {
+      (callable, womBundle.primaryCallable) match {
+        case (wf: WorkflowDefinition, Some(wf2: WorkflowDefinition)) =>
+          if (wf.name == wf2.name)
+            locked
+          else
+            true
+        case (_, _) =>
+          true
+      }
     }
+
+    for (callable <- depOrder) {
+      val (exec, auxCallables) = compileCallable(
+        callable,
+        womBundle.typeAliases,
+        taskDir,
+        workflowDir,
+        allCallables,
+        language,
+        isLocked(callable),
+        reorg
+      )
+      allCallables = allCallables ++ (auxCallables.map { apl =>
+        apl.name -> apl
+      }.toMap)
+      allCallables = allCallables + (exec.name -> exec)
+
+      // Add the auxiliary applets while preserving the dependency order
+      allCallablesSorted = allCallablesSorted ++ auxCallables :+ exec
+    }
+
+    // There could be duplicates, remove them here
+    allCallablesSorted = allCallablesSorted.distinct
+
+    // We already compiled all the individual wdl:tasks and
+    // wdl:workflows, let's find the entrypoint.
+    val primary = womBundle.primaryCallable.map { callable =>
+      allCallables(Utils.getUnqualifiedName(callable.name))
+    }
+    val allCallablesSortedNames = allCallablesSorted.map { _.name }
+    Utils.trace(verbose.on, s"allCallables=${allCallables.map(_._1)}")
+    Utils.trace(verbose.on, s"allCallablesSorted=${allCallablesSortedNames}")
+    assert(allCallables.size == allCallablesSortedNames.size)
+
+    Utils.traceLevelDec()
+    IR.Bundle(primary, allCallables, allCallablesSortedNames, womBundle.typeAliases)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -215,7 +215,7 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
     Utils.traceLevelDec()
 
     // compile the tasks/workflows from bottom to top.
-    var allCallables       = Map.empty[String, IR.Callable]
+    var allCallables = Map.empty[String, IR.Callable]
     var allCallablesSorted = Vector.empty[IR.Callable]
 
     // Only the toplevel workflow may be unlocked. This happens

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -44,14 +44,19 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
               Utils.getUnqualifiedName(cNode.callable.name)
           }.toSet
         case other =>
-          throw new Exception(s"Don't know how to deal with class ${other.getClass.getSimpleName}")
+          throw new Exception(
+            s"Don't know how to deal with class ${other.getClass.getSimpleName}"
+          )
       }
       Utils.getUnqualifiedName(callable.name) -> deps
     }.toMap
 
     // Find executables such that all of their dependencies are
     // satisfied. These can be compiled.
-    def next(callables: Vector[Callable], ready: Vector[Callable]): Vector[Callable] = {
+    def next(
+        callables: Vector[Callable],
+        ready: Vector[Callable]
+    ): Vector[Callable] = {
       val readyNames = ready.map(_.name).toSet
       val satisfiedCallables = callables.filter { c =>
         val deps = immediateDeps(c.name)
@@ -64,12 +69,14 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
           name -> (immediateDeps(name) -- readyNames)
         }.toMap
         val explanationLines = stuckWaitingOn.mkString("\n")
-        throw new Exception(s"""|Sanity: cannot find the next callable to compile.
+        throw new Exception(
+          s"""|Sanity: cannot find the next callable to compile.
                                         |ready = ${readyNames}
                                         |stuck = ${stuck}
                                         |stuckWaitingOn =
                                         |${explanationLines}
-                                        |""".stripMargin)
+                                        |""".stripMargin
+        )
       }
       satisfiedCallables
     }
@@ -100,7 +107,8 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
       reorg: Either[Boolean, ReorgAttrs]
   ): (IR.Workflow, Vector[IR.Callable]) = {
     // sort from low to high according to the source lines.
-    val callsLoToHi = ParseWomSourceFile(verbose.on).scanForCalls(wf.innerGraph, wfSource)
+    val callsLoToHi =
+      ParseWomSourceFile(verbose.on).scanForCalls(wf.innerGraph, wfSource)
 
     // Make a list of all task/workflow calls made inside the block. We will need to link
     // to the equivalent dx:applets and dx:workflows.
@@ -111,9 +119,12 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
           // wdl to internal workflows.
           val localName = Utils.getUnqualifiedName(cNode.callable.name)
           if (localName.startsWith("Scatter"))
-            throw new Exception("""|The workflow contains a nested scatter, it is not
+            throw new Exception(
+              """|The workflow contains a nested scatter, it is not
                                                |handled currently due to a cromwell WOM library issue
-                                               |""".stripMargin.replaceAll("\n", " "))
+                                               |""".stripMargin
+                .replaceAll("\n", " ")
+            )
           callables(localName)
         case cNode: CallNode =>
           val localname = Utils.getUnqualifiedName(cNode.callable.name)
@@ -168,12 +179,22 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
           case None =>
             throw new Exception(s"Did not find sources for workflow ${wf.name}")
           case Some(wfSource) =>
-            compileWorkflow(wf, typeAliases, wfSource, callables, language, locked, reorg)
+            compileWorkflow(
+              wf,
+              typeAliases,
+              wfSource,
+              callables,
+              language,
+              locked,
+              reorg
+            )
         }
       case x =>
-        throw new Exception(s"""|Can't compile: ${callable.name}, class=${callable.getClass}
+        throw new Exception(
+          s"""|Can't compile: ${callable.name}, class=${callable.getClass}
                                         |${x}
-                                        |""".stripMargin.replaceAll("\n", " "))
+                                        |""".stripMargin.replaceAll("\n", " ")
+        )
     }
   }
 
@@ -208,9 +229,14 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
             accu + (wfName -> wfSource)
         }
     }
-    Utils.trace(verbose.on, s"sortByDependencies ${womBundle.allCallables.values.map { _.name }}")
+    Utils.trace(
+      verbose.on,
+      s"sortByDependencies ${womBundle.allCallables.values.map { _.name }}"
+    )
     Utils.traceLevelInc()
-    val depOrder: Vector[Callable] = sortByDependencies(womBundle.allCallables.values.toVector)
+    val depOrder: Vector[Callable] = sortByDependencies(
+      womBundle.allCallables.values.toVector
+    )
     Utils.trace(verbose.on, s"depOrder =${depOrder.map { _.name }}")
     Utils.traceLevelDec()
 
@@ -266,6 +292,11 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
     assert(allCallables.size == allCallablesSortedNames.size)
 
     Utils.traceLevelDec()
-    IR.Bundle(primary, allCallables, allCallablesSortedNames, womBundle.typeAliases)
+    IR.Bundle(
+      primary,
+      allCallables,
+      allCallablesSortedNames,
+      womBundle.typeAliases
+    )
   }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -45,7 +45,7 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
           }.toSet
         case other =>
           throw new Exception(
-            s"Don't know how to deal with class ${other.getClass.getSimpleName}"
+              s"Don't know how to deal with class ${other.getClass.getSimpleName}"
           )
       }
       Utils.getUnqualifiedName(callable.name) -> deps
@@ -70,7 +70,7 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
         }.toMap
         val explanationLines = stuckWaitingOn.mkString("\n")
         throw new Exception(
-          s"""|Sanity: cannot find the next callable to compile.
+            s"""|Sanity: cannot find the next callable to compile.
                                         |ready = ${readyNames}
                                         |stuck = ${stuck}
                                         |stuckWaitingOn =
@@ -120,10 +120,10 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
           val localName = Utils.getUnqualifiedName(cNode.callable.name)
           if (localName.startsWith("Scatter"))
             throw new Exception(
-              """|The workflow contains a nested scatter, it is not
+                """|The workflow contains a nested scatter, it is not
                                                |handled currently due to a cromwell WOM library issue
                                                |""".stripMargin
-                .replaceAll("\n", " ")
+                  .replaceAll("\n", " ")
             )
           callables(localName)
         case cNode: CallNode =>
@@ -136,15 +136,15 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
         .standAloneWorkflow(wfSource, callablesUsedInWorkflow)
 
     val gir = new GenerateIRWorkflow(
-      wf,
-      wfSource,
-      wfSourceStandAlone,
-      callsLoToHi,
-      callables,
-      language,
-      verbose,
-      locked,
-      reorg
+        wf,
+        wfSource,
+        wfSourceStandAlone,
+        callsLoToHi,
+        callables,
+        language,
+        verbose,
+        locked,
+        reorg
     )
     gir.apply()
   }
@@ -180,18 +180,18 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
             throw new Exception(s"Did not find sources for workflow ${wf.name}")
           case Some(wfSource) =>
             compileWorkflow(
-              wf,
-              typeAliases,
-              wfSource,
-              callables,
-              language,
-              locked,
-              reorg
+                wf,
+                typeAliases,
+                wfSource,
+                callables,
+                language,
+                locked,
+                reorg
             )
         }
       case x =>
         throw new Exception(
-          s"""|Can't compile: ${callable.name}, class=${callable.getClass}
+            s"""|Can't compile: ${callable.name}, class=${callable.getClass}
                                         |${x}
                                         |""".stripMargin.replaceAll("\n", " ")
         )
@@ -230,12 +230,12 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
         }
     }
     Utils.trace(
-      verbose.on,
-      s"sortByDependencies ${womBundle.allCallables.values.map { _.name }}"
+        verbose.on,
+        s"sortByDependencies ${womBundle.allCallables.values.map { _.name }}"
     )
     Utils.traceLevelInc()
     val depOrder: Vector[Callable] = sortByDependencies(
-      womBundle.allCallables.values.toVector
+        womBundle.allCallables.values.toVector
     )
     Utils.trace(verbose.on, s"depOrder =${depOrder.map { _.name }}")
     Utils.traceLevelDec()
@@ -260,14 +260,14 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
 
     for (callable <- depOrder) {
       val (exec, auxCallables) = compileCallable(
-        callable,
-        womBundle.typeAliases,
-        taskDir,
-        workflowDir,
-        allCallables,
-        language,
-        isLocked(callable),
-        reorg
+          callable,
+          womBundle.typeAliases,
+          taskDir,
+          workflowDir,
+          allCallables,
+          language,
+          isLocked(callable),
+          reorg
       )
       allCallables = allCallables ++ (auxCallables.map { apl =>
         apl.name -> apl
@@ -293,10 +293,10 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
 
     Utils.traceLevelDec()
     IR.Bundle(
-      primary,
-      allCallables,
-      allCallablesSortedNames,
-      womBundle.typeAliases
+        primary,
+        allCallables,
+        allCallablesSortedNames,
+        womBundle.typeAliases
     )
   }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -51,11 +51,11 @@ case class GenerateIRTask(
 
     try {
       val dxInstanceType = evalAttr("dx_instance_type")
-      val memory         = evalAttr("memory")
-      val diskSpace      = evalAttr("disks")
-      val cores          = evalAttr("cpu")
-      val gpu            = evalAttr("gpu")
-      val iTypeDesc      = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
+      val memory = evalAttr("memory")
+      val diskSpace = evalAttr("disks")
+      val cores = evalAttr("cpu")
+      val gpu = evalAttr("gpu")
+      val iTypeDesc = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
       IR.InstanceTypeConst(
         iTypeDesc.dxInstanceType,
         iTypeDesc.memoryMB,

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -45,8 +45,8 @@ case class GenerateIRTask(
         case Some(expr) =>
           val result: ErrorOr[WomValue] =
             expr.evaluateValue(
-              Map.empty[String, WomValue],
-              wom.expression.NoIoFunctionSet
+                Map.empty[String, WomValue],
+                wom.expression.NoIoFunctionSet
             )
           result match {
             case Invalid(_)         => throw new DynamicInstanceTypesException()
@@ -64,11 +64,11 @@ case class GenerateIRTask(
       val iTypeDesc =
         InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
       IR.InstanceTypeConst(
-        iTypeDesc.dxInstanceType,
-        iTypeDesc.memoryMB,
-        iTypeDesc.diskGB,
-        iTypeDesc.cpu,
-        iTypeDesc.gpu
+          iTypeDesc.dxInstanceType,
+          iTypeDesc.memoryMB,
+          iTypeDesc.diskGB,
+          iTypeDesc.cpu,
+          iTypeDesc.gpu
       )
     } catch {
       case e: DynamicInstanceTypesException =>
@@ -165,7 +165,7 @@ case class GenerateIRTask(
           // make sure the runtime block is empty
           if (!task.runtimeAttributes.attributes.isEmpty)
             throw new Exception(
-              s"Native task ${task.name} should have an empty runtime block"
+                s"Native task ${task.name} should have an empty runtime block"
             )
           IR.AppletKindNative(id)
         case (_, _) =>
@@ -175,7 +175,7 @@ case class GenerateIRTask(
 
     // Figure out if we need to use docker
     val docker = triageDockerImage(
-      task.runtimeAttributes.attributes.get("docker")
+        task.runtimeAttributes.attributes.get("docker")
     )
 
     val taskCleanedSourceCode = docker match {
@@ -191,7 +191,7 @@ case class GenerateIRTask(
     }
     val WdlCodeSnippet(selfContainedSourceCode) =
       WdlCodeGen(verbose, typeAliases, language).standAloneTask(
-        taskCleanedSourceCode
+          taskCleanedSourceCode
       )
 
     val dockerFinal = docker match {
@@ -206,13 +206,13 @@ case class GenerateIRTask(
       case other => other
     }
     IR.Applet(
-      task.name,
-      inputs,
-      outputs,
-      instanceType,
-      dockerFinal,
-      kind,
-      selfContainedSourceCode
+        task.name,
+        inputs,
+        outputs,
+        instanceType,
+        dockerFinal,
+        kind,
+        selfContainedSourceCode
     )
   }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -14,172 +14,174 @@ import dxWDL.dx._
 import dxWDL.util._
 import IR.CVar
 
-case class GenerateIRTask(verbose: Verbose,
-                          typeAliases: Map[String, WomType],
-                          language: Language.Value,
-                          defaultRuntimeAttrs : WdlRuntimeAttrs) {
-    val verbose2 : Boolean = verbose.containsKey("GenerateIR")
+case class GenerateIRTask(
+    verbose: Verbose,
+    typeAliases: Map[String, WomType],
+    language: Language.Value,
+    defaultRuntimeAttrs: WdlRuntimeAttrs
+) {
+  val verbose2: Boolean = verbose.containsKey("GenerateIR")
 
-    private class DynamicInstanceTypesException private(ex: Exception) extends RuntimeException(ex) {
-        def this() = this(new RuntimeException("Runtime instance type calculation required"))
+  private class DynamicInstanceTypesException private (ex: Exception) extends RuntimeException(ex) {
+    def this() = this(new RuntimeException("Runtime instance type calculation required"))
+  }
+
+  // Figure out which instance to use.
+  //
+  // Extract three fields from the task:
+  // RAM, disk space, and number of cores. These are WDL expressions
+  // that, in the general case, could be calculated only at runtime.
+  // At compile time, constants expressions are handled. Some can
+  // only be evaluated at runtime.
+  private def calcInstanceType(task: CallableTaskDefinition): IR.InstanceType = {
+    def evalAttr(attrName: String): Option[WomValue] = {
+      task.runtimeAttributes.attributes.get(attrName) match {
+        case None =>
+          // Check the overall defaults, there might be a setting over there
+          defaultRuntimeAttrs.m.get(attrName)
+        case Some(expr) =>
+          val result: ErrorOr[WomValue] =
+            expr.evaluateValue(Map.empty[String, WomValue], wom.expression.NoIoFunctionSet)
+          result match {
+            case Invalid(_)         => throw new DynamicInstanceTypesException()
+            case Valid(x: WomValue) => Some(x)
+          }
+      }
     }
 
-    // Figure out which instance to use.
-    //
-    // Extract three fields from the task:
-    // RAM, disk space, and number of cores. These are WDL expressions
-    // that, in the general case, could be calculated only at runtime.
-    // At compile time, constants expressions are handled. Some can
-    // only be evaluated at runtime.
-    private def calcInstanceType(task: CallableTaskDefinition) : IR.InstanceType = {
-        def evalAttr(attrName: String) : Option[WomValue] = {
-            task.runtimeAttributes.attributes.get(attrName) match {
-                case None =>
-                    // Check the overall defaults, there might be a setting over there
-                    defaultRuntimeAttrs.m.get(attrName)
-                case Some(expr) =>
-                    val result: ErrorOr[WomValue] =
-                        expr.evaluateValue(Map.empty[String, WomValue], wom.expression.NoIoFunctionSet)
-                    result match {
-                        case Invalid(_) => throw new DynamicInstanceTypesException()
-                        case Valid(x: WomValue) => Some(x)
-                    }
-            }
-        }
-
-        try {
-            val dxInstanceType = evalAttr("dx_instance_type")
-            val memory = evalAttr("memory")
-            val diskSpace = evalAttr("disks")
-            val cores = evalAttr("cpu")
-            val gpu = evalAttr("gpu")
-            val iTypeDesc = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
-            IR.InstanceTypeConst(iTypeDesc.dxInstanceType,
-                                 iTypeDesc.memoryMB,
-                                 iTypeDesc.diskGB,
-                                 iTypeDesc.cpu,
-                                 iTypeDesc.gpu)
-        } catch {
-            case e : DynamicInstanceTypesException =>
-                // The generated code will need to calculate the instance type at runtime
-                IR.InstanceTypeRuntime
-        }
+    try {
+      val dxInstanceType = evalAttr("dx_instance_type")
+      val memory         = evalAttr("memory")
+      val diskSpace      = evalAttr("disks")
+      val cores          = evalAttr("cpu")
+      val gpu            = evalAttr("gpu")
+      val iTypeDesc      = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
+      IR.InstanceTypeConst(
+        iTypeDesc.dxInstanceType,
+        iTypeDesc.memoryMB,
+        iTypeDesc.diskGB,
+        iTypeDesc.cpu,
+        iTypeDesc.gpu
+      )
+    } catch {
+      case e: DynamicInstanceTypesException =>
+        // The generated code will need to calculate the instance type at runtime
+        IR.InstanceTypeRuntime
     }
+  }
 
-
-    // Process a docker image, if there is one
-    def triageDockerImage(dockerExpr : Option[WomExpression]) : IR.DockerImage = {
-        dockerExpr match {
-            case None =>
-                IR.DockerImageNone
-            case Some(expr) if WomValueAnalysis.isExpressionConst(WomStringType, expr) =>
-                val wdlConst = WomValueAnalysis.evalConst(WomStringType, expr)
-                wdlConst match {
-                    case WomString(url) if url.startsWith(Utils.DX_URL_PREFIX) =>
-                        // A constant image specified with a DX URL
-                        val dxfile = DxPath.resolveDxURLFile(url)
-                        IR.DockerImageDxFile(url, dxfile)
-                    case _ =>
-                        // Probably a public docker image
-                        IR.DockerImageNetwork
-                }
-            case _ =>
-                // Image will be downloaded from the network
-                IR.DockerImageNetwork
+  // Process a docker image, if there is one
+  def triageDockerImage(dockerExpr: Option[WomExpression]): IR.DockerImage = {
+    dockerExpr match {
+      case None =>
+        IR.DockerImageNone
+      case Some(expr) if WomValueAnalysis.isExpressionConst(WomStringType, expr) =>
+        val wdlConst = WomValueAnalysis.evalConst(WomStringType, expr)
+        wdlConst match {
+          case WomString(url) if url.startsWith(Utils.DX_URL_PREFIX) =>
+            // A constant image specified with a DX URL
+            val dxfile = DxPath.resolveDxURLFile(url)
+            IR.DockerImageDxFile(url, dxfile)
+          case _ =>
+            // Probably a public docker image
+            IR.DockerImageNetwork
         }
+      case _ =>
+        // Image will be downloaded from the network
+        IR.DockerImageNetwork
     }
+  }
 
-    // Compile a WDL task into an applet.
-    //
-    // Note: check if a task is a real WDL task, or if it is a wrapper for a
-    // native applet.
-    def apply(task : CallableTaskDefinition,
-              taskSourceCode: String) : IR.Applet = {
-        Utils.trace(verbose.on, s"Compiling task ${task.name}")
+  // Compile a WDL task into an applet.
+  //
+  // Note: check if a task is a real WDL task, or if it is a wrapper for a
+  // native applet.
+  def apply(task: CallableTaskDefinition, taskSourceCode: String): IR.Applet = {
+    Utils.trace(verbose.on, s"Compiling task ${task.name}")
 
-        // create dx:applet input definitions. Note, some "inputs" are
-        // actually expressions.
-        val inputs: Vector[CVar] = task.inputs.flatMap{
-            case RequiredInputDefinition(iName, womType, _, _) =>
-                Some(CVar(iName.value, womType, None))
+    // create dx:applet input definitions. Note, some "inputs" are
+    // actually expressions.
+    val inputs: Vector[CVar] = task.inputs.flatMap {
+      case RequiredInputDefinition(iName, womType, _, _) =>
+        Some(CVar(iName.value, womType, None))
 
-            case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                WomValueAnalysis.ifConstEval(womType, defaultExpr) match {
-                    case None =>
-                        // This is a task "input" of the form:
-                        //    Int y = x + 3
-                        // We consider it an expression, and not an input. The
-                        // runtime system will evaluate it.
-                        None
-                    case Some(value) =>
-                        Some(CVar(iName.value, womType, Some(value)))
-                }
-
-            // An input whose value should always be calculated from the default, and is
-            // not allowed to be overridden.
-            case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                None
-
-            case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
-                Some(CVar(iName.value, WomOptionalType(womType), None))
-        }.toVector
-
-        // create dx:applet outputs
-        val outputs : Vector[CVar] = task.outputs.map{
-            case OutputDefinition(id, womType, expr) =>
-                val defaultValue = WomValueAnalysis.ifConstEval(womType, expr) match {
-                    case None =>
-                        // This is an expression to be evaluated at runtime
-                        None
-                    case Some(value) =>
-                        // A constant, we can assign it now.
-                        Some(value)
-                }
-                CVar(id.value, womType, defaultValue)
-        }.toVector
-
-        val instanceType = calcInstanceType(task)
-
-        val kind =
-            (task.meta.get("type"), task.meta.get("id")) match {
-                case (Some(MetaValueElementString("native")), Some(MetaValueElementString(id))) =>
-                    // wrapper for a native applet.
-                    // make sure the runtime block is empty
-                    if (!task.runtimeAttributes.attributes.isEmpty)
-                        throw new Exception(s"Native task ${task.name} should have an empty runtime block")
-                    IR.AppletKindNative(id)
-                case (_,_) =>
-                    // a WDL task
-                    IR.AppletKindTask(task)
-            }
-
-        // Figure out if we need to use docker
-        val docker = triageDockerImage(task.runtimeAttributes.attributes.get("docker"))
-
-        val taskCleanedSourceCode = docker match {
-            case IR.DockerImageDxFile(orgURL, dxFile) =>
-                // The docker container is on the platform, we need to remove
-                // the dxURLs in the runtime section, to avoid a runtime
-                // lookup. For example:
-                //
-                //   dx://dxWDL_playground:/glnexus_internal  ->   dx://project-xxxx:record-yyyy
-                val dxURL = DxUtils.dxDataObjectToURL(dxFile)
-                taskSourceCode.replaceAll(orgURL, dxURL)
-            case _ => taskSourceCode
+      case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        WomValueAnalysis.ifConstEval(womType, defaultExpr) match {
+          case None =>
+            // This is a task "input" of the form:
+            //    Int y = x + 3
+            // We consider it an expression, and not an input. The
+            // runtime system will evaluate it.
+            None
+          case Some(value) =>
+            Some(CVar(iName.value, womType, Some(value)))
         }
-        val WdlCodeSnippet(selfContainedSourceCode) =
-            WdlCodeGen(verbose, typeAliases, language).standAloneTask(taskCleanedSourceCode)
 
-        val dockerFinal = docker match {
-            case IR.DockerImageNone =>
-                // No docker image was specified, but there might be one in the
-                // overall defaults
-                defaultRuntimeAttrs.m.get("docker") match {
-                    case None => IR.DockerImageNone
-                    case Some(wValue) => triageDockerImage(Some(ValueAsAnExpression(wValue)))
-                }
-            case other => other
+      // An input whose value should always be calculated from the default, and is
+      // not allowed to be overridden.
+      case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        None
+
+      case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
+        Some(CVar(iName.value, WomOptionalType(womType), None))
+    }.toVector
+
+    // create dx:applet outputs
+    val outputs: Vector[CVar] = task.outputs.map {
+      case OutputDefinition(id, womType, expr) =>
+        val defaultValue = WomValueAnalysis.ifConstEval(womType, expr) match {
+          case None =>
+            // This is an expression to be evaluated at runtime
+            None
+          case Some(value) =>
+            // A constant, we can assign it now.
+            Some(value)
         }
-        IR.Applet(task.name, inputs, outputs, instanceType, dockerFinal, kind, selfContainedSourceCode)
+        CVar(id.value, womType, defaultValue)
+    }.toVector
+
+    val instanceType = calcInstanceType(task)
+
+    val kind =
+      (task.meta.get("type"), task.meta.get("id")) match {
+        case (Some(MetaValueElementString("native")), Some(MetaValueElementString(id))) =>
+          // wrapper for a native applet.
+          // make sure the runtime block is empty
+          if (!task.runtimeAttributes.attributes.isEmpty)
+            throw new Exception(s"Native task ${task.name} should have an empty runtime block")
+          IR.AppletKindNative(id)
+        case (_, _) =>
+          // a WDL task
+          IR.AppletKindTask(task)
+      }
+
+    // Figure out if we need to use docker
+    val docker = triageDockerImage(task.runtimeAttributes.attributes.get("docker"))
+
+    val taskCleanedSourceCode = docker match {
+      case IR.DockerImageDxFile(orgURL, dxFile) =>
+        // The docker container is on the platform, we need to remove
+        // the dxURLs in the runtime section, to avoid a runtime
+        // lookup. For example:
+        //
+        //   dx://dxWDL_playground:/glnexus_internal  ->   dx://project-xxxx:record-yyyy
+        val dxURL = DxUtils.dxDataObjectToURL(dxFile)
+        taskSourceCode.replaceAll(orgURL, dxURL)
+      case _ => taskSourceCode
     }
+    val WdlCodeSnippet(selfContainedSourceCode) =
+      WdlCodeGen(verbose, typeAliases, language).standAloneTask(taskCleanedSourceCode)
+
+    val dockerFinal = docker match {
+      case IR.DockerImageNone =>
+        // No docker image was specified, but there might be one in the
+        // overall defaults
+        defaultRuntimeAttrs.m.get("docker") match {
+          case None         => IR.DockerImageNone
+          case Some(wValue) => triageDockerImage(Some(ValueAsAnExpression(wValue)))
+        }
+      case other => other
+    }
+    IR.Applet(task.name, inputs, outputs, instanceType, dockerFinal, kind, selfContainedSourceCode)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
@@ -81,7 +81,7 @@ case class GenerateIRWorkflow(
           WomValueAnalysis.ifConstEval(womType, defaultExpr) match {
             case None =>
               throw new Exception(
-                s"""|default expression in input should be a constant
+                  s"""|default expression in input should be a constant
                             | ${input}
                             |""".stripMargin
               )
@@ -159,9 +159,9 @@ case class GenerateIRWorkflow(
           Utils.trace(verbose.on, s"""|env =
                                                 |${envDbg}""".stripMargin)
           throw new Exception(
-            s"""|input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
+              s"""|input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
                             |is unspecified. This is illegal in a locked workflow.""".stripMargin
-              .replaceAll("\n", " ")
+                .replaceAll("\n", " ")
           )
 
         case None =>
@@ -171,11 +171,11 @@ case class GenerateIRWorkflow(
 
         case Some(tcInput)
             if WomValueAnalysis.isExpressionConst(
-              cVar.womType,
-              tcInput.womExpression
+                cVar.womType,
+                tcInput.womExpression
             ) =>
           IR.SArgConst(
-            WomValueAnalysis.evalConst(cVar.womType, tcInput.womExpression)
+              WomValueAnalysis.evalConst(cVar.womType, tcInput.womExpression)
           )
 
         case Some(tcInput) =>
@@ -189,16 +189,16 @@ case class GenerateIRWorkflow(
                 }
                 .mkString("\n")
               Utils.trace(
-                verbose.on,
-                s"""|env =
+                  verbose.on,
+                  s"""|env =
                                                         |${envDbg}""".stripMargin
               )
               throw new Exception(
-                s"""|Internal compiler error.
+                  s"""|Internal compiler error.
                                     |
                                     |Input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
                                     |is missing from the environment.""".stripMargin
-                  .replaceAll("\n", " ")
+                    .replaceAll("\n", " ")
               )
             case Some(lVar) => lVar.sArg
           }
@@ -242,7 +242,7 @@ case class GenerateIRWorkflow(
                                             |${envDesc}
                                             |]""".stripMargin)
         throw new Exception(
-          s"Sanity: could not find ${source} in the workflow environment"
+            s"Sanity: could not find ${source} in the workflow environment"
         )
       case Some(lVar) => lVar.sArg
     }
@@ -263,8 +263,8 @@ case class GenerateIRWorkflow(
         if (!optional) {
           // A missing compulsory argument
           Utils.warning(
-            verbose,
-            s"Missing argument ${fqn}, it will have to be provided at runtime"
+              verbose,
+              s"Missing argument ${fqn}, it will have to be provided at runtime"
           )
         }
         None
@@ -363,22 +363,22 @@ case class GenerateIRWorkflow(
       val pathStr = blockPath.map(x => x.toString).mkString("_")
       val closureInputs = graphClosure(inputNodes, subBlocks)
       Utils.trace(
-        verbose.on,
-        s"""|compileNestedBlock
+          verbose.on,
+          s"""|compileNestedBlock
                                         |    inputNodes = ${inputNodes.map(
-             _.singleOutputPort
-           )}
+                 _.singleOutputPort
+             )}
                                         |    closureInputs= ${closureInputs}
                                         |""".stripMargin
       )
       val (subwf, auxCallables, _) = compileWorkflowLocked(
-        wfName + "_block_" + pathStr,
-        inputNodes,
-        closureInputs,
-        outputNodes,
-        blockPath,
-        subBlocks,
-        IR.Level.Sub
+          wfName + "_block_" + pathStr,
+          inputNodes,
+          closureInputs,
+          outputNodes,
+          blockPath,
+          subBlocks,
+          IR.Level.Sub
       )
       (subwf, auxCallables)
     }
@@ -476,13 +476,13 @@ case class GenerateIRWorkflow(
       }
 
     val applet = IR.Applet(
-      s"${wfName}_frag_${genFragId()}",
-      inputVars,
-      outputVars,
-      IR.InstanceTypeDefault,
-      IR.DockerImageNone,
-      IR.AppletKindWfFragment(innerCall.toVector, blockPath, fqnDictTypes),
-      wfSourceStandAlone
+        s"${wfName}_frag_${genFragId()}",
+        inputVars,
+        outputVars,
+        IR.InstanceTypeDefault,
+        IR.DockerImageNone,
+        IR.AppletKindWfFragment(innerCall.toVector, blockPath, fqnDictTypes),
+        wfSourceStandAlone
     )
 
     val sArgs: Vector[SArg] = closure.map {
@@ -490,8 +490,8 @@ case class GenerateIRWorkflow(
     }.toVector
 
     (
-      IR.Stage(stageName, genStageId(), applet.name, sArgs, outputVars),
-      auxCallables :+ applet
+        IR.Stage(stageName, genStageId(), applet.name, sArgs, outputVars),
+        auxCallables :+ applet
     )
   }
 
@@ -531,8 +531,8 @@ case class GenerateIRWorkflow(
           // is no need to do any extra work. Compile directly into a workflow
           // stage.
           Utils.trace(
-            verbose.on,
-            s"Compiling call ${call.callable.name} as stage"
+              verbose.on,
+              s"Compiling call ${call.callable.name} as stage"
           )
           val stage = compileCall(call, env, locked)
 
@@ -564,8 +564,8 @@ case class GenerateIRWorkflow(
       allStageInfo.foreach {
         case (stage, _) =>
           Utils.trace(
-            verbose2,
-            s"    ${stage.description}, ${stage.id.getId} -> callee=${stage.calleeName}"
+              verbose2,
+              s"    ${stage.description}, ${stage.id.getId} -> callee=${stage.calleeName}"
           )
       }
       Utils.trace(verbose2, "]")
@@ -591,7 +591,7 @@ case class GenerateIRWorkflow(
       case expr: ExpressionBasedGraphOutputNode =>
         // An expression that requires evaluation
         throw new Exception(
-          s"Internal error: non trivial expressions are handled elsewhere ${expr}"
+            s"Internal error: non trivial expressions are handled elsewhere ${expr}"
         )
       case other =>
         throw new Exception(s"unhandled output ${other}")
@@ -608,13 +608,13 @@ case class GenerateIRWorkflow(
     val outputVars: Vector[CVar] = inputVars
 
     val applet = IR.Applet(
-      s"${wfName}_${COMMON}",
-      inputVars,
-      outputVars,
-      IR.InstanceTypeDefault,
-      IR.DockerImageNone,
-      IR.AppletKindWfInputs,
-      wfSourceStandAlone
+        s"${wfName}_${COMMON}",
+        inputVars,
+        outputVars,
+        IR.InstanceTypeDefault,
+        IR.DockerImageNone,
+        IR.AppletKindWfInputs,
+        wfSourceStandAlone
     )
     Utils.trace(verbose.on, s"Compiling common applet ${applet.name}")
 
@@ -622,22 +622,22 @@ case class GenerateIRWorkflow(
       IR.SArgEmpty
     }.toVector
     (
-      IR.Stage(
-        COMMON,
-        genStageId(Some(COMMON)),
-        applet.name,
-        sArgs,
-        outputVars
-      ),
-      applet
+        IR.Stage(
+            COMMON,
+            genStageId(Some(COMMON)),
+            applet.name,
+            sArgs,
+            outputVars
+        ),
+        applet
     )
   }
 
   private def addOutputStatus(outputsVar: Vector[CVar]) = {
     outputsVar :+ CVar(
-      Utils.REORG_STATUS,
-      WomStringType,
-      Some(WomString(Utils.REORG_STATUS_COMPLETE))
+        Utils.REORG_STATUS,
+        WomStringType,
+        Some(WomString(Utils.REORG_STATUS_COMPLETE))
     )
   }
 
@@ -660,7 +660,7 @@ case class GenerateIRWorkflow(
       val lVar = env.find { case (key, _) => key == name } match {
         case None =>
           throw new Exception(
-            s"could not find variable ${name} in the environment"
+              s"could not find variable ${name} in the environment"
           )
         case Some((_, lVar)) => lVar
       }
@@ -696,25 +696,25 @@ case class GenerateIRWorkflow(
     }
 
     val applet = IR.Applet(
-      s"${wfName}_${OUTPUT_SECTION}",
-      inputVars.map(_.cVar),
-      updatedOutputVars,
-      IR.InstanceTypeDefault,
-      IR.DockerImageNone,
-      appletKind,
-      wfSourceStandAlone
+        s"${wfName}_${OUTPUT_SECTION}",
+        inputVars.map(_.cVar),
+        updatedOutputVars,
+        IR.InstanceTypeDefault,
+        IR.DockerImageNone,
+        appletKind,
+        wfSourceStandAlone
     )
 
     // define the extra stage we add to the workflow
     (
-      IR.Stage(
-        OUTPUT_SECTION,
-        genStageId(Some(OUTPUT_SECTION)),
-        applet.name,
-        inputVars.map(_.sArg),
-        updatedOutputVars
-      ),
-      applet
+        IR.Stage(
+            OUTPUT_SECTION,
+            genStageId(Some(OUTPUT_SECTION)),
+            applet.name,
+            inputVars.map(_.sArg),
+            updatedOutputVars
+        ),
+        applet
     )
   }
 
@@ -729,17 +729,17 @@ case class GenerateIRWorkflow(
   ): (IR.Stage, IR.Applet) = {
     // We need minimal compute resources, use the default instance type
     val applet = IR.Applet(
-      s"${wfName}_${REORG}",
-      wfOutputs.map { case (cVar, _) => cVar },
-      Vector.empty,
-      IR.InstanceTypeDefault,
-      IR.DockerImageNone,
-      IR.AppletKindWorkflowOutputReorg,
-      wfSourceStandAlone
+        s"${wfName}_${REORG}",
+        wfOutputs.map { case (cVar, _) => cVar },
+        Vector.empty,
+        IR.InstanceTypeDefault,
+        IR.DockerImageNone,
+        IR.AppletKindWorkflowOutputReorg,
+        wfSourceStandAlone
     )
     Utils.trace(
-      verbose.on,
-      s"Compiling output reorganization applet ${applet.name}"
+        verbose.on,
+        s"Compiling output reorganization applet ${applet.name}"
     )
 
     // Link to the X.y original variables
@@ -747,14 +747,14 @@ case class GenerateIRWorkflow(
       .toVector
 
     (
-      IR.Stage(
-        REORG,
-        genStageId(Some(REORG)),
-        applet.name,
-        inputs,
-        Vector.empty[CVar]
-      ),
-      applet
+        IR.Stage(
+            REORG,
+            genStageId(Some(REORG)),
+            applet.name,
+            inputs,
+            Vector.empty[CVar]
+        ),
+        applet
     )
   }
 
@@ -778,23 +778,23 @@ case class GenerateIRWorkflow(
     }
 
     val appInputs = Vector(
-      reorgStatusCvar,
-      CVar(Utils.REORG_CONFIG, WomSingleFileType, configFile)
+        reorgStatusCvar,
+        CVar(Utils.REORG_CONFIG, WomSingleFileType, configFile)
     )
 
     val applet = IR.Applet(
-      reorgAttributes.appId,
-      appInputs,
-      Vector.empty,
-      IR.InstanceTypeDefault,
-      IR.DockerImageNone,
-      appletKind,
-      wfSourceStandAlone
+        reorgAttributes.appId,
+        appInputs,
+        Vector.empty,
+        IR.InstanceTypeDefault,
+        IR.DockerImageNone,
+        appletKind,
+        wfSourceStandAlone
     )
 
     Utils.trace(
-      verbose.on,
-      s"Adding custom output reorganization applet ${reorgAttributes.appId}"
+        verbose.on,
+        s"Adding custom output reorganization applet ${reorgAttributes.appId}"
     )
 
     // Link to the X.y original variables
@@ -805,14 +805,14 @@ case class GenerateIRWorkflow(
     }
 
     (
-      IR.Stage(
-        REORG,
-        genStageId(Some(REORG)),
-        applet.name,
-        inputs,
-        Vector.empty[CVar]
-      ),
-      applet
+        IR.Stage(
+            REORG,
+            genStageId(Some(REORG)),
+            applet.name,
+            inputs,
+            Vector.empty[CVar]
+        ),
+        applet
     )
   }
 
@@ -876,13 +876,13 @@ case class GenerateIRWorkflow(
         outputNodes.map(node => buildSimpleWorkflowOutput(node, env)).toVector
       val irwf =
         IR.Workflow(
-          wfName,
-          allWfInputs,
-          simpleWfOutputs,
-          stages,
-          wfSourceCode,
-          true,
-          level
+            wfName,
+            allWfInputs,
+            simpleWfOutputs,
+            stages,
+            wfSourceCode,
+            true,
+            level
         )
       (irwf, auxCallables.flatten, simpleWfOutputs)
     } else {
@@ -894,13 +894,13 @@ case class GenerateIRWorkflow(
         (cVar, IR.SArgLink(outputStage.id, cVar))
       }
       val irwf = IR.Workflow(
-        wfName,
-        allWfInputs,
-        wfOutputs,
-        stages :+ outputStage,
-        wfSourceCode,
-        true,
-        level
+          wfName,
+          allWfInputs,
+          wfOutputs,
+          stages :+ outputStage,
+          wfSourceCode,
+          true,
+          level
       )
       (irwf, auxCallables.flatten :+ outputApplet, wfOutputs)
     }
@@ -942,13 +942,13 @@ case class GenerateIRWorkflow(
       (cVar, IR.SArgLink(outputStage.id, cVar))
     }
     val irwf = IR.Workflow(
-      wf.name,
-      wfInputs.toVector,
-      wfOutputs.toVector,
-      commonStg +: stages :+ outputStage,
-      wfSourceCode,
-      false,
-      IR.Level.Top
+        wf.name,
+        wfInputs.toVector,
+        wfOutputs.toVector,
+        commonStg +: stages :+ outputStage,
+        wfSourceCode,
+        false,
+        IR.Level.Top
     )
     (irwf, commonApplet +: auxCallables.flatten :+ outputApplet, wfOutputs)
   }
@@ -967,13 +967,13 @@ case class GenerateIRWorkflow(
     val (irwf, irCallables, wfOutputs) =
       if (locked) {
         compileWorkflowLocked(
-          wf.name,
-          inputNodes,
-          Map.empty,
-          outputNodes,
-          Vector.empty,
-          subBlocks,
-          IR.Level.Top
+            wf.name,
+            inputNodes,
+            Map.empty,
+            outputNodes,
+            Vector.empty,
+            subBlocks,
+            IR.Level.Top
         )
       } else {
         compileWorkflowRegular(inputNodes, outputNodes, subBlocks)
@@ -986,8 +986,8 @@ case class GenerateIRWorkflow(
           val (reorgStage, reorgApl) =
             buildReorgStage(wf.name, wfSourceStandAlone, wfOutputs)
           (
-            irwf.copy(stages = irwf.stages :+ reorgStage),
-            irCallables :+ reorgApl
+              irwf.copy(stages = irwf.stages :+ reorgStage),
+              irCallables :+ reorgApl
           )
         } else {
           (irwf, irCallables)
@@ -1001,14 +1001,14 @@ case class GenerateIRWorkflow(
         if (!locked) {
           val (reorgStage, reorgApl) =
             addCustomReorgStage(
-              wf.name,
-              wfSourceStandAlone,
-              wfOutputs,
-              reorgAttributes
+                wf.name,
+                wfSourceStandAlone,
+                wfOutputs,
+                reorgAttributes
             )
           (
-            irwf.copy(stages = irwf.stages :+ reorgStage),
-            irCallables :+ reorgApl
+              irwf.copy(stages = irwf.stages :+ reorgStage),
+              irCallables :+ reorgApl
           )
         } else {
           (irwf, irCallables)

--- a/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
@@ -13,887 +13,936 @@ import dxWDL.dx._
 import dxWDL.util._
 import IR.{COMMON, CVar, OUTPUT_SECTION, REORG, SArg, SArgConst}
 
-case class GenerateIRWorkflow(wf: WorkflowDefinition,
-                              wfSourceCode: String,
-                              wfSourceStandAlone: String,
-                              callsLoToHi: Vector[String],
-                              callables: Map[String, IR.Callable],
-                              language: Language.Value,
-                              verbose: Verbose,
-                              locked: Boolean,
-                              reorg: Either[Boolean, ReorgAttrs]) {
-    val verbose2 : Boolean = verbose.containsKey("GenerateIR")
+case class GenerateIRWorkflow(
+    wf: WorkflowDefinition,
+    wfSourceCode: String,
+    wfSourceStandAlone: String,
+    callsLoToHi: Vector[String],
+    callables: Map[String, IR.Callable],
+    language: Language.Value,
+    verbose: Verbose,
+    locked: Boolean,
+    reorg: Either[Boolean, ReorgAttrs]
+) {
+  val verbose2: Boolean = verbose.containsKey("GenerateIR")
 
-    private case class LinkedVar(cVar: CVar, sArg: SArg)
-    private type CallEnv = Map[String, LinkedVar]
+  private case class LinkedVar(cVar: CVar, sArg: SArg)
+  private type CallEnv = Map[String, LinkedVar]
 
-    // generate a stage Id, this is a string of the form: 'stage-xxx'
-    private var stageNum = 0
-    private def genStageId(stageName: Option[String] = None) : DxWorkflowStage = {
-        stageName match {
-            case None =>
-                val retval = DxWorkflowStage(s"stage-${stageNum}")
-                stageNum += 1
-                retval
-            case Some(nm) =>
-                DxWorkflowStage(s"stage-${nm}")
-        }
+  // generate a stage Id, this is a string of the form: 'stage-xxx'
+  private var stageNum = 0
+  private def genStageId(stageName: Option[String] = None): DxWorkflowStage = {
+    stageName match {
+      case None =>
+        val retval = DxWorkflowStage(s"stage-${stageNum}")
+        stageNum += 1
+        retval
+      case Some(nm) =>
+        DxWorkflowStage(s"stage-${nm}")
     }
+  }
 
-    // create a unique name for a workflow fragment
-    private var fragNum = 0
-    private def genFragId() : String = {
-        fragNum += 1
-        fragNum.toString
-    }
+  // create a unique name for a workflow fragment
+  private var fragNum = 0
+  private def genFragId(): String = {
+    fragNum += 1
+    fragNum.toString
+  }
 
-    // Represent each workflow input with:
-    // 1. CVar, for type declarations
-    // 2. SVar, connecting it to the source of the input
-    //
-    // It is possible to provide a default value to a workflow input.
-    // For example:
-    // workflow w {
-    //   Int? x = 3
-    //   String s = "glasses"
-    //   ...
-    // }
-    // We handle only the case where the default is a constant.
-    def buildWorkflowInput(input: GraphInputNode) : CVar = {
-        input match {
-            case RequiredGraphInputNode(id, womType, nameInInputSet, valueMapper) =>
-                CVar(id.workflowLocalName, womType, None)
+  // Represent each workflow input with:
+  // 1. CVar, for type declarations
+  // 2. SVar, connecting it to the source of the input
+  //
+  // It is possible to provide a default value to a workflow input.
+  // For example:
+  // workflow w {
+  //   Int? x = 3
+  //   String s = "glasses"
+  //   ...
+  // }
+  // We handle only the case where the default is a constant.
+  def buildWorkflowInput(input: GraphInputNode): CVar = {
+    input match {
+      case RequiredGraphInputNode(id, womType, nameInInputSet, valueMapper) =>
+        CVar(id.workflowLocalName, womType, None)
 
-            case OptionalGraphInputNode(id, womType, nameInInputSet, valueMapper) =>
-                assert(womType.isInstanceOf[WomOptionalType])
-                CVar(id.workflowLocalName, womType, None)
+      case OptionalGraphInputNode(id, womType, nameInInputSet, valueMapper) =>
+        assert(womType.isInstanceOf[WomOptionalType])
+        CVar(id.workflowLocalName, womType, None)
 
-            case OptionalGraphInputNodeWithDefault(id, womType, defaultExpr : WomExpression,
-                                                   nameInInputSet, valueMapper) =>
-                val defaultValue: WomValue = WomValueAnalysis.ifConstEval(womType, defaultExpr) match {
-                    case None => throw new Exception(
-                        s"""|default expression in input should be a constant
+      case OptionalGraphInputNodeWithDefault(
+          id,
+          womType,
+          defaultExpr: WomExpression,
+          nameInInputSet,
+          valueMapper
+          ) =>
+        val defaultValue: WomValue = WomValueAnalysis.ifConstEval(womType, defaultExpr) match {
+          case None        => throw new Exception(s"""|default expression in input should be a constant
                             | ${input}
                             |""".stripMargin)
-                    case Some(value) => value
-                }
-                CVar(id.workflowLocalName, womType, Some(defaultValue))
-
-            case ScatterVariableNode(id, expression: ExpressionNode , womType) =>
-                CVar(id.workflowLocalName, womType, None)
-
-            case ogin : OuterGraphInputNode =>
-                val womType = ogin.linkToOuterGraph.womType
-                CVar(ogin.identifier.workflowLocalName, womType, None)
-
-            case other =>
-                throw new Exception(s"Unhandled type ${other.getClass}")
+          case Some(value) => value
         }
+        CVar(id.workflowLocalName, womType, Some(defaultValue))
+
+      case ScatterVariableNode(id, expression: ExpressionNode, womType) =>
+        CVar(id.workflowLocalName, womType, None)
+
+      case ogin: OuterGraphInputNode =>
+        val womType = ogin.linkToOuterGraph.womType
+        CVar(ogin.identifier.workflowLocalName, womType, None)
+
+      case other =>
+        throw new Exception(s"Unhandled type ${other.getClass}")
     }
+  }
 
-    // In a call like:
-    //   call lib.native_mk_list as mk_list {
-    //     input: a=x, b=5
-    //   }
-    // it maps callee input <a> to expression <x>. The expressions are
-    // trivial because this is a case where we can directly call an applet.
-    //
-    // Note that in an expression like:
-    //    call volume { input: i = 10 }
-    // the "i" parameter, under WDL draft-2, is compiled as "volume.i"
-    // under WDL version 1.0, it is compiled as "i"
-    //
-    private def findInputByName(callInputs: Seq[AnonymousExpressionNode],
-                                cVar: CVar) : Option[AnonymousExpressionNode] = {
-        val retval = callInputs.find{
-            case expr : AnonymousExpressionNode =>
-                //Utils.trace(verbose2, s"compare ${cVar.name} to ${expr.identifier.localName.value}")
-                cVar.name == Utils.getUnqualifiedName(expr.identifier.localName.value)
-        }
-        retval
+  // In a call like:
+  //   call lib.native_mk_list as mk_list {
+  //     input: a=x, b=5
+  //   }
+  // it maps callee input <a> to expression <x>. The expressions are
+  // trivial because this is a case where we can directly call an applet.
+  //
+  // Note that in an expression like:
+  //    call volume { input: i = 10 }
+  // the "i" parameter, under WDL draft-2, is compiled as "volume.i"
+  // under WDL version 1.0, it is compiled as "i"
+  //
+  private def findInputByName(
+      callInputs: Seq[AnonymousExpressionNode],
+      cVar: CVar
+  ): Option[AnonymousExpressionNode] = {
+    val retval = callInputs.find {
+      case expr: AnonymousExpressionNode =>
+        //Utils.trace(verbose2, s"compare ${cVar.name} to ${expr.identifier.localName.value}")
+        cVar.name == Utils.getUnqualifiedName(expr.identifier.localName.value)
     }
+    retval
+  }
 
-    // compile a call into a stage in an IR.Workflow
-    private def compileCall(call: CallNode,
-                            env : CallEnv,
-                            locked: Boolean) : IR.Stage = {
-        // Find the callee
-        val calleeName = Utils.getUnqualifiedName(call.callable.name)
-        val callee: IR.Callable = callables(calleeName)
-        val callInputs: Seq[AnonymousExpressionNode] = call.upstream.collect{
-            case tcExpr : AnonymousExpressionNode => tcExpr
-        }.toSeq
+  // compile a call into a stage in an IR.Workflow
+  private def compileCall(call: CallNode, env: CallEnv, locked: Boolean): IR.Stage = {
+    // Find the callee
+    val calleeName          = Utils.getUnqualifiedName(call.callable.name)
+    val callee: IR.Callable = callables(calleeName)
+    val callInputs: Seq[AnonymousExpressionNode] = call.upstream.collect {
+      case tcExpr: AnonymousExpressionNode => tcExpr
+    }.toSeq
 
-        // Extract the input values/links from the environment
-        val inputs: Vector[SArg] = callee.inputVars.map{ cVar =>
-            findInputByName(callInputs, cVar) match {
-                case None if Utils.isOptional(cVar.womType) =>
-                    // optional argument that is not provided
-                    IR.SArgEmpty
+    // Extract the input values/links from the environment
+    val inputs: Vector[SArg] = callee.inputVars.map { cVar =>
+      findInputByName(callInputs, cVar) match {
+        case None if Utils.isOptional(cVar.womType) =>
+          // optional argument that is not provided
+          IR.SArgEmpty
 
-                case None if cVar.default != None =>
-                    // argument that has a default, it can be omitted in the call
-                    IR.SArgEmpty
+        case None if cVar.default != None =>
+          // argument that has a default, it can be omitted in the call
+          IR.SArgEmpty
 
-                case None if locked =>
-                    val envDbg = env.map{ case (name, lVar) =>
-                        s"  ${name} -> ${lVar.sArg}"
-                    }.mkString("\n")
-                    Utils.trace(verbose.on, s"""|env =
+        case None if locked =>
+          val envDbg = env
+            .map {
+              case (name, lVar) =>
+                s"  ${name} -> ${lVar.sArg}"
+            }
+            .mkString("\n")
+          Utils.trace(verbose.on, s"""|env =
                                                 |${envDbg}""".stripMargin)
-                    throw new Exception(
-                        s"""|input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
-                            |is unspecified. This is illegal in a locked workflow.""".stripMargin.replaceAll("\n", " "))
+          throw new Exception(
+            s"""|input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
+                            |is unspecified. This is illegal in a locked workflow.""".stripMargin
+              .replaceAll("\n", " ")
+          )
 
-                case None =>
-                    // Perhaps the callee is not going to use the argument, lets not fail
-                    // right here, but leave it for runtime.
-                    IR.SArgEmpty
+        case None =>
+          // Perhaps the callee is not going to use the argument, lets not fail
+          // right here, but leave it for runtime.
+          IR.SArgEmpty
 
-                case Some(tcInput) if WomValueAnalysis.isExpressionConst(cVar.womType, tcInput.womExpression) =>
-                    IR.SArgConst(WomValueAnalysis.evalConst(cVar.womType, tcInput.womExpression))
+        case Some(tcInput)
+            if WomValueAnalysis.isExpressionConst(cVar.womType, tcInput.womExpression) =>
+          IR.SArgConst(WomValueAnalysis.evalConst(cVar.womType, tcInput.womExpression))
 
-                case Some(tcInput) =>
-                    val exprSourceString = tcInput.womExpression.sourceString
-                    env.get(exprSourceString) match {
-                        case None =>
-                            val envDbg = env.map{ case (name, lVar) =>
-                                s"  ${name} -> ${lVar.sArg}"
-                            }.mkString("\n")
-                            Utils.trace(verbose.on, s"""|env =
+        case Some(tcInput) =>
+          val exprSourceString = tcInput.womExpression.sourceString
+          env.get(exprSourceString) match {
+            case None =>
+              val envDbg = env
+                .map {
+                  case (name, lVar) =>
+                    s"  ${name} -> ${lVar.sArg}"
+                }
+                .mkString("\n")
+              Utils.trace(verbose.on, s"""|env =
                                                         |${envDbg}""".stripMargin)
-                            throw new Exception(
-                                s"""|Internal compiler error.
+              throw new Exception(
+                s"""|Internal compiler error.
                                     |
                                     |Input <${cVar.name}, ${cVar.womType}> to call <${call.fullyQualifiedName}>
-                                    |is missing from the environment."""
-                                    .stripMargin.replaceAll("\n", " "))
-                        case Some(lVar) => lVar.sArg
-                    }
-            }
-        }
-
-        val stageName = call.identifier.localName.value
-        IR.Stage(stageName, genStageId(), calleeName, inputs, callee.outputVars)
+                                    |is missing from the environment.""".stripMargin
+                  .replaceAll("\n", " ")
+              )
+            case Some(lVar) => lVar.sArg
+          }
+      }
     }
 
-    // Check if the environment has a variable with a binding for
-    // a fully-qualified name. For example, if fqn is "A.B.C", then
-    // look for "A.B.C", "A.B", or "A", in that order.
-    //
-    // If the environment has a pair "p", then we want to be able to
-    // to return "p" when looking for "p.left" or "p.right".
-    //
-    private def lookupInEnvInner(fqn: String, env: CallEnv) : Option[(String, LinkedVar)] = {
-        if (env contains fqn) {
-            // exact match
-            Some(fqn, env(fqn))
-        } else {
-            // A.B.C --> A.B
-            val pos = fqn.lastIndexOf(".")
-            if (pos < 0) None
-            else {
-                val lhs = fqn.substring(0, pos)
-                lookupInEnvInner(lhs, env)
-            }
-        }
-    }
+    val stageName = call.identifier.localName.value
+    IR.Stage(stageName, genStageId(), calleeName, inputs, callee.outputVars)
+  }
 
-    private def getSArgFromEnv(source: String,
-                               env: CallEnv) : SArg = {
-        env.get(source) match {
-            case None =>
-                val envDesc = env.mkString("\n")
-                Utils.trace(verbose.on, s"""|env=[
+  // Check if the environment has a variable with a binding for
+  // a fully-qualified name. For example, if fqn is "A.B.C", then
+  // look for "A.B.C", "A.B", or "A", in that order.
+  //
+  // If the environment has a pair "p", then we want to be able to
+  // to return "p" when looking for "p.left" or "p.right".
+  //
+  private def lookupInEnvInner(fqn: String, env: CallEnv): Option[(String, LinkedVar)] = {
+    if (env contains fqn) {
+      // exact match
+      Some(fqn, env(fqn))
+    } else {
+      // A.B.C --> A.B
+      val pos = fqn.lastIndexOf(".")
+      if (pos < 0) None
+      else {
+        val lhs = fqn.substring(0, pos)
+        lookupInEnvInner(lhs, env)
+      }
+    }
+  }
+
+  private def getSArgFromEnv(source: String, env: CallEnv): SArg = {
+    env.get(source) match {
+      case None =>
+        val envDesc = env.mkString("\n")
+        Utils.trace(verbose.on, s"""|env=[
                                             |${envDesc}
                                             |]""".stripMargin)
-                throw new Exception(s"Sanity: could not find ${source} in the workflow environment")
-            case Some(lVar) => lVar.sArg
+        throw new Exception(s"Sanity: could not find ${source} in the workflow environment")
+      case Some(lVar) => lVar.sArg
+    }
+  }
+
+  // Lookup in the environment. Provide a human readable error message
+  // if the fully-qualified-name is not found.
+  private def lookupInEnv(
+      fqn: String,
+      womType: WomType,
+      env: CallEnv,
+      optional: Boolean
+  ): Option[(String, LinkedVar)] = {
+    lookupInEnvInner(fqn, env) match {
+      case None if Utils.isOptional(womType) =>
+        None
+      case None =>
+        if (!optional) {
+          // A missing compulsory argument
+          Utils.warning(verbose, s"Missing argument ${fqn}, it will have to be provided at runtime")
         }
+        None
+      case Some((name, lVar)) =>
+        Some((name, lVar))
     }
+  }
 
-    // Lookup in the environment. Provide a human readable error message
-    // if the fully-qualified-name is not found.
-    private def lookupInEnv(fqn: String,
-                            womType: WomType,
-                            env: CallEnv,
-                            optional: Boolean) : Option[(String, LinkedVar)] = {
-        lookupInEnvInner(fqn, env) match {
-            case None if Utils.isOptional(womType) =>
-                None
-            case None =>
-                if (!optional) {
-                    // A missing compulsory argument
-                    Utils.warning(verbose,
-                                  s"Missing argument ${fqn}, it will have to be provided at runtime")
-                }
-                None
-            case Some((name, lVar)) =>
-                Some((name, lVar))
-        }
-    }
+  // Find the closure of a block. All the variables defined earlier
+  // that are required for the calculation.
+  private def blockClosure(block: Block, env: CallEnv, dbg: String): CallEnv = {
+    val allInputs = Block.closure(block)
+    allInputs.flatMap {
+      case (name, (womType, isOptionalArg)) =>
+        lookupInEnv(name, womType, env, isOptionalArg)
+    }.toMap
+  }
 
-    // Find the closure of a block. All the variables defined earlier
-    // that are required for the calculation.
-    private def blockClosure(block: Block,
-                             env : CallEnv,
-                             dbg: String) : CallEnv = {
-        val allInputs = Block.closure(block)
-        allInputs.flatMap { case (name, (womType, isOptionalArg)) =>
-            lookupInEnv(name, womType, env, isOptionalArg)
-        }.toMap
-    }
+  // Find the closure of a graph, besides its normal inputs. Create an input
+  // node for each of these external references.
+  private def graphClosure(
+      inputNodes: Vector[GraphInputNode],
+      subBlocks: Vector[Block]
+  ): Map[String, (WomType, Boolean)] = {
+    val allInputs: Map[String, (WomType, Boolean)] = subBlocks
+      .map { block =>
+        Block.closure(block)
+      }
+      .flatten
+      .toMap
 
-    // Find the closure of a graph, besides its normal inputs. Create an input
-    // node for each of these external references.
-    private def graphClosure(inputNodes: Vector[GraphInputNode],
-                             subBlocks: Vector[Block]) : Map[String, (WomType, Boolean)] = {
-        val allInputs : Map[String, (WomType, Boolean)] = subBlocks.map{ block =>
-            Block.closure(block)
-        }.flatten.toMap
+    // remove the regular inputs
+    val regularInputNames: Set[String] = inputNodes.map {
+      case iNode => iNode.localName
+    }.toSet
 
-        // remove the regular inputs
-        val regularInputNames : Set[String] = inputNodes.map {
-            case iNode => iNode.localName
-        }.toSet
+    allInputs.filter {
+      case (name, _) =>
+        !(regularInputNames contains name)
+    }.toMap
+  }
 
-        allInputs.filter{
-            case (name, _) =>
-                !(regularInputNames contains name)
-        }.toMap
-    }
+  // A block inside a conditional or scatter. If it is simple,
+  // we can use a direct call. Otherwise, recursively call into the asssemble-backbone method, and
+  // get a locked subworkflow.
+  private def compileNestedBlock(
+      wfName: String,
+      graph: Graph,
+      blockPath: Vector[Int],
+      env: CallEnv
+  ): (IR.Callable, Vector[IR.Callable]) = {
+    val (inputNodes, _, subBlocks, outputNodes) =
+      Block.splitGraph(graph, callsLoToHi)
+    assert(subBlocks.size > 0)
 
-    // A block inside a conditional or scatter. If it is simple,
-    // we can use a direct call. Otherwise, recursively call into the asssemble-backbone method, and
-    // get a locked subworkflow.
-    private def compileNestedBlock(wfName: String,
-                                   graph: Graph,
-                                   blockPath: Vector[Int],
-                                   env: CallEnv) : (IR.Callable, Vector[IR.Callable]) = {
-        val (inputNodes, _, subBlocks, outputNodes) =
-            Block.splitGraph(graph, callsLoToHi)
-        assert(subBlocks.size > 0)
+    if (subBlocks.size == 1) {
+      Block.categorize(subBlocks(0)) match {
+        case Block.CallDirect(_, _) | Block.CallWithSubexpressions(_, _) =>
+          throw new Exception("sanity")
+        case _ => ()
+      }
 
-        if (subBlocks.size == 1) {
-            Block.categorize(subBlocks(0)) match {
-                case Block.CallDirect(_,_) | Block.CallWithSubexpressions(_, _) =>
-                    throw new Exception("sanity")
-                case _ => ()
-            }
-
-            // At runtime, we will need to execute a workflow
-            // fragment. This requires an applet.
-            //
-            // This is a recursive call, to compile a  potentially
-            // complex sub-block. It could have many calls generating
-            // many applets and subworkflows.
-            val (stage, aux) = compileWfFragment(wfName,
-                                                 subBlocks(0),
-                                                 blockPath :+ 0,
-                                                 env)
-            val fragName = stage.calleeName
-            val main = aux.find(_.name == fragName) match {
-                case None => throw new Exception(s"Could not find ${fragName}")
-                case Some(x) => x
-            }
-            (main, aux)
-        } else {
-            // there are several subblocks, we need a subworkflow to string them
-            // together.
-            //
-            // The subworkflow may access declarations outside of its scope.
-            // For example, stage-0.result, and stage-1.result are inputs to
-            // stage-2, that belongs to a subworkflow. Because the subworkflow is
-            // locked, we need to make them proper inputs.
-            //
-            //  |- stage-0.result
-            //  |
-            //  |- stage-1.result
-            //  |
-            //  |--- |- stage-2
-            //       |
-            //       |- stage-3
-            //       |
-            //       |- stage-4
-            //
-            val pathStr = blockPath.map(x => x.toString).mkString("_")
-            val closureInputs = graphClosure(inputNodes, subBlocks)
-            Utils.trace(verbose.on, s"""|compileNestedBlock
+      // At runtime, we will need to execute a workflow
+      // fragment. This requires an applet.
+      //
+      // This is a recursive call, to compile a  potentially
+      // complex sub-block. It could have many calls generating
+      // many applets and subworkflows.
+      val (stage, aux) = compileWfFragment(wfName, subBlocks(0), blockPath :+ 0, env)
+      val fragName     = stage.calleeName
+      val main = aux.find(_.name == fragName) match {
+        case None    => throw new Exception(s"Could not find ${fragName}")
+        case Some(x) => x
+      }
+      (main, aux)
+    } else {
+      // there are several subblocks, we need a subworkflow to string them
+      // together.
+      //
+      // The subworkflow may access declarations outside of its scope.
+      // For example, stage-0.result, and stage-1.result are inputs to
+      // stage-2, that belongs to a subworkflow. Because the subworkflow is
+      // locked, we need to make them proper inputs.
+      //
+      //  |- stage-0.result
+      //  |
+      //  |- stage-1.result
+      //  |
+      //  |--- |- stage-2
+      //       |
+      //       |- stage-3
+      //       |
+      //       |- stage-4
+      //
+      val pathStr       = blockPath.map(x => x.toString).mkString("_")
+      val closureInputs = graphClosure(inputNodes, subBlocks)
+      Utils.trace(
+        verbose.on,
+        s"""|compileNestedBlock
                                         |    inputNodes = ${inputNodes.map(_.singleOutputPort)}
                                         |    closureInputs= ${closureInputs}
-                                        |""".stripMargin)
-            val (subwf, auxCallables, _ ) = compileWorkflowLocked(wfName + "_block_" + pathStr,
-                                                                  inputNodes,
-                                                                  closureInputs,
-                                                                  outputNodes,
-                                                                  blockPath, subBlocks,
-                                                                  IR.Level.Sub)
-            (subwf, auxCallables)
-        }
+                                        |""".stripMargin
+      )
+      val (subwf, auxCallables, _) = compileWorkflowLocked(
+        wfName + "_block_" + pathStr,
+        inputNodes,
+        closureInputs,
+        outputNodes,
+        blockPath,
+        subBlocks,
+        IR.Level.Sub
+      )
+      (subwf, auxCallables)
     }
+  }
 
-    // Build an applet to evaluate a WDL workflow fragment
+  // Build an applet to evaluate a WDL workflow fragment
+  //
+  // The [blockPath] argument keeps track of which block this fragment represents.
+  // A top level block is a number. A sub-block of a top-level block is a vector of two
+  // numbers, etc.
+  private def compileWfFragment(
+      wfName: String,
+      block: Block,
+      blockPath: Vector[Int],
+      env: CallEnv
+  ): (IR.Stage, Vector[IR.Callable]) = {
+    val stageName = block.makeName match {
+      case None       => "eval"
+      case Some(name) => name
+    }
+    Utils.trace(verbose.on, s"Compiling fragment <${stageName}> as stage")
+
+    // Figure out the closure required for this block, out of the
+    // environment
+    val closure = blockClosure(block, env, stageName)
+    val inputVars: Vector[CVar] = closure.map {
+      case (fqn, LinkedVar(cVar, _)) =>
+        cVar.copy(name = fqn)
+    }.toVector
+
+    // A reversible conversion mul.result --> mul___result. This
+    // assumes the '___' symbol is not used anywhere in the original WDL script.
     //
-    // The [blockPath] argument keeps track of which block this fragment represents.
-    // A top level block is a number. A sub-block of a top-level block is a vector of two
-    // numbers, etc.
-    private def compileWfFragment(wfName: String,
-                                  block: Block,
-                                  blockPath: Vector[Int],
-                                  env : CallEnv) : (IR.Stage, Vector[IR.Callable]) = {
-        val stageName = block.makeName match {
-            case None => "eval"
-            case Some(name) => name
-        }
-        Utils.trace(verbose.on, s"Compiling fragment <${stageName}> as stage")
+    // This is a simplifying assumption, that is hopefully sufficient. It disallows
+    // users from using variables with the ___ character sequence.
+    val fqnDictTypes = inputVars.map { cVar =>
+      cVar.dxVarName -> cVar.womType
+    }.toMap
 
-        // Figure out the closure required for this block, out of the
-        // environment
-        val closure = blockClosure(block, env, stageName)
-        val inputVars: Vector[CVar] = closure.map {
-            case (fqn, LinkedVar(cVar, _)) =>
-                cVar.copy(name = fqn)
-        }.toVector
+    // Figure out the block outputs
+    val outputs: Map[String, WomType] = Block.outputs(block)
 
-        // A reversible conversion mul.result --> mul___result. This
-        // assumes the '___' symbol is not used anywhere in the original WDL script.
-        //
-        // This is a simplifying assumption, that is hopefully sufficient. It disallows
-        // users from using variables with the ___ character sequence.
-        val fqnDictTypes = inputVars.map{ cVar => cVar.dxVarName -> cVar.womType}.toMap
+    // create a cVar definition from each block output. The dx:stage
+    // will output these cVars.
+    val outputVars = outputs.map {
+      case (fqn, womType) =>
+        CVar(fqn, womType, None)
+    }.toVector
 
-        // Figure out the block outputs
-        val outputs : Map[String, WomType] = Block.outputs(block)
-
-        // create a cVar definition from each block output. The dx:stage
-        // will output these cVars.
-        val outputVars = outputs.map{case (fqn, womType) =>
-            CVar(fqn, womType, None)
-        }.toVector
-
-        // The fragment runner can only handle a single call. If the
-        // block already has exactly one call, then we are good. If
-        // it contains a scatter/conditional with several calls,
-        // then compile the inner block into a sub-workflow.
-        //
-        // Figure out the name of the callable; we need to link with it when we
-        // get to the native phase.
-        val catg = Block.categorize(block)
-        Utils.trace(verbose2, s"""|category : ${Block.Category.toString(catg)}
+    // The fragment runner can only handle a single call. If the
+    // block already has exactly one call, then we are good. If
+    // it contains a scatter/conditional with several calls,
+    // then compile the inner block into a sub-workflow.
+    //
+    // Figure out the name of the callable; we need to link with it when we
+    // get to the native phase.
+    val catg = Block.categorize(block)
+    Utils.trace(verbose2, s"""|category : ${Block.Category.toString(catg)}
                                   |""".stripMargin)
 
-        val (innerCall, auxCallables) : (Option[String], Vector[IR.Callable]) = catg match {
-            case Block.AllExpressions(_) => (None, Vector.empty)
-            case Block.CallDirect(_,_) => throw new Exception(s"a direct call should not reach this stage")
+    val (innerCall, auxCallables): (Option[String], Vector[IR.Callable]) = catg match {
+      case Block.AllExpressions(_) => (None, Vector.empty)
+      case Block.CallDirect(_, _) =>
+        throw new Exception(s"a direct call should not reach this stage")
 
-            // A block with no nested sub-blocks, and a single call.
-            case Block.CallWithSubexpressions(_, cNode) =>
-                (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
-            case Block.CallFragment(_, cNode) =>
-                (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
+      // A block with no nested sub-blocks, and a single call.
+      case Block.CallWithSubexpressions(_, cNode) =>
+        (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
+      case Block.CallFragment(_, cNode) =>
+        (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
 
-            // A conditional/scatter with exactly one call in the sub-block.
-                // Can be executed by a fragment.
-            case Block.CondOneCall(_, _, cNode) =>
-                (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
-            case Block.ScatterOneCall(_, _, cNode) =>
-                (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
+      // A conditional/scatter with exactly one call in the sub-block.
+      // Can be executed by a fragment.
+      case Block.CondOneCall(_, _, cNode) =>
+        (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
+      case Block.ScatterOneCall(_, _, cNode) =>
+        (Some(Utils.getUnqualifiedName(cNode.callable.name)), Vector.empty)
 
-            case Block.CondFullBlock(_, condNode) =>
-                val (callable, aux) = compileNestedBlock(wfName, condNode.innerGraph,
-                                                         blockPath, env)
-                (Some(callable.name), aux :+ callable)
+      case Block.CondFullBlock(_, condNode) =>
+        val (callable, aux) = compileNestedBlock(wfName, condNode.innerGraph, blockPath, env)
+        (Some(callable.name), aux :+ callable)
 
-            case Block.ScatterFullBlock(_,sctNode) =>
-                // add the iteration variable to the inner environment
-                assert(sctNode.scatterVariableNodes.size == 1)
-                val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
-                val iterVarName = svNode.identifier.localName.value
-                val cVar = CVar(iterVarName, svNode.womType, None)
-                val innerEnv = env + (iterVarName -> LinkedVar(cVar, IR.SArgEmpty))
-                val (callable, aux) = compileNestedBlock(wfName, sctNode.innerGraph,
-                                                         blockPath, innerEnv)
-                (Some(callable.name), aux :+ callable)
-        }
-
-        val applet = IR.Applet(s"${wfName}_frag_${genFragId()}",
-                               inputVars,
-                               outputVars,
-                               IR.InstanceTypeDefault,
-                               IR.DockerImageNone,
-                               IR.AppletKindWfFragment(innerCall.toVector, blockPath, fqnDictTypes),
-                               wfSourceStandAlone)
-
-        val sArgs : Vector[SArg] = closure.map {
-            case (_, LinkedVar(_, sArg)) => sArg
-        }.toVector
-
-        (IR.Stage(stageName, genStageId(), applet.name, sArgs, outputVars),
-         auxCallables :+ applet)
+      case Block.ScatterFullBlock(_, sctNode) =>
+        // add the iteration variable to the inner environment
+        assert(sctNode.scatterVariableNodes.size == 1)
+        val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
+        val iterVarName                 = svNode.identifier.localName.value
+        val cVar                        = CVar(iterVarName, svNode.womType, None)
+        val innerEnv                    = env + (iterVarName -> LinkedVar(cVar, IR.SArgEmpty))
+        val (callable, aux)             = compileNestedBlock(wfName, sctNode.innerGraph, blockPath, innerEnv)
+        (Some(callable.name), aux :+ callable)
     }
 
-    // Assemble the backbone of a workflow, having compiled the
-    // independent tasks.  This is shared between locked and unlocked
-    // workflows. At this point we we have workflow level inputs and
-    // outputs.
-    private def assembleBackbone(wfName: String,
-                                 wfInputs: Vector[(CVar, SArg)],
-                                 blockPath: Vector[Int],
-                                 subBlocks: Vector[Block],
-                                 locked: Boolean)
-            : (Vector[(IR.Stage, Vector[IR.Callable])], CallEnv) =
-    {
-        Utils.trace(verbose.on, s"Assembling workflow backbone ${wfName}")
-        Utils.traceLevelInc()
-        val inputNamesDbg = wfInputs.map{ case (cVar, _) => cVar.name }
-        Utils.trace(verbose.on, s"inputs= ${inputNamesDbg}")
+    val applet = IR.Applet(
+      s"${wfName}_frag_${genFragId()}",
+      inputVars,
+      outputVars,
+      IR.InstanceTypeDefault,
+      IR.DockerImageNone,
+      IR.AppletKindWfFragment(innerCall.toVector, blockPath, fqnDictTypes),
+      wfSourceStandAlone
+    )
 
-        var env : CallEnv = wfInputs.map { case (cVar,sArg) =>
-            cVar.name -> LinkedVar(cVar, sArg)
-        }.toMap
+    val sArgs: Vector[SArg] = closure.map {
+      case (_, LinkedVar(_, sArg)) => sArg
+    }.toVector
 
-        var allStageInfo = Vector.empty[(IR.Stage, Vector[IR.Callable])]
-        var remainingBlocks = subBlocks
+    (IR.Stage(stageName, genStageId(), applet.name, sArgs, outputVars), auxCallables :+ applet)
+  }
 
-        // link together all the stages into a linear workflow
-        for (blockNum <- 0 to (subBlocks.length -1)) {
-            val block = remainingBlocks.head
-            remainingBlocks = remainingBlocks.tail
+  // Assemble the backbone of a workflow, having compiled the
+  // independent tasks.  This is shared between locked and unlocked
+  // workflows. At this point we we have workflow level inputs and
+  // outputs.
+  private def assembleBackbone(
+      wfName: String,
+      wfInputs: Vector[(CVar, SArg)],
+      blockPath: Vector[Int],
+      subBlocks: Vector[Block],
+      locked: Boolean
+  ): (Vector[(IR.Stage, Vector[IR.Callable])], CallEnv) = {
+    Utils.trace(verbose.on, s"Assembling workflow backbone ${wfName}")
+    Utils.traceLevelInc()
+    val inputNamesDbg = wfInputs.map { case (cVar, _) => cVar.name }
+    Utils.trace(verbose.on, s"inputs= ${inputNamesDbg}")
 
-            val (stage, auxCallables) = Block.categorize(block) match {
-                case Block.CallDirect(_, call) =>
-                    // The block contains exactly one call, with no extra declarations.
-                    // All the variables are already in the environment, so there
-                    // is no need to do any extra work. Compile directly into a workflow
-                    // stage.
-                    Utils.trace(verbose.on, s"Compiling call ${call.callable.name} as stage")
-                    val stage = compileCall(call, env, locked)
+    var env: CallEnv = wfInputs.map {
+      case (cVar, sArg) =>
+        cVar.name -> LinkedVar(cVar, sArg)
+    }.toMap
 
-                    // Add bindings for the output variables. This allows later calls to refer
-                    // to these results.
-                    for (cVar <- stage.outputs) {
-                        val fqn = call.identifier.localName.value ++ "." + cVar.name
-                        val cVarFqn = cVar.copy(name = fqn)
-                        env = env + (fqn -> LinkedVar(cVarFqn, IR.SArgLink(stage.id, cVar)))
-                    }
-                    (stage, Vector.empty)
+    var allStageInfo    = Vector.empty[(IR.Stage, Vector[IR.Callable])]
+    var remainingBlocks = subBlocks
 
-                case _ =>
-                    //     A simple block that requires just one applet,
-                    // OR: A complex block that needs a subworkflow
-                    val (stage, auxCallables) = compileWfFragment(wfName,
-                                                                  block,
-                                                                  blockPath :+ blockNum,
-                                                                  env)
-                    for (cVar <- stage.outputs) {
-                        env = env + (cVar.name ->
-                                         LinkedVar(cVar, IR.SArgLink(stage.id, cVar)))
-                    }
-                    (stage, auxCallables)
-            }
-            allStageInfo :+= (stage, auxCallables)
-        }
+    // link together all the stages into a linear workflow
+    for (blockNum <- 0 to (subBlocks.length - 1)) {
+      val block = remainingBlocks.head
+      remainingBlocks = remainingBlocks.tail
 
-        if (verbose2) {
-            Utils.trace(verbose2, s"stages for workflow ${wfName} = [")
-            allStageInfo.foreach{ case (stage,_) =>
-                Utils.trace(verbose2, s"    ${stage.description}, ${stage.id.getId} -> callee=${stage.calleeName}")
-            }
-            Utils.trace(verbose2, "]")
-        }
-        Utils.traceLevelDec()
-        (allStageInfo, env)
+      val (stage, auxCallables) = Block.categorize(block) match {
+        case Block.CallDirect(_, call) =>
+          // The block contains exactly one call, with no extra declarations.
+          // All the variables are already in the environment, so there
+          // is no need to do any extra work. Compile directly into a workflow
+          // stage.
+          Utils.trace(verbose.on, s"Compiling call ${call.callable.name} as stage")
+          val stage = compileCall(call, env, locked)
+
+          // Add bindings for the output variables. This allows later calls to refer
+          // to these results.
+          for (cVar <- stage.outputs) {
+            val fqn     = call.identifier.localName.value ++ "." + cVar.name
+            val cVarFqn = cVar.copy(name = fqn)
+            env = env + (fqn -> LinkedVar(cVarFqn, IR.SArgLink(stage.id, cVar)))
+          }
+          (stage, Vector.empty)
+
+        case _ =>
+          //     A simple block that requires just one applet,
+          // OR: A complex block that needs a subworkflow
+          val (stage, auxCallables) = compileWfFragment(wfName, block, blockPath :+ blockNum, env)
+          for (cVar <- stage.outputs) {
+            env = env + (cVar.name ->
+              LinkedVar(cVar, IR.SArgLink(stage.id, cVar)))
+          }
+          (stage, auxCallables)
+      }
+      allStageInfo :+= (stage, auxCallables)
     }
 
-
-    private def buildSimpleWorkflowOutput(outputNode: GraphOutputNode, env: CallEnv) : (CVar, SArg) = {
-        outputNode match {
-            case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-                val cVar = CVar(id.fullyQualifiedName.value, womType, None)
-                val source = sourcePort.name
-                (cVar, getSArgFromEnv(source, env))
-            case expr :ExpressionBasedGraphOutputNode if (Block.isTrivialExpression(expr.womType, expr.womExpression)) =>
-                val cVar = CVar(expr.graphOutputPort.name, expr.womType, None)
-                val source = expr.womExpression.sourceString
-                (cVar, getSArgFromEnv(source, env))
-            case expr :ExpressionBasedGraphOutputNode =>
-                // An expression that requires evaluation
-                throw new Exception(s"Internal error: non trivial expressions are handled elsewhere ${expr}")
-            case other =>
-                throw new Exception(s"unhandled output ${other}")
-        }
+    if (verbose2) {
+      Utils.trace(verbose2, s"stages for workflow ${wfName} = [")
+      allStageInfo.foreach {
+        case (stage, _) =>
+          Utils.trace(
+            verbose2,
+            s"    ${stage.description}, ${stage.id.getId} -> callee=${stage.calleeName}"
+          )
+      }
+      Utils.trace(verbose2, "]")
     }
+    Utils.traceLevelDec()
+    (allStageInfo, env)
+  }
 
-
-    // Create a preliminary applet to handle workflow input/outputs. This is
-    // used only in the absence of workflow-level inputs/outputs.
-    private def buildCommonApplet(wfName: String,
-                                  wfSourceStandAlone: String,
-                                  inputVars: Vector[CVar]) : (IR.Stage, IR.Applet) = {
-        val outputVars: Vector[CVar] = inputVars
-
-        val applet = IR.Applet(s"${wfName}_${COMMON}",
-                               inputVars,
-                               outputVars,
-                               IR.InstanceTypeDefault,
-                               IR.DockerImageNone,
-                               IR.AppletKindWfInputs,
-                               wfSourceStandAlone)
-        Utils.trace(verbose.on, s"Compiling common applet ${applet.name}")
-
-        val sArgs: Vector[SArg] = inputVars.map{ _ => IR.SArgEmpty}.toVector
-        (IR.Stage(COMMON, genStageId(Some(COMMON)), applet.name, sArgs, outputVars),
-         applet)
-    }
-
-    private def addOutputStatus(outputsVar: Vector[CVar]) = {
-        outputsVar :+ CVar(
-            Utils.REORG_STATUS,
-            WomStringType,
-            Some(WomString(Utils.REORG_STATUS_COMPLETE))
+  private def buildSimpleWorkflowOutput(outputNode: GraphOutputNode, env: CallEnv): (CVar, SArg) = {
+    outputNode match {
+      case PortBasedGraphOutputNode(id, womType, sourcePort) =>
+        val cVar   = CVar(id.fullyQualifiedName.value, womType, None)
+        val source = sourcePort.name
+        (cVar, getSArgFromEnv(source, env))
+      case expr: ExpressionBasedGraphOutputNode
+          if (Block.isTrivialExpression(expr.womType, expr.womExpression)) =>
+        val cVar   = CVar(expr.graphOutputPort.name, expr.womType, None)
+        val source = expr.womExpression.sourceString
+        (cVar, getSArgFromEnv(source, env))
+      case expr: ExpressionBasedGraphOutputNode =>
+        // An expression that requires evaluation
+        throw new Exception(
+          s"Internal error: non trivial expressions are handled elsewhere ${expr}"
         )
+      case other =>
+        throw new Exception(s"unhandled output ${other}")
+    }
+  }
+
+  // Create a preliminary applet to handle workflow input/outputs. This is
+  // used only in the absence of workflow-level inputs/outputs.
+  private def buildCommonApplet(
+      wfName: String,
+      wfSourceStandAlone: String,
+      inputVars: Vector[CVar]
+  ): (IR.Stage, IR.Applet) = {
+    val outputVars: Vector[CVar] = inputVars
+
+    val applet = IR.Applet(
+      s"${wfName}_${COMMON}",
+      inputVars,
+      outputVars,
+      IR.InstanceTypeDefault,
+      IR.DockerImageNone,
+      IR.AppletKindWfInputs,
+      wfSourceStandAlone
+    )
+    Utils.trace(verbose.on, s"Compiling common applet ${applet.name}")
+
+    val sArgs: Vector[SArg] = inputVars.map { _ =>
+      IR.SArgEmpty
+    }.toVector
+    (IR.Stage(COMMON, genStageId(Some(COMMON)), applet.name, sArgs, outputVars), applet)
+  }
+
+  private def addOutputStatus(outputsVar: Vector[CVar]) = {
+    outputsVar :+ CVar(
+      Utils.REORG_STATUS,
+      WomStringType,
+      Some(WomString(Utils.REORG_STATUS_COMPLETE))
+    )
+  }
+
+  // There are two reasons to be build a special output section:
+  // 1. Locked workflow: some of the workflow outputs are expressions.
+  //    We need an extra applet+stage to evaluate them.
+  // 2. Unlocked workflow: there are no workflow outputs, so we create
+  //    them artificially with a separate stage that collects the outputs.
+  private def buildOutputStage(
+      wfName: String,
+      wfSourceStandAlone: String,
+      outputNodes: Vector[GraphOutputNode],
+      env: CallEnv
+  ): (IR.Stage, IR.Applet) = {
+    // Figure out what variables from the environment we need to pass
+    // into the applet.
+    val closure = Block.outputClosure(outputNodes)
+
+    val inputVars: Vector[LinkedVar] = closure.map { name =>
+      val lVar = env.find { case (key, _) => key == name } match {
+        case None            => throw new Exception(s"could not find variable ${name} in the environment")
+        case Some((_, lVar)) => lVar
+      }
+      lVar
+    }.toVector
+    Utils.trace(verbose.on, s"inputVars=${inputVars.map(_.cVar)}")
+
+    // build definitions of the output variables
+    val outputVars: Vector[CVar] = outputNodes.map {
+      case PortBasedGraphOutputNode(id, womType, sourcePort) =>
+        CVar(id.workflowLocalName, womType, None)
+      case expr: ExpressionBasedGraphOutputNode =>
+        CVar(expr.graphOutputPort.name, expr.womType, None)
+      case other =>
+        throw new Exception(s"unhandled output ${other}")
+    }.toVector
+
+    val updatedOutputVars: Vector[CVar] = reorg match {
+      case Left(_)             => outputVars
+      case Right(_) if locked  => outputVars
+      case Right(_) if !locked => addOutputStatus(outputVars)
+
     }
 
-    // There are two reasons to be build a special output section:
-    // 1. Locked workflow: some of the workflow outputs are expressions.
-    //    We need an extra applet+stage to evaluate them.
-    // 2. Unlocked workflow: there are no workflow outputs, so we create
-    //    them artificially with a separate stage that collects the outputs.
-    private def buildOutputStage(wfName: String,
-                                 wfSourceStandAlone : String,
-                                 outputNodes : Vector[GraphOutputNode],
-                                 env: CallEnv)
-            : (IR.Stage, IR.Applet) = {
-        // Figure out what variables from the environment we need to pass
-        // into the applet.
-        val closure = Block.outputClosure(outputNodes)
+    val appletKind: IR.AppletKind = reorg match {
+      case Left(_) => IR.AppletKindWfOutputs
+      // if custom reorg app is used, check if workflow is not locked to ensure that the wf is top level
+      // You cannot declare a custom reorg app with a locked workflow.
+      // This is checked in Main.scala
+      case Right(_) if locked  => IR.AppletKindWfOutputs
+      case Right(_) if !locked => IR.AppletKindWfCustomReorgOutputs
 
-        val inputVars : Vector[LinkedVar] = closure.map{ name =>
-            val lVar = env.find{ case (key,_) => key == name } match {
-                case None => throw new Exception(s"could not find variable ${name} in the environment")
-                case Some((_,lVar)) => lVar
-            }
-            lVar
-        }.toVector
-        Utils.trace(verbose.on, s"inputVars=${inputVars.map(_.cVar)}")
-
-        // build definitions of the output variables
-        val outputVars: Vector[CVar] = outputNodes.map {
-            case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-                CVar(id.workflowLocalName, womType, None)
-            case expr :ExpressionBasedGraphOutputNode =>
-                CVar(expr.graphOutputPort.name, expr.womType, None)
-            case other =>
-                throw new Exception(s"unhandled output ${other}")
-        }.toVector
-
-        val updatedOutputVars: Vector[CVar] = reorg match {
-            case Left(_) => outputVars
-            case Right(_) if locked => outputVars
-            case Right(_) if !locked => addOutputStatus(outputVars)
-
-        }
-
-        val appletKind: IR.AppletKind = reorg match {
-            case Left(_) => IR.AppletKindWfOutputs
-            // if custom reorg app is used, check if workflow is not locked to ensure that the wf is top level
-            // You cannot declare a custom reorg app with a locked workflow.
-            // This is checked in Main.scala
-            case Right(_) if locked => IR.AppletKindWfOutputs
-            case Right(_) if !locked => IR.AppletKindWfCustomReorgOutputs
-
-        }
-
-        val applet = IR.Applet(s"${wfName}_${OUTPUT_SECTION}",
-            inputVars.map(_.cVar),
-            updatedOutputVars,
-            IR.InstanceTypeDefault,
-            IR.DockerImageNone,
-            appletKind,
-            wfSourceStandAlone)
-
-
-        // define the extra stage we add to the workflow
-        (IR.Stage(OUTPUT_SECTION, genStageId(Some(OUTPUT_SECTION)), applet.name,
-                  inputVars.map(_.sArg), updatedOutputVars),
-         applet)
     }
 
-     // Create an applet to reorganize the output files. We want to
-    // move the intermediate results to a subdirectory.  The applet
-    // needs to process all the workflow outputs, to find the files
-    // that belong to the final results.
-    private def buildReorgStage(wfName: String,
-                                wfSourceStandAlone : String,
-                                wfOutputs: Vector[(CVar, SArg)]) : (IR.Stage, IR.Applet) = {
-        // We need minimal compute resources, use the default instance type
-        val applet = IR.Applet(s"${wfName}_${REORG}",
-                               wfOutputs.map{ case (cVar, _) => cVar },
-                               Vector.empty,
-                               IR.InstanceTypeDefault,
-                               IR.DockerImageNone,
-                               IR.AppletKindWorkflowOutputReorg,
-                               wfSourceStandAlone)
-        Utils.trace(verbose.on, s"Compiling output reorganization applet ${applet.name}")
+    val applet = IR.Applet(
+      s"${wfName}_${OUTPUT_SECTION}",
+      inputVars.map(_.cVar),
+      updatedOutputVars,
+      IR.InstanceTypeDefault,
+      IR.DockerImageNone,
+      appletKind,
+      wfSourceStandAlone
+    )
 
-        // Link to the X.y original variables
-        val inputs: Vector[IR.SArg] = wfOutputs.map{ case (_, sArg) => sArg }.toVector
+    // define the extra stage we add to the workflow
+    (
+      IR.Stage(
+        OUTPUT_SECTION,
+        genStageId(Some(OUTPUT_SECTION)),
+        applet.name,
+        inputVars.map(_.sArg),
+        updatedOutputVars
+      ),
+      applet
+    )
+  }
 
-        (IR.Stage(REORG, genStageId(Some(REORG)), applet.name, inputs, Vector.empty[CVar]),
-         applet)
+  // Create an applet to reorganize the output files. We want to
+  // move the intermediate results to a subdirectory.  The applet
+  // needs to process all the workflow outputs, to find the files
+  // that belong to the final results.
+  private def buildReorgStage(
+      wfName: String,
+      wfSourceStandAlone: String,
+      wfOutputs: Vector[(CVar, SArg)]
+  ): (IR.Stage, IR.Applet) = {
+    // We need minimal compute resources, use the default instance type
+    val applet = IR.Applet(
+      s"${wfName}_${REORG}",
+      wfOutputs.map { case (cVar, _) => cVar },
+      Vector.empty,
+      IR.InstanceTypeDefault,
+      IR.DockerImageNone,
+      IR.AppletKindWorkflowOutputReorg,
+      wfSourceStandAlone
+    )
+    Utils.trace(verbose.on, s"Compiling output reorganization applet ${applet.name}")
+
+    // Link to the X.y original variables
+    val inputs: Vector[IR.SArg] = wfOutputs.map { case (_, sArg) => sArg }.toVector
+
+    (IR.Stage(REORG, genStageId(Some(REORG)), applet.name, inputs, Vector.empty[CVar]), applet)
+  }
+
+  private def addCustomReorgStage(
+      wfName: String,
+      wfSourceStandAlone: String,
+      wfOutputs: Vector[(CVar, SArg)],
+      reorgAttributes: ReorgAttrs
+  ): (IR.Stage, IR.Applet) = {
+
+    val appletKind = IR.AppletKindWorkflowCustomReorg(reorgAttributes.appId)
+
+    // will throw error if there is no status string. Should consider checking there i s only one.
+    val (reorgStatusCvar, reorgStatusSArg): (CVar, SArg) = wfOutputs.filter {
+      case (x, y) => x.name == Utils.REORG_STATUS
+    }.head
+
+    val configFile: Option[WomSingleFile] = reorgAttributes.reorgConf match {
+      case ""        => None
+      case x: String => Some(WomSingleFile(x))
     }
 
-    private def addCustomReorgStage(wfName: String,
-                                    wfSourceStandAlone: String,
-                                    wfOutputs: Vector[(CVar, SArg)],
-                                    reorgAttributes: ReorgAttrs
-                                   ) : (IR.Stage, IR.Applet) = {
+    val appInputs = Vector(
+      reorgStatusCvar,
+      CVar(Utils.REORG_CONFIG, WomSingleFileType, configFile)
+    )
 
-        val appletKind = IR.AppletKindWorkflowCustomReorg(reorgAttributes.appId)
+    val applet = IR.Applet(
+      reorgAttributes.appId,
+      appInputs,
+      Vector.empty,
+      IR.InstanceTypeDefault,
+      IR.DockerImageNone,
+      appletKind,
+      wfSourceStandAlone
+    )
 
-        // will throw error if there is no status string. Should consider checking there i s only one.
-        val(reorgStatusCvar, reorgStatusSArg): (CVar, SArg) = wfOutputs.filter {
-            case (x, y) => x.name == Utils.REORG_STATUS
-        }.head
+    Utils.trace(verbose.on, s"Adding custom output reorganization applet ${reorgAttributes.appId}")
 
-        val configFile: Option[WomSingleFile] = reorgAttributes.reorgConf match {
-            case "" => None
-            case x: String => Some(WomSingleFile(x))
-        }
+    // Link to the X.y original variables
 
-        val appInputs = Vector(
-            reorgStatusCvar,
-            CVar(Utils.REORG_CONFIG, WomSingleFileType, configFile)
-        )
-
-        val applet = IR.Applet(
-            reorgAttributes.appId,
-            appInputs,
-            Vector.empty,
-            IR.InstanceTypeDefault,
-            IR.DockerImageNone,
-            appletKind,
-            wfSourceStandAlone
-        )
-
-        Utils.trace(verbose.on, s"Adding custom output reorganization applet ${reorgAttributes.appId}")
-
-        // Link to the X.y original variables
-
-        val inputs: Vector[IR.SArg] = configFile match {
-            case Some(x) => Vector(reorgStatusSArg, SArgConst(x))
-            case _ =>  Vector(reorgStatusSArg)
-        }
-
-        (IR.Stage(REORG, genStageId(Some(REORG)), applet.name, inputs
-            , Vector.empty[CVar]),
-          applet)
+    val inputs: Vector[IR.SArg] = configFile match {
+      case Some(x) => Vector(reorgStatusSArg, SArgConst(x))
+      case _       => Vector(reorgStatusSArg)
     }
 
+    (IR.Stage(REORG, genStageId(Some(REORG)), applet.name, inputs, Vector.empty[CVar]), applet)
+  }
 
-    private def compileWorkflowLocked(wfName: String,
-                                      inputNodes: Vector[GraphInputNode],
-                                      closureInputs: Map[String, (WomType, Boolean)],
-                                      outputNodes: Vector[GraphOutputNode],
-                                      blockPath: Vector[Int],
-                                      subBlocks : Vector[Block],
-                                      level: IR.Level.Value) :
-            (IR.Workflow, Vector[IR.Callable], Vector[(CVar, SArg)]) =
-    {
-        val wfInputs:Vector[(CVar, SArg)] = inputNodes.map{
-            case iNode =>
-                val cVar = buildWorkflowInput(iNode)
-                (cVar, IR.SArgWorkflowInput(cVar))
-        }.toVector
+  private def compileWorkflowLocked(
+      wfName: String,
+      inputNodes: Vector[GraphInputNode],
+      closureInputs: Map[String, (WomType, Boolean)],
+      outputNodes: Vector[GraphOutputNode],
+      blockPath: Vector[Int],
+      subBlocks: Vector[Block],
+      level: IR.Level.Value
+  ): (IR.Workflow, Vector[IR.Callable], Vector[(CVar, SArg)]) = {
+    val wfInputs: Vector[(CVar, SArg)] = inputNodes.map {
+      case iNode =>
+        val cVar = buildWorkflowInput(iNode)
+        (cVar, IR.SArgWorkflowInput(cVar))
+    }.toVector
 
-        // inputs that are a result of accessing declarations in an encompassing
-        // WDL workflow.
-        val clsInputs: Vector[(CVar, SArg)] = closureInputs.map{
-            case (name, (womType, false)) =>
-                // no default value
-                val cVar = CVar(name, womType, None)
-                (cVar, IR.SArgWorkflowInput(cVar))
-            case (name, (womType, true)) =>
-                // there is a default value. This input is de facto optional.
-                // We change the type of the CVar and make sure it is optional.
-                val cVar =
-                    if (Utils.isOptional(womType))
-                        CVar(name, womType, None)
-                    else
-                        CVar(name, WomOptionalType(womType), None)
-                (cVar, IR.SArgWorkflowInput(cVar))
-        }.toVector
-        val allWfInputs = wfInputs ++ clsInputs
+    // inputs that are a result of accessing declarations in an encompassing
+    // WDL workflow.
+    val clsInputs: Vector[(CVar, SArg)] = closureInputs.map {
+      case (name, (womType, false)) =>
+        // no default value
+        val cVar = CVar(name, womType, None)
+        (cVar, IR.SArgWorkflowInput(cVar))
+      case (name, (womType, true)) =>
+        // there is a default value. This input is de facto optional.
+        // We change the type of the CVar and make sure it is optional.
+        val cVar =
+          if (Utils.isOptional(womType))
+            CVar(name, womType, None)
+          else
+            CVar(name, WomOptionalType(womType), None)
+        (cVar, IR.SArgWorkflowInput(cVar))
+    }.toVector
+    val allWfInputs = wfInputs ++ clsInputs
 
-        val (allStageInfo, env) = assembleBackbone(wfName, allWfInputs,
-                                                   blockPath, subBlocks, true)
-        val (stages, auxCallables) = allStageInfo.unzip
+    val (allStageInfo, env)    = assembleBackbone(wfName, allWfInputs, blockPath, subBlocks, true)
+    val (stages, auxCallables) = allStageInfo.unzip
 
-        // Handle outputs that are constants or variables, we can output them directly.
-        //
-        // Is an output used directly as an input? For example, in the
-        // small workflow below, 'lane' is used in such a manner.
-        //
-        // workflow inner {
-        //   input {
-        //      String lane
-        //   }
-        //   output {
-        //      String blah = lane
-        //   }
-        // }
-        //
-        // In locked dx:workflows, it is illegal to access a workflow input directly from
-        // a workflow output. It is only allowed to access a stage input/output.
-        if (outputNodes.forall(Block.isSimpleOutput) &&
-                Block.inputsUsedAsOutputs(inputNodes, outputNodes).isEmpty) {
-            val simpleWfOutputs = outputNodes.map(node => buildSimpleWorkflowOutput(node, env)).toVector
-            val irwf = IR.Workflow(wfName, allWfInputs, simpleWfOutputs, stages, wfSourceCode, true, level)
-            (irwf, auxCallables.flatten, simpleWfOutputs)
-        } else {
-            // Some of the outputs are expressions. We need an extra applet+stage
-            // to evaluate them.
-            val (outputStage, outputApplet) = buildOutputStage(wfName,
-                                                               wfSourceStandAlone,
-                                                               outputNodes,
-                                                               env)
-            val wfOutputs = outputStage.outputs.map{ cVar =>
-                (cVar, IR.SArgLink(outputStage.id, cVar))
-            }
-            val irwf = IR.Workflow(wfName,
-                                   allWfInputs, wfOutputs,
-                                   stages :+ outputStage,
-                                   wfSourceCode,
-                                   true, level)
-            (irwf, auxCallables.flatten :+ outputApplet, wfOutputs)
-        }
-    }
-
-
-    private def compileWorkflowRegular(inputNodes: Vector[GraphInputNode],
-                                       outputNodes: Vector[GraphOutputNode],
-                                       subBlocks : Vector[Block])
-            : (IR.Workflow, Vector[IR.Callable], Vector[(CVar, SArg)]) =
-    {
-        // Create a special applet+stage for the inputs. This is a substitute for
-        // workflow inputs. We now call the workflow inputs, "fauxWfInputs". This is because
-        // they are references to the outputs of this first applet.
-
-        // compile into dx:workflow inputs
-        val wfInputDefs:Vector[CVar] = inputNodes.map{
-            case iNode => buildWorkflowInput(iNode)
-        }.toVector
-        val (commonStg, commonApplet) = buildCommonApplet(wf.name,
-                                                          wfSourceStandAlone,
-                                                          wfInputDefs)
-        val fauxWfInputs:Vector[(CVar, SArg)] = commonStg.outputs.map{
-            case cVar: CVar =>
-                val sArg = IR.SArgLink(commonStg.id, cVar)
-                (cVar, sArg)
-        }.toVector
-
-        val (allStageInfo, env) = assembleBackbone(wf.name, fauxWfInputs, Vector.empty, subBlocks, false)
-        val (stages: Vector[IR.Stage], auxCallables) = allStageInfo.unzip
-
-        // convert the outputs into an applet+stage
-        val (outputStage, outputApplet) = buildOutputStage(wf.name,
-                                                           wfSourceStandAlone,
-                                                           outputNodes, env)
-
-        val wfInputs = wfInputDefs.map{ cVar =>
-            (cVar, IR.SArgEmpty)
-        }
-        val wfOutputs = outputStage.outputs.map{ cVar =>
-            (cVar, IR.SArgLink(outputStage.id, cVar))
-        }
-        val irwf = IR.Workflow(wf.name,
-                               wfInputs.toVector,
-                               wfOutputs.toVector,
-                               commonStg +: stages :+ outputStage,
-                               wfSourceCode,
-                               false,
-                               IR.Level.Top)
-        (irwf, commonApplet +: auxCallables.flatten :+ outputApplet, wfOutputs)
-    }
-
-
-    // Compile a (single) user defined WDL workflow into a dx:workflow.
+    // Handle outputs that are constants or variables, we can output them directly.
     //
-    private def apply2() =
-    {
-        Utils.trace(verbose.on, s"compiling workflow ${wf.name}")
-        val graph = wf.innerGraph
+    // Is an output used directly as an input? For example, in the
+    // small workflow below, 'lane' is used in such a manner.
+    //
+    // workflow inner {
+    //   input {
+    //      String lane
+    //   }
+    //   output {
+    //      String blah = lane
+    //   }
+    // }
+    //
+    // In locked dx:workflows, it is illegal to access a workflow input directly from
+    // a workflow output. It is only allowed to access a stage input/output.
+    if (outputNodes.forall(Block.isSimpleOutput) &&
+        Block.inputsUsedAsOutputs(inputNodes, outputNodes).isEmpty) {
+      val simpleWfOutputs = outputNodes.map(node => buildSimpleWorkflowOutput(node, env)).toVector
+      val irwf =
+        IR.Workflow(wfName, allWfInputs, simpleWfOutputs, stages, wfSourceCode, true, level)
+      (irwf, auxCallables.flatten, simpleWfOutputs)
+    } else {
+      // Some of the outputs are expressions. We need an extra applet+stage
+      // to evaluate them.
+      val (outputStage, outputApplet) =
+        buildOutputStage(wfName, wfSourceStandAlone, outputNodes, env)
+      val wfOutputs = outputStage.outputs.map { cVar =>
+        (cVar, IR.SArgLink(outputStage.id, cVar))
+      }
+      val irwf = IR.Workflow(
+        wfName,
+        allWfInputs,
+        wfOutputs,
+        stages :+ outputStage,
+        wfSourceCode,
+        true,
+        level
+      )
+      (irwf, auxCallables.flatten :+ outputApplet, wfOutputs)
+    }
+  }
 
-        // Create a stage per call/scatter-block/declaration-block
-        val (inputNodes, _, subBlocks, outputNodes) = Block.splitGraph(graph, callsLoToHi)
+  private def compileWorkflowRegular(
+      inputNodes: Vector[GraphInputNode],
+      outputNodes: Vector[GraphOutputNode],
+      subBlocks: Vector[Block]
+  ): (IR.Workflow, Vector[IR.Callable], Vector[(CVar, SArg)]) = {
+    // Create a special applet+stage for the inputs. This is a substitute for
+    // workflow inputs. We now call the workflow inputs, "fauxWfInputs". This is because
+    // they are references to the outputs of this first applet.
 
-        // compile into an IR workflow
-        val (irwf, irCallables, wfOutputs) =
-            if (locked) {
-                compileWorkflowLocked(wf.name,
-                                      inputNodes, Map.empty, outputNodes,
-                                      Vector.empty, subBlocks, IR.Level.Top)
-            } else {
-                compileWorkflowRegular(inputNodes, outputNodes, subBlocks)
-            }
+    // compile into dx:workflow inputs
+    val wfInputDefs: Vector[CVar] = inputNodes.map {
+      case iNode => buildWorkflowInput(iNode)
+    }.toVector
+    val (commonStg, commonApplet) = buildCommonApplet(wf.name, wfSourceStandAlone, wfInputDefs)
+    val fauxWfInputs: Vector[(CVar, SArg)] = commonStg.outputs.map {
+      case cVar: CVar =>
+        val sArg = IR.SArgLink(commonStg.id, cVar)
+        (cVar, sArg)
+    }.toVector
 
-        // Add a workflow reorg applet if necessary
-        val (wf2: IR.Workflow, apl2: Vector[IR.Callable]) = reorg match {
-            case Left(reorg_flag) => if (reorg_flag) {
-                val (reorgStage, reorgApl) = buildReorgStage(wf.name,
-                    wfSourceStandAlone,
-                    wfOutputs)
-                (irwf.copy(stages = irwf.stages :+ reorgStage),
-                  irCallables :+ reorgApl)
-            } else {
-                (irwf, irCallables)
-            }
+    val (allStageInfo, env) =
+      assembleBackbone(wf.name, fauxWfInputs, Vector.empty, subBlocks, false)
+    val (stages: Vector[IR.Stage], auxCallables) = allStageInfo.unzip
 
-            // Only the top level workflow will have a custom reorg stage.
-            // All subworkflow are locked.
-            // Cannot use custom reorg stage with --locked flag.
-            // This is checked in Main.scala.
-            case Right(reorgAttributes) =>
-                if (!locked) {
-                    val (reorgStage, reorgApl) = addCustomReorgStage(wf.name,
-                        wfSourceStandAlone,
-                        wfOutputs,
-                        reorgAttributes)
-                    (irwf.copy(stages = irwf.stages :+ reorgStage),
-                      irCallables :+ reorgApl)
-                }
-                else {
-                    (irwf, irCallables)
-                }
+    // convert the outputs into an applet+stage
+    val (outputStage, outputApplet) =
+      buildOutputStage(wf.name, wfSourceStandAlone, outputNodes, env)
+
+    val wfInputs = wfInputDefs.map { cVar =>
+      (cVar, IR.SArgEmpty)
+    }
+    val wfOutputs = outputStage.outputs.map { cVar =>
+      (cVar, IR.SArgLink(outputStage.id, cVar))
+    }
+    val irwf = IR.Workflow(
+      wf.name,
+      wfInputs.toVector,
+      wfOutputs.toVector,
+      commonStg +: stages :+ outputStage,
+      wfSourceCode,
+      false,
+      IR.Level.Top
+    )
+    (irwf, commonApplet +: auxCallables.flatten :+ outputApplet, wfOutputs)
+  }
+
+  // Compile a (single) user defined WDL workflow into a dx:workflow.
+  //
+  private def apply2() = {
+    Utils.trace(verbose.on, s"compiling workflow ${wf.name}")
+    val graph = wf.innerGraph
+
+    // Create a stage per call/scatter-block/declaration-block
+    val (inputNodes, _, subBlocks, outputNodes) = Block.splitGraph(graph, callsLoToHi)
+
+    // compile into an IR workflow
+    val (irwf, irCallables, wfOutputs) =
+      if (locked) {
+        compileWorkflowLocked(
+          wf.name,
+          inputNodes,
+          Map.empty,
+          outputNodes,
+          Vector.empty,
+          subBlocks,
+          IR.Level.Top
+        )
+      } else {
+        compileWorkflowRegular(inputNodes, outputNodes, subBlocks)
+      }
+
+    // Add a workflow reorg applet if necessary
+    val (wf2: IR.Workflow, apl2: Vector[IR.Callable]) = reorg match {
+      case Left(reorg_flag) =>
+        if (reorg_flag) {
+          val (reorgStage, reorgApl) = buildReorgStage(wf.name, wfSourceStandAlone, wfOutputs)
+          (irwf.copy(stages = irwf.stages :+ reorgStage), irCallables :+ reorgApl)
+        } else {
+          (irwf, irCallables)
         }
 
-        (wf2, apl2)
+      // Only the top level workflow will have a custom reorg stage.
+      // All subworkflow are locked.
+      // Cannot use custom reorg stage with --locked flag.
+      // This is checked in Main.scala.
+      case Right(reorgAttributes) =>
+        if (!locked) {
+          val (reorgStage, reorgApl) =
+            addCustomReorgStage(wf.name, wfSourceStandAlone, wfOutputs, reorgAttributes)
+          (irwf.copy(stages = irwf.stages :+ reorgStage), irCallables :+ reorgApl)
+        } else {
+          (irwf, irCallables)
+        }
     }
 
-    def apply(): (IR.Workflow, Vector[IR.Callable]) = {
-        val (irwf, irCallables) = apply2()
+    (wf2, apl2)
+  }
 
-        // sanity check
-        val callableNames: Set[String] =
-            irCallables.map(_.name).toSet ++ callables.map(_._1).toSet
+  def apply(): (IR.Workflow, Vector[IR.Callable]) = {
+    val (irwf, irCallables) = apply2()
 
-        irwf.stages.foreach {
-            case stage =>
-                if (!(callableNames contains stage.calleeName)) {
-                    val allStages = irwf.stages.map{ case stg =>
-                        s"${stg}.description, ${stg}.id.getId"
-                    }.mkString("    ")
-                    throw new Exception(
-                        s"""|Generated bad workflow.
+    // sanity check
+    val callableNames: Set[String] =
+      irCallables.map(_.name).toSet ++ callables.map(_._1).toSet
+
+    irwf.stages.foreach {
+      case stage =>
+        if (!(callableNames contains stage.calleeName)) {
+          val allStages = irwf.stages
+            .map {
+              case stg =>
+                s"${stg}.description, ${stg}.id.getId"
+            }
+            .mkString("    ")
+          throw new Exception(s"""|Generated bad workflow.
                             |Stage <${stage.id.getId}, ${stage.description}> calls <${stage.calleeName}>
                             |which is missing.
                             |
                             |stages = ${allStages}
                             |callables = ${callableNames}
                             |""".stripMargin)
-                }
         }
-
-        (irwf, irCallables)
     }
+
+    (irwf, irCallables)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
@@ -124,7 +124,7 @@ case class GenerateIRWorkflow(
   // compile a call into a stage in an IR.Workflow
   private def compileCall(call: CallNode, env: CallEnv, locked: Boolean): IR.Stage = {
     // Find the callee
-    val calleeName          = Utils.getUnqualifiedName(call.callable.name)
+    val calleeName = Utils.getUnqualifiedName(call.callable.name)
     val callee: IR.Callable = callables(calleeName)
     val callInputs: Seq[AnonymousExpressionNode] = call.upstream.collect {
       case tcExpr: AnonymousExpressionNode => tcExpr
@@ -310,7 +310,7 @@ case class GenerateIRWorkflow(
       // complex sub-block. It could have many calls generating
       // many applets and subworkflows.
       val (stage, aux) = compileWfFragment(wfName, subBlocks(0), blockPath :+ 0, env)
-      val fragName     = stage.calleeName
+      val fragName = stage.calleeName
       val main = aux.find(_.name == fragName) match {
         case None    => throw new Exception(s"Could not find ${fragName}")
         case Some(x) => x
@@ -335,7 +335,7 @@ case class GenerateIRWorkflow(
       //       |
       //       |- stage-4
       //
-      val pathStr       = blockPath.map(x => x.toString).mkString("_")
+      val pathStr = blockPath.map(x => x.toString).mkString("_")
       val closureInputs = graphClosure(inputNodes, subBlocks)
       Utils.trace(
         verbose.on,
@@ -438,10 +438,10 @@ case class GenerateIRWorkflow(
         // add the iteration variable to the inner environment
         assert(sctNode.scatterVariableNodes.size == 1)
         val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
-        val iterVarName                 = svNode.identifier.localName.value
-        val cVar                        = CVar(iterVarName, svNode.womType, None)
-        val innerEnv                    = env + (iterVarName -> LinkedVar(cVar, IR.SArgEmpty))
-        val (callable, aux)             = compileNestedBlock(wfName, sctNode.innerGraph, blockPath, innerEnv)
+        val iterVarName = svNode.identifier.localName.value
+        val cVar = CVar(iterVarName, svNode.womType, None)
+        val innerEnv = env + (iterVarName -> LinkedVar(cVar, IR.SArgEmpty))
+        val (callable, aux) = compileNestedBlock(wfName, sctNode.innerGraph, blockPath, innerEnv)
         (Some(callable.name), aux :+ callable)
     }
 
@@ -483,7 +483,7 @@ case class GenerateIRWorkflow(
         cVar.name -> LinkedVar(cVar, sArg)
     }.toMap
 
-    var allStageInfo    = Vector.empty[(IR.Stage, Vector[IR.Callable])]
+    var allStageInfo = Vector.empty[(IR.Stage, Vector[IR.Callable])]
     var remainingBlocks = subBlocks
 
     // link together all the stages into a linear workflow
@@ -503,7 +503,7 @@ case class GenerateIRWorkflow(
           // Add bindings for the output variables. This allows later calls to refer
           // to these results.
           for (cVar <- stage.outputs) {
-            val fqn     = call.identifier.localName.value ++ "." + cVar.name
+            val fqn = call.identifier.localName.value ++ "." + cVar.name
             val cVarFqn = cVar.copy(name = fqn)
             env = env + (fqn -> LinkedVar(cVarFqn, IR.SArgLink(stage.id, cVar)))
           }
@@ -540,12 +540,12 @@ case class GenerateIRWorkflow(
   private def buildSimpleWorkflowOutput(outputNode: GraphOutputNode, env: CallEnv): (CVar, SArg) = {
     outputNode match {
       case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-        val cVar   = CVar(id.fullyQualifiedName.value, womType, None)
+        val cVar = CVar(id.fullyQualifiedName.value, womType, None)
         val source = sourcePort.name
         (cVar, getSArgFromEnv(source, env))
       case expr: ExpressionBasedGraphOutputNode
           if (Block.isTrivialExpression(expr.womType, expr.womExpression)) =>
-        val cVar   = CVar(expr.graphOutputPort.name, expr.womType, None)
+        val cVar = CVar(expr.graphOutputPort.name, expr.womType, None)
         val source = expr.womExpression.sourceString
         (cVar, getSArgFromEnv(source, env))
       case expr: ExpressionBasedGraphOutputNode =>
@@ -773,7 +773,7 @@ case class GenerateIRWorkflow(
     }.toVector
     val allWfInputs = wfInputs ++ clsInputs
 
-    val (allStageInfo, env)    = assembleBackbone(wfName, allWfInputs, blockPath, subBlocks, true)
+    val (allStageInfo, env) = assembleBackbone(wfName, allWfInputs, blockPath, subBlocks, true)
     val (stages, auxCallables) = allStageInfo.unzip
 
     // Handle outputs that are constants or variables, we can output them directly.

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -17,9 +17,9 @@ import dxWDL.dx.{DxFile, DxWorkflowStage}
 
 object IR {
   // stages that the compiler uses in generated DNAx workflows
-  val COMMON              = "common"
-  val OUTPUT_SECTION      = "outputs"
-  val REORG               = "reorg"
+  val COMMON = "common"
+  val OUTPUT_SECTION = "outputs"
+  val REORG = "reorg"
   val CUSTOM_REORG_CONFIG = "reorg_config"
 
   // Compile time representation of a variable. Used also as
@@ -74,8 +74,8 @@ object IR {
   //  DxAsset: the image is a platform asset
   //
   sealed trait DockerImage
-  case object DockerImageNone                                extends DockerImage
-  case object DockerImageNetwork                             extends DockerImage
+  case object DockerImageNone extends DockerImage
+  case object DockerImageNetwork extends DockerImage
   case class DockerImageDxFile(url: String, tarball: DxFile) extends DockerImage
 
   // A unified type representing a WDL workflow or a WDL applet.
@@ -96,7 +96,7 @@ object IR {
   //   WfOutputs:  evaluate workflow outputs
   //   WorkflowOutputReorg: move intermediate result files to a subdirectory.
   sealed trait AppletKind
-  case class AppletKindNative(id: String)                 extends AppletKind
+  case class AppletKindNative(id: String) extends AppletKind
   case class AppletKindTask(task: CallableTaskDefinition) extends AppletKind
   case class AppletKindWfFragment(
       calls: Vector[String],
@@ -106,11 +106,11 @@ object IR {
   case object AppletKindWfInputs extends AppletKind
 
   // Output - default and custom reorg
-  case object AppletKindWfOutputs            extends AppletKind
+  case object AppletKindWfOutputs extends AppletKind
   case object AppletKindWfCustomReorgOutputs extends AppletKind
 
   // Reorg - default and custom reorg
-  case object AppletKindWorkflowOutputReorg            extends AppletKind
+  case object AppletKindWorkflowOutputReorg extends AppletKind
   case class AppletKindWorkflowCustomReorg(id: String) extends AppletKind
 
   /** @param name          Name of applet
@@ -131,7 +131,7 @@ object IR {
       kind: AppletKind,
       womSourceCode: String
   ) extends Callable {
-    def inputVars  = inputs
+    def inputVars = inputs
     def outputVars = outputs
   }
 
@@ -140,10 +140,10 @@ object IR {
     *  or a workflow input.
     */
   sealed trait SArg
-  case object SArgEmpty                                        extends SArg
-  case class SArgConst(wdlValue: WomValue)                     extends SArg
+  case object SArgEmpty extends SArg
+  case class SArgConst(wdlValue: WomValue) extends SArg
   case class SArgLink(stageId: DxWorkflowStage, argName: CVar) extends SArg
-  case class SArgWorkflowInput(argName: CVar)                  extends SArg
+  case class SArgWorkflowInput(argName: CVar) extends SArg
 
   // A stage can call an applet or a workflow.
   //
@@ -178,7 +178,7 @@ object IR {
       locked: Boolean,
       level: Level.Value
   ) extends Callable {
-    def inputVars  = inputs.map { case (cVar, _)  => cVar }.toVector
+    def inputVars = inputs.map { case (cVar, _)   => cVar }.toVector
     def outputVars = outputs.map { case (cVar, _) => cVar }.toVector
   }
 

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -16,172 +16,179 @@ import dxWDL.base.Utils
 import dxWDL.dx.{DxFile, DxWorkflowStage}
 
 object IR {
-    // stages that the compiler uses in generated DNAx workflows
-    val COMMON = "common"
-    val OUTPUT_SECTION = "outputs"
-    val REORG = "reorg"
-    val CUSTOM_REORG_CONFIG = "reorg_config"
+  // stages that the compiler uses in generated DNAx workflows
+  val COMMON              = "common"
+  val OUTPUT_SECTION      = "outputs"
+  val REORG               = "reorg"
+  val CUSTOM_REORG_CONFIG = "reorg_config"
 
-    // Compile time representation of a variable. Used also as
-    // an applet argument.
+  // Compile time representation of a variable. Used also as
+  // an applet argument.
+  //
+  // The fullyQualifiedName could contains dots. However dx does not allow
+  // dots in applet/workflow arugment names, this requires some kind
+  // of transform.
+  //
+  //
+  // The attributes are used to encode DNAx applet input/output
+  // specification fields, such as {help, suggestions, patterns}.
+  //
+  case class CVar(name: String, womType: WomType, default: Option[WomValue]) {
+    // dx does not allow dots in variable names, so we
+    // convert them to underscores.
     //
-    // The fullyQualifiedName could contains dots. However dx does not allow
-    // dots in applet/workflow arugment names, this requires some kind
-    // of transform.
-    //
-    //
-    // The attributes are used to encode DNAx applet input/output
-    // specification fields, such as {help, suggestions, patterns}.
-    //
-    case class  CVar(name: String,
-                     womType: WomType,
-                     default: Option[WomValue]) {
-        // dx does not allow dots in variable names, so we
-        // convert them to underscores.
-        //
-        // TODO: check for collisions that are created this way.
-        def dxVarName : String = {
-            val nameNoDots = Utils.transformVarName(name)
-            assert(!(nameNoDots contains "."))
-            nameNoDots
-        }
+    // TODO: check for collisions that are created this way.
+    def dxVarName: String = {
+      val nameNoDots = Utils.transformVarName(name)
+      assert(!(nameNoDots contains "."))
+      nameNoDots
     }
+  }
 
+  /** Specification of instance type.
+    *
+    *  An instance could be:
+    *  Default: the platform default, useful for auxiliary calculations.
+    *  Const:   instance type is known at compile time. We can start the
+    *           job directly on the correct instance type.
+    *  Runtime: WDL specifies a calculation for the instance type, based
+    *           on information known only at runtime. The generated applet
+    *           will need to evalulate the expressions at runtime, and then
+    *           start another job on the correct instance type.
+    */
+  sealed trait InstanceType
+  case object InstanceTypeDefault extends InstanceType
+  case class InstanceTypeConst(
+      dxInstanceType: Option[String],
+      memoryMB: Option[Int],
+      diskGB: Option[Int],
+      cpu: Option[Int],
+      gpu: Option[Boolean]
+  ) extends InstanceType
+  case object InstanceTypeRuntime extends InstanceType
 
-    /** Specification of instance type.
-      *
-      *  An instance could be:
-      *  Default: the platform default, useful for auxiliary calculations.
-      *  Const:   instance type is known at compile time. We can start the
-      *           job directly on the correct instance type.
-      *  Runtime: WDL specifies a calculation for the instance type, based
-      *           on information known only at runtime. The generated applet
-      *           will need to evalulate the expressions at runtime, and then
-      *           start another job on the correct instance type.
-      */
-    sealed trait InstanceType
-    case object InstanceTypeDefault extends InstanceType
-    case class InstanceTypeConst(
-        dxInstanceType: Option[String],
-        memoryMB: Option[Int],
-        diskGB: Option[Int],
-        cpu: Option[Int],
-        gpu: Option[Boolean]
-    ) extends InstanceType
-    case object InstanceTypeRuntime extends InstanceType
+  // A task may specify a docker image to run under. There are three
+  // supported options:
+  //  None:    no image
+  //  Network: the image resides on a network site and requires download
+  //  DxAsset: the image is a platform asset
+  //
+  sealed trait DockerImage
+  case object DockerImageNone                                extends DockerImage
+  case object DockerImageNetwork                             extends DockerImage
+  case class DockerImageDxFile(url: String, tarball: DxFile) extends DockerImage
 
-    // A task may specify a docker image to run under. There are three
-    // supported options:
-    //  None:    no image
-    //  Network: the image resides on a network site and requires download
-    //  DxAsset: the image is a platform asset
-    //
-    sealed trait DockerImage
-    case object DockerImageNone extends DockerImage
-    case object DockerImageNetwork extends DockerImage
-    case class DockerImageDxFile(url: String, tarball: DxFile) extends DockerImage
+  // A unified type representing a WDL workflow or a WDL applet.
+  // This is useful when compiling WDL workflows, because they can
+  // call other WDL workflows and applets. This is done using the
+  // same syntax.
+  sealed trait Callable {
+    def name: String
+    def inputVars: Vector[CVar]
+    def outputVars: Vector[CVar]
+  }
 
-    // A unified type representing a WDL workflow or a WDL applet.
-    // This is useful when compiling WDL workflows, because they can
-    // call other WDL workflows and applets. This is done using the
-    // same syntax.
-    sealed trait Callable {
-        def name: String
-        def inputVars: Vector[CVar]
-        def outputVars: Vector[CVar]
-    }
+  // There are several kinds of applets
+  //   Native:     a native platform applet
+  //   Task:       call a task, execute a shell command (usually)
+  //   WfFragment: WDL workflow fragment, can included nested if/scatter blocks
+  //   WfInputs:   handle workflow inputs for unlocked workflows
+  //   WfOutputs:  evaluate workflow outputs
+  //   WorkflowOutputReorg: move intermediate result files to a subdirectory.
+  sealed trait AppletKind
+  case class AppletKindNative(id: String)                 extends AppletKind
+  case class AppletKindTask(task: CallableTaskDefinition) extends AppletKind
+  case class AppletKindWfFragment(
+      calls: Vector[String],
+      blockPath: Vector[Int],
+      fqnDictTypes: Map[String, WomType]
+  ) extends AppletKind
+  case object AppletKindWfInputs extends AppletKind
 
-    // There are several kinds of applets
-    //   Native:     a native platform applet
-    //   Task:       call a task, execute a shell command (usually)
-    //   WfFragment: WDL workflow fragment, can included nested if/scatter blocks
-    //   WfInputs:   handle workflow inputs for unlocked workflows
-    //   WfOutputs:  evaluate workflow outputs
-    //   WorkflowOutputReorg: move intermediate result files to a subdirectory.
-    sealed trait AppletKind
-    case class  AppletKindNative(id: String) extends AppletKind
-    case class  AppletKindTask(task: CallableTaskDefinition) extends AppletKind
-    case class  AppletKindWfFragment(calls: Vector[String],
-                                     blockPath: Vector[Int],
-                                     fqnDictTypes: Map[String, WomType]) extends AppletKind
-    case object AppletKindWfInputs extends AppletKind
+  // Output - default and custom reorg
+  case object AppletKindWfOutputs            extends AppletKind
+  case object AppletKindWfCustomReorgOutputs extends AppletKind
 
-    // Output - default and custom reorg
-    case object AppletKindWfOutputs extends AppletKind
-    case object AppletKindWfCustomReorgOutputs extends AppletKind
+  // Reorg - default and custom reorg
+  case object AppletKindWorkflowOutputReorg            extends AppletKind
+  case class AppletKindWorkflowCustomReorg(id: String) extends AppletKind
 
-    // Reorg - default and custom reorg
-    case object AppletKindWorkflowOutputReorg extends AppletKind
-    case class  AppletKindWorkflowCustomReorg(id: String) extends AppletKind
+  /** @param name          Name of applet
+    * @param inputs        input arguments
+    * @param outputs       output arguments
+    * @param instaceType   a platform instance name
+    * @param docker        is docker used? if so, what image
+    * @param kind          Kind of applet: task, scatter, ...
+    * @param task          Task definition
+    * @param womSourceCode WDL/CWL source code for task.
+    */
+  case class Applet(
+      name: String,
+      inputs: Vector[CVar],
+      outputs: Vector[CVar],
+      instanceType: InstanceType,
+      docker: DockerImage,
+      kind: AppletKind,
+      womSourceCode: String
+  ) extends Callable {
+    def inputVars  = inputs
+    def outputVars = outputs
+  }
 
-    /** @param name          Name of applet
-      * @param inputs        input arguments
-      * @param outputs       output arguments
-      * @param instaceType   a platform instance name
-      * @param docker        is docker used? if so, what image
-      * @param kind          Kind of applet: task, scatter, ...
-      * @param task          Task definition
-      * @param womSourceCode WDL/CWL source code for task.
-      */
-    case class Applet(name: String,
-                      inputs: Vector[CVar],
-                      outputs: Vector[CVar],
-                      instanceType: InstanceType,
-                      docker: DockerImage,
-                      kind: AppletKind,
-                      womSourceCode: String) extends Callable {
-        def inputVars = inputs
-        def outputVars = outputs
-    }
+  /** An input to a stage. Could be empty, a wdl constant,
+    *  a link to an output variable from another stage,
+    *  or a workflow input.
+    */
+  sealed trait SArg
+  case object SArgEmpty                                        extends SArg
+  case class SArgConst(wdlValue: WomValue)                     extends SArg
+  case class SArgLink(stageId: DxWorkflowStage, argName: CVar) extends SArg
+  case class SArgWorkflowInput(argName: CVar)                  extends SArg
 
-    /** An input to a stage. Could be empty, a wdl constant,
-      *  a link to an output variable from another stage,
-      *  or a workflow input.
-      */
-    sealed trait SArg
-    case object SArgEmpty extends SArg
-    case class SArgConst(wdlValue: WomValue) extends SArg
-    case class SArgLink(stageId: DxWorkflowStage, argName: CVar) extends SArg
-    case class SArgWorkflowInput(argName: CVar) extends SArg
+  // A stage can call an applet or a workflow.
+  //
+  // Note: the description may contain dots, parentheses, and other special
+  // symbols. It is shown to the user on the UI. The [id] is unique
+  // across the workflow.
+  case class Stage(
+      description: String,
+      id: DxWorkflowStage,
+      calleeName: String,
+      inputs: Vector[SArg],
+      outputs: Vector[CVar]
+  )
 
-    // A stage can call an applet or a workflow.
-    //
-    // Note: the description may contain dots, parentheses, and other special
-    // symbols. It is shown to the user on the UI. The [id] is unique
-    // across the workflow.
-    case class Stage(description: String,
-                     id: DxWorkflowStage,
-                     calleeName: String,
-                     inputs: Vector[SArg],
-                     outputs: Vector[CVar])
+  /** A workflow output is linked to the stage that
+    * generated it.
+    *
+    * If [level] is SubWorkflow, then a workflow matches part of a
+    * WDL workflow, it is not a first class citizen. It is compiled
+    * into a hidden dx:workflow.
+    */
+  object Level extends Enumeration {
+    val Top, Sub = Value
+  }
 
-    /** A workflow output is linked to the stage that
-      * generated it.
-      *
-      * If [level] is SubWorkflow, then a workflow matches part of a
-      * WDL workflow, it is not a first class citizen. It is compiled
-      * into a hidden dx:workflow.
-      */
-    object Level extends Enumeration {
-        val Top, Sub = Value
-    }
+  case class Workflow(
+      name: String,
+      inputs: Vector[(CVar, SArg)],
+      outputs: Vector[(CVar, SArg)],
+      stages: Vector[Stage],
+      womSourceCode: String,
+      locked: Boolean,
+      level: Level.Value
+  ) extends Callable {
+    def inputVars  = inputs.map { case (cVar, _)  => cVar }.toVector
+    def outputVars = outputs.map { case (cVar, _) => cVar }.toVector
+  }
 
-    case class Workflow(name: String,
-                        inputs: Vector[(CVar,SArg)],
-                        outputs: Vector[(CVar,SArg)],
-                        stages: Vector[Stage],
-                        womSourceCode: String,
-                        locked: Boolean,
-                        level: Level.Value) extends Callable {
-        def inputVars = inputs.map{ case (cVar,_) => cVar }.toVector
-        def outputVars = outputs.map{ case (cVar,_) => cVar }.toVector
-    }
-
-    // dependencies: the order in which to compile the workflows and tasks.
-    // The first element in the vector depends on nothing else. Each other
-    // element (may) depend on all previous elements.
-    case class Bundle(primaryCallable: Option[Callable],
-                      allCallables: Map[String, Callable],
-                      dependencies: Vector[String],
-                      typeAliases: Map[String, WomType])
+  // dependencies: the order in which to compile the workflows and tasks.
+  // The first element in the vector depends on nothing else. Each other
+  // element (may) depend on all previous elements.
+  case class Bundle(
+      primaryCallable: Option[Callable],
+      allCallables: Map[String, Callable],
+      dependencies: Vector[String],
+      typeAliases: Map[String, WomType]
+  )
 }

--- a/src/main/scala/dxWDL/compiler/InputFile.scala
+++ b/src/main/scala/dxWDL/compiler/InputFile.scala
@@ -62,8 +62,8 @@ case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbo
           JsString(k)
         }.toVector
         val valuesJs = jsValue.asJsObject.fields.values.toVector
-        val kFiles   = keysJs.flatMap(findDxFiles(keyType, _))
-        val vFiles   = valuesJs.flatMap(findDxFiles(valueType, _))
+        val kFiles = keysJs.flatMap(findDxFiles(keyType, _))
+        val vFiles = valuesJs.flatMap(findDxFiles(valueType, _))
         kFiles.toVector ++ vFiles.toVector
 
       // Two ways of writing pairs: an object with left/right fields, or an array
@@ -140,7 +140,7 @@ case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbo
 
   def apply(inputPath: Path): InputFileScanResults = {
     // Read the JSON values from the file
-    val content                      = Utils.readFileContent(inputPath).parseJson
+    val content = Utils.readFileContent(inputPath).parseJson
     val inputs: Map[String, JsValue] = content.asJsObject.fields
 
     val allCallables: Vector[IR.Callable] =
@@ -188,7 +188,7 @@ case class InputFile(
     typeAliases: Map[String, WomType],
     verbose: Verbose
 ) {
-  val verbose2: Boolean            = verbose.containsKey("InputFile")
+  val verbose2: Boolean = verbose.containsKey("InputFile")
   private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
 
   // Convert a job input to a WomValue. Do not download any files, convert them
@@ -205,7 +205,7 @@ case class InputFile(
       case (WomSingleFileType, JsObject(_)) =>
         // Convert the path in DNAx to a string. We can later
         // decide if we want to download it or not
-        val dxFile          = DxUtils.dxFileFromJsValue(jsValue)
+        val dxFile = DxUtils.dxFileFromJsValue(jsValue)
         val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
         WomSingleFile(s)
 
@@ -224,12 +224,12 @@ case class InputFile(
       // a few ways of writing a pair: an object, or an array
       case (WomPairType(lType, rType), JsObject(fields))
           if (List("left", "right").forall(fields contains _)) =>
-        val left  = womValueFromCromwellJSON(lType, fields("left"))
+        val left = womValueFromCromwellJSON(lType, fields("left"))
         val right = womValueFromCromwellJSON(rType, fields("right"))
         WomPair(left, right)
 
       case (WomPairType(lType, rType), JsArray(Vector(l, r))) =>
-        val left  = womValueFromCromwellJSON(lType, l)
+        val left = womValueFromCromwellJSON(lType, l)
         val right = womValueFromCromwellJSON(rType, r)
         WomPair(left, right)
 
@@ -255,7 +255,7 @@ case class InputFile(
         // convert each field
         val m = fields.map {
           case (key, value) =>
-            val t: WomType     = typeMap(key)
+            val t: WomType = typeMap(key)
             val elem: WomValue = womValueFromCromwellJSON(t, value)
             key -> elem
         }.toMap
@@ -393,7 +393,7 @@ case class InputFile(
       }
 
     // check that the stage order hasn't changed
-    val allStageNames      = wf.stages.map { _.id }.toVector
+    val allStageNames = wf.stages.map { _.id }.toVector
     val embedAllStageNames = wfWithDefaults.stages.map { _.id }.toVector
     assert(allStageNames == embedAllStageNames)
 
@@ -408,7 +408,7 @@ case class InputFile(
     Utils.trace(verbose.on, s"Embedding defaults into the IR")
 
     // read the default inputs file (xxxx.json)
-    val wdlDefaults: JsObject                   = Utils.readFileContent(defaultInputs).parseJson.asJsObject
+    val wdlDefaults: JsObject = Utils.readFileContent(defaultInputs).parseJson.asJsObject
     val defaultFields: HashMap[String, JsValue] = preprocessInputs(wdlDefaults)
 
     val callablesWithDefaults = bundle.allCallables.map {
@@ -479,13 +479,13 @@ case class InputFile(
     Utils.traceLevelInc()
 
     // read the input file xxxx.json
-    val wdlInputs: JsObject                   = Utils.readFileContent(inputPath).parseJson.asJsObject
+    val wdlInputs: JsObject = Utils.readFileContent(inputPath).parseJson.asJsObject
     val inputFields: HashMap[String, JsValue] = preprocessInputs(wdlInputs)
-    val cif                                   = CromwellInputFileState(inputFields, HashMap.empty)
+    val cif = CromwellInputFileState(inputFields, HashMap.empty)
 
     def handleTask(applet: IR.Applet): Unit = {
       applet.inputs.foreach { cVar =>
-        val fqn    = s"${applet.name}.${cVar.name}"
+        val fqn = s"${applet.name}.${cVar.name}"
         val dxName = s"${cVar.name}"
         cif.checkAndBind(fqn, dxName, cVar)
       }
@@ -512,7 +512,7 @@ case class InputFile(
         // inputs; nothing else.
         wf.inputs.foreach {
           case (cVar, sArg) =>
-            val fqn    = s"${wf.name}.${cVar.name}"
+            val fqn = s"${wf.name}.${cVar.name}"
             val dxName = s"${cVar.name}"
             cif.checkAndBind(fqn, dxName, cVar)
         }
@@ -526,7 +526,7 @@ case class InputFile(
         val commonStage = wf.stages.head.id.getId
         wf.inputs.foreach {
           case (cVar, _) =>
-            val fqn    = s"${wf.name}.${cVar.name}"
+            val fqn = s"${wf.name}.${cVar.name}"
             val dxName = s"${commonStage}.${cVar.name}"
             cif.checkAndBind(fqn, dxName, cVar)
         }
@@ -545,7 +545,7 @@ case class InputFile(
             case Some(x) => x
           }
           callee.inputVars.foreach { cVar =>
-            val fqn    = s"${wf.name}.${stg.description}.${cVar.name}"
+            val fqn = s"${wf.name}.${stg.description}.${cVar.name}"
             val dxName = s"${stg.description}.${cVar.name}"
             cif.checkAndBind(fqn, dxName, cVar)
           }

--- a/src/main/scala/dxWDL/compiler/InputFile.scala
+++ b/src/main/scala/dxWDL/compiler/InputFile.scala
@@ -41,506 +41,524 @@ import IR.{CVar, SArg, COMMON, OUTPUT_SECTION, REORG}
 // }
 //
 
-case class InputFileScanResults(path2file: Map[String, DxFile],
-                                dxFiles: Vector[DxFile])
+case class InputFileScanResults(path2file: Map[String, DxFile], dxFiles: Vector[DxFile])
 
-case class InputFileScan(bundle: IR.Bundle,
-                         dxProject: DxProject,
-                         verbose: Verbose) {
+case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbose) {
 
-    private def findDxFiles(womType: WomType,
-                            jsValue: JsValue) : Vector[JsValue] = {
-        (womType, jsValue)  match {
-            // base case: primitive types
-            case (WomBooleanType, _) => Vector.empty
-            case (WomIntegerType, _) => Vector.empty
-            case (WomFloatType, _) => Vector.empty
-            case (WomStringType, _) => Vector.empty
-            case (WomSingleFileType, jsv) => Vector(jsv)
+  private def findDxFiles(womType: WomType, jsValue: JsValue): Vector[JsValue] = {
+    (womType, jsValue) match {
+      // base case: primitive types
+      case (WomBooleanType, _)      => Vector.empty
+      case (WomIntegerType, _)      => Vector.empty
+      case (WomFloatType, _)        => Vector.empty
+      case (WomStringType, _)       => Vector.empty
+      case (WomSingleFileType, jsv) => Vector(jsv)
 
-            // Maps. These are serialized as an object with a keys array and
-            // a values array.
-            case (WomMapType(keyType, valueType), _) =>
-                //System.out.println(s"wom map    kv-type=(${keyType}, ${valueType})")
-                val keysJs = jsValue.asJsObject.fields.keys.map{ k => JsString(k)}.toVector
-                val valuesJs = jsValue.asJsObject.fields.values.toVector
-                val kFiles = keysJs.flatMap(findDxFiles(keyType, _))
-                val vFiles = valuesJs.flatMap(findDxFiles(valueType, _))
-                kFiles.toVector ++ vFiles.toVector
+      // Maps. These are serialized as an object with a keys array and
+      // a values array.
+      case (WomMapType(keyType, valueType), _) =>
+        //System.out.println(s"wom map    kv-type=(${keyType}, ${valueType})")
+        val keysJs = jsValue.asJsObject.fields.keys.map { k =>
+          JsString(k)
+        }.toVector
+        val valuesJs = jsValue.asJsObject.fields.values.toVector
+        val kFiles   = keysJs.flatMap(findDxFiles(keyType, _))
+        val vFiles   = valuesJs.flatMap(findDxFiles(valueType, _))
+        kFiles.toVector ++ vFiles.toVector
 
-                // Two ways of writing pairs: an object with left/right fields, or an array
-                // with two elements.
-            case (WomPairType(lType, rType), JsObject(fields))
-                    if (List("left", "right").forall(fields contains _)) =>
-                val lFiles = findDxFiles(lType, fields("left"))
-                val rFiles = findDxFiles(rType, fields("right"))
-                lFiles ++ rFiles
+      // Two ways of writing pairs: an object with left/right fields, or an array
+      // with two elements.
+      case (WomPairType(lType, rType), JsObject(fields))
+          if (List("left", "right").forall(fields contains _)) =>
+        val lFiles = findDxFiles(lType, fields("left"))
+        val rFiles = findDxFiles(rType, fields("right"))
+        lFiles ++ rFiles
 
-            case (WomPairType(lType, rType), JsArray(Vector(l,r))) =>
-                val lFiles = findDxFiles(lType, l)
-                val rFiles = findDxFiles(rType, r)
-                lFiles ++ rFiles
+      case (WomPairType(lType, rType), JsArray(Vector(l, r))) =>
+        val lFiles = findDxFiles(lType, l)
+        val rFiles = findDxFiles(rType, r)
+        lFiles ++ rFiles
 
-            case (WomArrayType(t), JsArray(vec)) =>
-                vec.flatMap( findDxFiles(t, _ ))
+      case (WomArrayType(t), JsArray(vec)) =>
+        vec.flatMap(findDxFiles(t, _))
 
-            case (WomOptionalType(t), JsNull) =>
-                Vector.empty
+      case (WomOptionalType(t), JsNull) =>
+        Vector.empty
 
-            case (WomOptionalType(t), jsv) =>
-                findDxFiles(t, jsv)
+      case (WomOptionalType(t), jsv) =>
+        findDxFiles(t, jsv)
 
-            // structs
-            case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
-                fields.flatMap {
-                    case (key, value) =>
-                        val t : WomType = typeMap(key)
-                        findDxFiles(t, value)
-                }.toVector
-
-            case _ =>
-                throw new AppInternalException(
-                    s"Unsupported combination ${womType} ${jsValue.prettyPrint}")
-        }
-    }
-
-    private def findFilesForApplet(inputs: Map[String, JsValue],
-                                   applet: IR.Applet) : Vector[JsValue] = {
-        applet.inputs.flatMap{
-            case cVar =>
-                val fqn = s"${applet.name}.${cVar.name}"
-                inputs.get(fqn) match {
-                    case None => None
-                    case Some(jsValue) =>
-                        Some(findDxFiles(cVar.womType, jsValue))
-                }
-        }.flatten.toVector
-    }
-
-    private def findFilesForWorkflow(inputs: Map[String, JsValue],
-                                     wf: IR.Workflow) : Vector[JsValue] = {
-        wf.inputs.flatMap {
-            case (cVar, _) =>
-                val fqn = s"${wf.name}.${cVar.name}"
-                inputs.get(fqn) match {
-                    case None => None
-                    case Some(jsValue) =>
-                        //System.out.println(s"findDxFiles ${cVar.womType} ${jsValue.prettyPrint}")
-                        Some(findDxFiles(cVar.womType, jsValue))
-                }
-        }.flatten.toVector
-    }
-
-    def apply(inputPath: Path) : InputFileScanResults = {
-        // Read the JSON values from the file
-        val content = Utils.readFileContent(inputPath).parseJson
-        val inputs: Map[String, JsValue] = content.asJsObject.fields
-
-        val allCallables: Vector[IR.Callable] =
-            bundle.primaryCallable.toVector ++ bundle.allCallables.map(_._2)
-
-        // Match each field with its WOM type, this allows
-        // accurately finding dx-files.
-        val jsFileDesc : Vector[JsValue] = allCallables.map {
-            case applet :IR.Applet =>
-                findFilesForApplet(inputs, applet)
-            case wf :IR.Workflow =>
-                findFilesForWorkflow(inputs, wf)
-        }.flatten.toVector
-
-        // files that have already been resolved
-        val dxFiles : Vector[DxFile] = jsFileDesc.collect{
-            case jsv : JsObject => DxUtils.dxFileFromJsValue(jsv)
+      // structs
+      case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
+        fields.flatMap {
+          case (key, value) =>
+            val t: WomType = typeMap(key)
+            findDxFiles(t, value)
         }.toVector
 
-        // Paths that look like this: "dx://dxWDL_playground:/test_data/fileB".
-        // These need to be resolved.
-        val dxPaths : Vector[String] = jsFileDesc.collect{
-            case JsString(x) => x
-        }.toVector
-        val resolvedPaths = DxPath.resolveBulk(dxPaths, dxProject).map {
-            case (key, dxobj) if dxobj.isInstanceOf[DxFile] =>
-                key -> dxobj.asInstanceOf[DxFile]
-            case (key, dxobj) =>
-                throw new Exception(s"Scanning the input file produced ${dxobj} which is not a file")
-        }.toMap
-
-        InputFileScanResults(resolvedPaths, (dxFiles ++ resolvedPaths.values))
+      case _ =>
+        throw new AppInternalException(s"Unsupported combination ${womType} ${jsValue.prettyPrint}")
     }
+  }
+
+  private def findFilesForApplet(
+      inputs: Map[String, JsValue],
+      applet: IR.Applet
+  ): Vector[JsValue] = {
+    applet.inputs
+      .flatMap {
+        case cVar =>
+          val fqn = s"${applet.name}.${cVar.name}"
+          inputs.get(fqn) match {
+            case None => None
+            case Some(jsValue) =>
+              Some(findDxFiles(cVar.womType, jsValue))
+          }
+      }
+      .flatten
+      .toVector
+  }
+
+  private def findFilesForWorkflow(
+      inputs: Map[String, JsValue],
+      wf: IR.Workflow
+  ): Vector[JsValue] = {
+    wf.inputs
+      .flatMap {
+        case (cVar, _) =>
+          val fqn = s"${wf.name}.${cVar.name}"
+          inputs.get(fqn) match {
+            case None          => None
+            case Some(jsValue) =>
+              //System.out.println(s"findDxFiles ${cVar.womType} ${jsValue.prettyPrint}")
+              Some(findDxFiles(cVar.womType, jsValue))
+          }
+      }
+      .flatten
+      .toVector
+  }
+
+  def apply(inputPath: Path): InputFileScanResults = {
+    // Read the JSON values from the file
+    val content                      = Utils.readFileContent(inputPath).parseJson
+    val inputs: Map[String, JsValue] = content.asJsObject.fields
+
+    val allCallables: Vector[IR.Callable] =
+      bundle.primaryCallable.toVector ++ bundle.allCallables.map(_._2)
+
+    // Match each field with its WOM type, this allows
+    // accurately finding dx-files.
+    val jsFileDesc: Vector[JsValue] = allCallables
+      .map {
+        case applet: IR.Applet =>
+          findFilesForApplet(inputs, applet)
+        case wf: IR.Workflow =>
+          findFilesForWorkflow(inputs, wf)
+      }
+      .flatten
+      .toVector
+
+    // files that have already been resolved
+    val dxFiles: Vector[DxFile] = jsFileDesc.collect {
+      case jsv: JsObject => DxUtils.dxFileFromJsValue(jsv)
+    }.toVector
+
+    // Paths that look like this: "dx://dxWDL_playground:/test_data/fileB".
+    // These need to be resolved.
+    val dxPaths: Vector[String] = jsFileDesc.collect {
+      case JsString(x) => x
+    }.toVector
+    val resolvedPaths = DxPath
+      .resolveBulk(dxPaths, dxProject)
+      .map {
+        case (key, dxobj) if dxobj.isInstanceOf[DxFile] =>
+          key -> dxobj.asInstanceOf[DxFile]
+        case (key, dxobj) =>
+          throw new Exception(s"Scanning the input file produced ${dxobj} which is not a file")
+      }
+      .toMap
+
+    InputFileScanResults(resolvedPaths, (dxFiles ++ resolvedPaths.values))
+  }
 }
 
-case class InputFile(fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
-                     path2file: Map[String, DxFile],
-                     typeAliases: Map[String, WomType],
-                     verbose: Verbose) {
-    val verbose2:Boolean = verbose.containsKey("InputFile")
-    private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
+case class InputFile(
+    fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
+    path2file: Map[String, DxFile],
+    typeAliases: Map[String, WomType],
+    verbose: Verbose
+) {
+  val verbose2: Boolean            = verbose.containsKey("InputFile")
+  private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
 
-    // Convert a job input to a WomValue. Do not download any files, convert them
-    // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
-    //
-    private def womValueFromCromwellJSON(womType: WomType,
-                                         jsValue: JsValue) : WomValue = {
-        (womType, jsValue)  match {
-            // base case: primitive types
-            case (WomBooleanType, JsBoolean(b)) => WomBoolean(b.booleanValue)
-            case (WomIntegerType, JsNumber(bnm)) => WomInteger(bnm.intValue)
-            case (WomFloatType, JsNumber(bnm)) => WomFloat(bnm.doubleValue)
-            case (WomStringType, JsString(s)) => WomString(s)
-            case (WomSingleFileType, JsString(s)) => WomSingleFile(s)
-            case (WomSingleFileType, JsObject(_)) =>
-                // Convert the path in DNAx to a string. We can later
-                // decide if we want to download it or not
-                val dxFile = DxUtils.dxFileFromJsValue(jsValue)
-                val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
-                WomSingleFile(s)
+  // Convert a job input to a WomValue. Do not download any files, convert them
+  // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
+  //
+  private def womValueFromCromwellJSON(womType: WomType, jsValue: JsValue): WomValue = {
+    (womType, jsValue) match {
+      // base case: primitive types
+      case (WomBooleanType, JsBoolean(b))   => WomBoolean(b.booleanValue)
+      case (WomIntegerType, JsNumber(bnm))  => WomInteger(bnm.intValue)
+      case (WomFloatType, JsNumber(bnm))    => WomFloat(bnm.doubleValue)
+      case (WomStringType, JsString(s))     => WomString(s)
+      case (WomSingleFileType, JsString(s)) => WomSingleFile(s)
+      case (WomSingleFileType, JsObject(_)) =>
+        // Convert the path in DNAx to a string. We can later
+        // decide if we want to download it or not
+        val dxFile          = DxUtils.dxFileFromJsValue(jsValue)
+        val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
+        WomSingleFile(s)
 
-            // Maps. These are serialized as an object with a keys array and
-            // a values array.
-            case (WomMapType(keyType, valueType), _) =>
-                val fields = jsValue.asJsObject.fields
-                val m: Map[WomValue, WomValue] = fields.map {
-                    case (k:String, v:JsValue) =>
-                        val kWom = womValueFromCromwellJSON(keyType, JsString(k))
-                        val vWom = womValueFromCromwellJSON(valueType, v)
-                        kWom -> vWom
-                }.toMap
-                WomMap(WomMapType(keyType, valueType), m)
-
-            // a few ways of writing a pair: an object, or an array
-            case (WomPairType(lType, rType), JsObject(fields))
-                    if (List("left", "right").forall(fields contains _)) =>
-                val left = womValueFromCromwellJSON(lType, fields("left"))
-                val right = womValueFromCromwellJSON(rType, fields("right"))
-                WomPair(left, right)
-
-            case (WomPairType(lType, rType), JsArray(Vector(l,r))) =>
-                val left = womValueFromCromwellJSON(lType, l)
-                val right = womValueFromCromwellJSON(rType, r)
-                WomPair(left, right)
-
-            // empty array
-            case (WomArrayType(t), JsNull) =>
-                WomArray(WomArrayType(t), List.empty[WomValue])
-
-            // array
-            case (WomArrayType(t), JsArray(vec)) =>
-                val wVec: Seq[WomValue] = vec.map{
-                    elem:JsValue => womValueFromCromwellJSON(t, elem)
-                }
-                WomArray(WomArrayType(t), wVec)
-
-            case (WomOptionalType(t), JsNull) =>
-                WomOptionalValue(t, None)
-            case (WomOptionalType(t), jsv) =>
-                val value = womValueFromCromwellJSON(t, jsv)
-                WomOptionalValue(t, Some(value))
-
-            // structs
-            case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
-                // convert each field
-                val m = fields.map {
-                    case (key, value) =>
-                        val t : WomType = typeMap(key)
-                        val elem: WomValue = womValueFromCromwellJSON(t, value)
-                        key -> elem
-                }.toMap
-                WomObject(m, WomCompositeType(typeMap, Some(structName)))
-
-            case _ =>
-                throw new AppInternalException(
-                    s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
-                )
-        }
-    }
-
-    // Import into a WDL value, and convert back to JSON.
-    private def translateValue(cVar: CVar,
-                               jsv: JsValue) : WdlVarLinks = {
-        val womValue = womValueFromCromwellJSON(cVar.womType, jsv)
-        wdlVarLinksConverter.importFromWDL(cVar.womType, womValue)
-    }
-
-    // skip comment lines, these start with ##.
-    private def preprocessInputs(obj: JsObject) : HashMap[String, JsValue] = {
-        val inputFields = HashMap.empty[String, JsValue]
-        obj.fields.foreach{ case (k,v) =>
-            if (!k.startsWith("##"))
-                inputFields(k) = v
-        }
-        inputFields
-    }
-
-
-    private def getExactlyOnce(fields: HashMap[String, JsValue],
-                               fqn: String) : Option[JsValue] = {
-        fields.get(fqn) match {
-            case None =>
-                Utils.trace(verbose2, s"getExactlyOnce ${fqn} => None")
-                None
-            case Some(v:JsValue) =>
-                Utils.trace(verbose2, s"getExactlyOnce ${fqn} => Some(${v})")
-                fields -= fqn
-                Some(v)
-        }
-    }
-
-    // If a stage has defaults, set the SArg to a constant. The user
-    // can override it at runtime.
-    private def addDefaultsToStage(stg: IR.Stage,
-                                   prefix: String,
-                                   callee: IR.Callable,
-                                   defaultFields: HashMap[String, JsValue]) : IR.Stage = {
-        Utils.trace(verbose2, s"addDefaultToStage ${stg.id.getId}, ${stg.description}")
-        val inputsFull:Vector[(SArg,CVar)] = stg.inputs.zipWithIndex.map{
-            case (sArg,idx) =>
-                val cVar = callee.inputVars(idx)
-                (sArg, cVar)
-        }
-        val inputsWithDefaults: Vector[SArg] = inputsFull.map{ case (sArg, cVar) =>
-            val fqn = s"${prefix}.${cVar.name}"
-            getExactlyOnce(defaultFields, fqn) match {
-                case None => sArg
-                case Some(dflt:JsValue) =>
-                    val w : WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
-                    IR.SArgConst(w)
-            }
-        }
-        stg.copy(inputs = inputsWithDefaults)
-    }
-
-
-    // Set defaults for workflow inputs.
-    private def addDefaultsToWorkflowInputs(inputs:Vector[(CVar, SArg)],
-                                            wfName:String,
-                                            defaultFields: HashMap[String, JsValue])
-            : Vector[(CVar, SArg)] = {
-        inputs.map { case (cVar, sArg) =>
-            val fqn = s"${wfName}.${cVar.name}"
-            val sArgDflt = getExactlyOnce(defaultFields, fqn) match {
-                case None => sArg
-                case Some(dflt:JsValue) =>
-                    val w : WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
-                    IR.SArgConst(w)
-            }
-            (cVar, sArgDflt)
-        }.toVector
-    }
-
-    // set defaults for a task
-    private def embedDefaultsIntoTask(applet: IR.Applet,
-                                      defaultFields:HashMap[String,JsValue]) : IR.Applet = {
-        val inputsWithDefaults: Vector[CVar] = applet.inputs.map {
-            case cVar =>
-                val fqn = s"${applet.name}.${cVar.name}"
-                getExactlyOnce(defaultFields, fqn) match {
-                    case None =>
-                        cVar
-                    case Some(dflt:JsValue) =>
-                        val w : WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
-                        cVar.copy(default = Some(w))
-                }
-        }.toVector
-        applet.copy(inputs = inputsWithDefaults)
-    }
-
-    // Embed default values into the workflow IR
-    //
-    // Make a sequential pass on the IR, figure out the fully qualified names
-    // of all CVar and SArgs. If they have a default value, add it as an attribute
-    // (DeclAttrs).
-    private def embedDefaultsIntoWorkflow(wf: IR.Workflow,
-                                          callables: Map[String, IR.Callable],
-                                          defaultFields:HashMap[String,JsValue]) : IR.Workflow = {
-        val wfWithDefaults =
-            if (wf.locked) {
-                // Locked workflows, we have workflow level inputs
-                val wfInputsWithDefaults = addDefaultsToWorkflowInputs(wf.inputs, wf.name,
-                                                                       defaultFields)
-                wf.copy(inputs = wfInputsWithDefaults)
-            } else {
-                // Workflow is unlocked, we don't have proper
-                // workflow level inputs. Instead, set the defaults in the COMMON stage
-
-                val stagesWithDefaults = wf.stages.map{ stg =>
-                    val callee:IR.Callable = callables(stg.calleeName)
-                    if (stg.id.getId == s"stage-${COMMON}") {
-                        addDefaultsToStage(stg, wf.name, callee, defaultFields)
-                    } else {
-                        addDefaultsToStage(stg, s"${wf.name}.${stg.description}", callee, defaultFields)
-                    }
-                }
-                wf.copy(stages = stagesWithDefaults)
-            }
-
-        // check that the stage order hasn't changed
-        val allStageNames = wf.stages.map{ _.id }.toVector
-        val embedAllStageNames = wfWithDefaults.stages.map{ _.id }.toVector
-        assert(allStageNames == embedAllStageNames)
-
-        wfWithDefaults
-    }
-
-    // Embed default values into the IR
-    //
-    // Make a sequential pass on the IR, figure out the fully qualified names
-    // of all CVar and SArgs. If they have a default value, embed it into the IR.
-    def embedDefaults(bundle: IR.Bundle,
-                      defaultInputs: Path) : IR.Bundle = {
-        Utils.trace(verbose.on, s"Embedding defaults into the IR")
-
-        // read the default inputs file (xxxx.json)
-        val wdlDefaults: JsObject = Utils.readFileContent(defaultInputs).parseJson.asJsObject
-        val defaultFields:HashMap[String,JsValue] = preprocessInputs(wdlDefaults)
-
-        val callablesWithDefaults = bundle.allCallables.map {
-            case (name, callable) =>
-                val callableWithDefaults = callable match {
-                    case applet : IR.Applet =>
-                        embedDefaultsIntoTask(applet, defaultFields)
-                    case subwf : IR.Workflow =>
-                        embedDefaultsIntoWorkflow(subwf, bundle.allCallables, defaultFields)
-                }
-                name -> callableWithDefaults
+      // Maps. These are serialized as an object with a keys array and
+      // a values array.
+      case (WomMapType(keyType, valueType), _) =>
+        val fields = jsValue.asJsObject.fields
+        val m: Map[WomValue, WomValue] = fields.map {
+          case (k: String, v: JsValue) =>
+            val kWom = womValueFromCromwellJSON(keyType, JsString(k))
+            val vWom = womValueFromCromwellJSON(valueType, v)
+            kWom -> vWom
         }.toMap
-        val primaryCallable = bundle.primaryCallable match {
-            case None => None
-            case Some(applet : IR.Applet) =>
-                Some(embedDefaultsIntoTask(applet, defaultFields))
-            case Some(wf : IR.Workflow) =>
-                Some(embedDefaultsIntoWorkflow(wf, bundle.allCallables, defaultFields))
+        WomMap(WomMapType(keyType, valueType), m)
+
+      // a few ways of writing a pair: an object, or an array
+      case (WomPairType(lType, rType), JsObject(fields))
+          if (List("left", "right").forall(fields contains _)) =>
+        val left  = womValueFromCromwellJSON(lType, fields("left"))
+        val right = womValueFromCromwellJSON(rType, fields("right"))
+        WomPair(left, right)
+
+      case (WomPairType(lType, rType), JsArray(Vector(l, r))) =>
+        val left  = womValueFromCromwellJSON(lType, l)
+        val right = womValueFromCromwellJSON(rType, r)
+        WomPair(left, right)
+
+      // empty array
+      case (WomArrayType(t), JsNull) =>
+        WomArray(WomArrayType(t), List.empty[WomValue])
+
+      // array
+      case (WomArrayType(t), JsArray(vec)) =>
+        val wVec: Seq[WomValue] = vec.map { elem: JsValue =>
+          womValueFromCromwellJSON(t, elem)
         }
-        if (!defaultFields.isEmpty) {
-            throw new Exception(s"""|Could not map all default fields.
+        WomArray(WomArrayType(t), wVec)
+
+      case (WomOptionalType(t), JsNull) =>
+        WomOptionalValue(t, None)
+      case (WomOptionalType(t), jsv) =>
+        val value = womValueFromCromwellJSON(t, jsv)
+        WomOptionalValue(t, Some(value))
+
+      // structs
+      case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
+        // convert each field
+        val m = fields.map {
+          case (key, value) =>
+            val t: WomType     = typeMap(key)
+            val elem: WomValue = womValueFromCromwellJSON(t, value)
+            key -> elem
+        }.toMap
+        WomObject(m, WomCompositeType(typeMap, Some(structName)))
+
+      case _ =>
+        throw new AppInternalException(
+          s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
+        )
+    }
+  }
+
+  // Import into a WDL value, and convert back to JSON.
+  private def translateValue(cVar: CVar, jsv: JsValue): WdlVarLinks = {
+    val womValue = womValueFromCromwellJSON(cVar.womType, jsv)
+    wdlVarLinksConverter.importFromWDL(cVar.womType, womValue)
+  }
+
+  // skip comment lines, these start with ##.
+  private def preprocessInputs(obj: JsObject): HashMap[String, JsValue] = {
+    val inputFields = HashMap.empty[String, JsValue]
+    obj.fields.foreach {
+      case (k, v) =>
+        if (!k.startsWith("##"))
+          inputFields(k) = v
+    }
+    inputFields
+  }
+
+  private def getExactlyOnce(fields: HashMap[String, JsValue], fqn: String): Option[JsValue] = {
+    fields.get(fqn) match {
+      case None =>
+        Utils.trace(verbose2, s"getExactlyOnce ${fqn} => None")
+        None
+      case Some(v: JsValue) =>
+        Utils.trace(verbose2, s"getExactlyOnce ${fqn} => Some(${v})")
+        fields -= fqn
+        Some(v)
+    }
+  }
+
+  // If a stage has defaults, set the SArg to a constant. The user
+  // can override it at runtime.
+  private def addDefaultsToStage(
+      stg: IR.Stage,
+      prefix: String,
+      callee: IR.Callable,
+      defaultFields: HashMap[String, JsValue]
+  ): IR.Stage = {
+    Utils.trace(verbose2, s"addDefaultToStage ${stg.id.getId}, ${stg.description}")
+    val inputsFull: Vector[(SArg, CVar)] = stg.inputs.zipWithIndex.map {
+      case (sArg, idx) =>
+        val cVar = callee.inputVars(idx)
+        (sArg, cVar)
+    }
+    val inputsWithDefaults: Vector[SArg] = inputsFull.map {
+      case (sArg, cVar) =>
+        val fqn = s"${prefix}.${cVar.name}"
+        getExactlyOnce(defaultFields, fqn) match {
+          case None => sArg
+          case Some(dflt: JsValue) =>
+            val w: WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
+            IR.SArgConst(w)
+        }
+    }
+    stg.copy(inputs = inputsWithDefaults)
+  }
+
+  // Set defaults for workflow inputs.
+  private def addDefaultsToWorkflowInputs(
+      inputs: Vector[(CVar, SArg)],
+      wfName: String,
+      defaultFields: HashMap[String, JsValue]
+  ): Vector[(CVar, SArg)] = {
+    inputs.map {
+      case (cVar, sArg) =>
+        val fqn = s"${wfName}.${cVar.name}"
+        val sArgDflt = getExactlyOnce(defaultFields, fqn) match {
+          case None => sArg
+          case Some(dflt: JsValue) =>
+            val w: WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
+            IR.SArgConst(w)
+        }
+        (cVar, sArgDflt)
+    }.toVector
+  }
+
+  // set defaults for a task
+  private def embedDefaultsIntoTask(
+      applet: IR.Applet,
+      defaultFields: HashMap[String, JsValue]
+  ): IR.Applet = {
+    val inputsWithDefaults: Vector[CVar] = applet.inputs.map {
+      case cVar =>
+        val fqn = s"${applet.name}.${cVar.name}"
+        getExactlyOnce(defaultFields, fqn) match {
+          case None =>
+            cVar
+          case Some(dflt: JsValue) =>
+            val w: WomValue = womValueFromCromwellJSON(cVar.womType, dflt)
+            cVar.copy(default = Some(w))
+        }
+    }.toVector
+    applet.copy(inputs = inputsWithDefaults)
+  }
+
+  // Embed default values into the workflow IR
+  //
+  // Make a sequential pass on the IR, figure out the fully qualified names
+  // of all CVar and SArgs. If they have a default value, add it as an attribute
+  // (DeclAttrs).
+  private def embedDefaultsIntoWorkflow(
+      wf: IR.Workflow,
+      callables: Map[String, IR.Callable],
+      defaultFields: HashMap[String, JsValue]
+  ): IR.Workflow = {
+    val wfWithDefaults =
+      if (wf.locked) {
+        // Locked workflows, we have workflow level inputs
+        val wfInputsWithDefaults = addDefaultsToWorkflowInputs(wf.inputs, wf.name, defaultFields)
+        wf.copy(inputs = wfInputsWithDefaults)
+      } else {
+        // Workflow is unlocked, we don't have proper
+        // workflow level inputs. Instead, set the defaults in the COMMON stage
+
+        val stagesWithDefaults = wf.stages.map { stg =>
+          val callee: IR.Callable = callables(stg.calleeName)
+          if (stg.id.getId == s"stage-${COMMON}") {
+            addDefaultsToStage(stg, wf.name, callee, defaultFields)
+          } else {
+            addDefaultsToStage(stg, s"${wf.name}.${stg.description}", callee, defaultFields)
+          }
+        }
+        wf.copy(stages = stagesWithDefaults)
+      }
+
+    // check that the stage order hasn't changed
+    val allStageNames      = wf.stages.map { _.id }.toVector
+    val embedAllStageNames = wfWithDefaults.stages.map { _.id }.toVector
+    assert(allStageNames == embedAllStageNames)
+
+    wfWithDefaults
+  }
+
+  // Embed default values into the IR
+  //
+  // Make a sequential pass on the IR, figure out the fully qualified names
+  // of all CVar and SArgs. If they have a default value, embed it into the IR.
+  def embedDefaults(bundle: IR.Bundle, defaultInputs: Path): IR.Bundle = {
+    Utils.trace(verbose.on, s"Embedding defaults into the IR")
+
+    // read the default inputs file (xxxx.json)
+    val wdlDefaults: JsObject                   = Utils.readFileContent(defaultInputs).parseJson.asJsObject
+    val defaultFields: HashMap[String, JsValue] = preprocessInputs(wdlDefaults)
+
+    val callablesWithDefaults = bundle.allCallables.map {
+      case (name, callable) =>
+        val callableWithDefaults = callable match {
+          case applet: IR.Applet =>
+            embedDefaultsIntoTask(applet, defaultFields)
+          case subwf: IR.Workflow =>
+            embedDefaultsIntoWorkflow(subwf, bundle.allCallables, defaultFields)
+        }
+        name -> callableWithDefaults
+    }.toMap
+    val primaryCallable = bundle.primaryCallable match {
+      case None => None
+      case Some(applet: IR.Applet) =>
+        Some(embedDefaultsIntoTask(applet, defaultFields))
+      case Some(wf: IR.Workflow) =>
+        Some(embedDefaultsIntoWorkflow(wf, bundle.allCallables, defaultFields))
+    }
+    if (!defaultFields.isEmpty) {
+      throw new Exception(s"""|Could not map all default fields.
                                     |These were left: ${defaultFields}""".stripMargin)
-        }
-        bundle.copy(primaryCallable = primaryCallable,
-                    allCallables = callablesWithDefaults)
+    }
+    bundle.copy(primaryCallable = primaryCallable, allCallables = callablesWithDefaults)
+  }
+
+  // Converting a Cromwell style input JSON file, into a valid DNAx input file
+  //
+  case class CromwellInputFileState(
+      inputFields: HashMap[String, JsValue],
+      dxKeyValues: HashMap[String, JsValue]
+  ) {
+    // If WDL variable fully qualified name [fqn] was provided in the
+    // input file, set [stage.cvar] to its JSON value
+    def checkAndBind(fqn: String, dxName: String, cVar: IR.CVar): Unit = {
+      getExactlyOnce(inputFields, fqn) match {
+        case None      => ()
+        case Some(jsv) =>
+          // Do not assign the value to any later stages.
+          // We found the variable declaration, the others
+          // are variable uses.
+          Utils.trace(verbose.on, s"${fqn} -> ${dxName}")
+          val wvl = translateValue(cVar, jsv)
+          wdlVarLinksConverter
+            .genFields(wvl, dxName, encodeDots = false)
+            .foreach { case (name, jsv) => dxKeyValues(name) = jsv }
+      }
     }
 
-    // Converting a Cromwell style input JSON file, into a valid DNAx input file
-    //
-    case class CromwellInputFileState(inputFields: HashMap[String,JsValue],
-                                      dxKeyValues: HashMap[String, JsValue]) {
-        // If WDL variable fully qualified name [fqn] was provided in the
-        // input file, set [stage.cvar] to its JSON value
-        def checkAndBind(fqn:String, dxName:String, cVar:IR.CVar) : Unit = {
-            getExactlyOnce(inputFields, fqn) match {
-                case None => ()
-                case Some(jsv) =>
-                    // Do not assign the value to any later stages.
-                    // We found the variable declaration, the others
-                     // are variable uses.
-                    Utils.trace(verbose.on, s"${fqn} -> ${dxName}")
-                    val wvl = translateValue(cVar, jsv)
-                    wdlVarLinksConverter.genFields(wvl, dxName, encodeDots=false)
-                        .foreach{ case (name, jsv) => dxKeyValues(name) = jsv }
-            }
-        }
-
-        // Check if all the input fields were actually used. Otherwise, there are some
-        // key/value pairs that were not translated to DNAx.
-        def checkAllUsed() : Unit = {
-            if (inputFields.isEmpty)
-                return
-            throw new Exception(s"""|Could not map all default fields.
+    // Check if all the input fields were actually used. Otherwise, there are some
+    // key/value pairs that were not translated to DNAx.
+    def checkAllUsed(): Unit = {
+      if (inputFields.isEmpty)
+        return
+      throw new Exception(s"""|Could not map all default fields.
                                     |These were left: ${inputFields}""".stripMargin)
-        }
+    }
+  }
+
+  // Build a dx input file, based on the JSON input file and the workflow
+  //
+  // The general idea here is to figure out the ancestry of each
+  // applet/call/workflow input. This provides the fully-qualified-name (fqn)
+  // of each IR variable. Then we check if the fqn is defined in
+  // the input file.
+  def dxFromCromwell(bundle: IR.Bundle, inputPath: Path): JsObject = {
+    Utils.trace(verbose.on, s"Translating WDL input file ${inputPath}")
+    Utils.traceLevelInc()
+
+    // read the input file xxxx.json
+    val wdlInputs: JsObject                   = Utils.readFileContent(inputPath).parseJson.asJsObject
+    val inputFields: HashMap[String, JsValue] = preprocessInputs(wdlInputs)
+    val cif                                   = CromwellInputFileState(inputFields, HashMap.empty)
+
+    def handleTask(applet: IR.Applet): Unit = {
+      applet.inputs.foreach { cVar =>
+        val fqn    = s"${applet.name}.${cVar.name}"
+        val dxName = s"${cVar.name}"
+        cif.checkAndBind(fqn, dxName, cVar)
+      }
     }
 
+    // If there is one task, we can generate one input file for it.
+    val tasks: Vector[IR.Applet] = bundle.allCallables.collect {
+      case (_, callable: IR.Applet) => callable
+    }.toVector
 
-    // Build a dx input file, based on the JSON input file and the workflow
-    //
-    // The general idea here is to figure out the ancestry of each
-    // applet/call/workflow input. This provides the fully-qualified-name (fqn)
-    // of each IR variable. Then we check if the fqn is defined in
-    // the input file.
-    def dxFromCromwell(bundle: IR.Bundle,
-                       inputPath: Path) : JsObject = {
-        Utils.trace(verbose.on, s"Translating WDL input file ${inputPath}")
-        Utils.traceLevelInc()
+    bundle.primaryCallable match {
+      // File with WDL tasks only, no workflows
+      case None if tasks.size == 0 =>
+        ()
+      case None if tasks.size == 1 =>
+        handleTask(tasks.head)
+      case None =>
+        throw new Exception(s"Cannot generate one input file for ${tasks.size} tasks")
+      case Some(task: IR.Applet) =>
+        handleTask(task)
 
-        // read the input file xxxx.json
-        val wdlInputs: JsObject = Utils.readFileContent(inputPath).parseJson.asJsObject
-        val inputFields:HashMap[String,JsValue] = preprocessInputs(wdlInputs)
-        val cif = CromwellInputFileState(inputFields, HashMap.empty)
+      case Some(wf: IR.Workflow) if wf.locked =>
+        // Locked workflow. A user can set workflow level
+        // inputs; nothing else.
+        wf.inputs.foreach {
+          case (cVar, sArg) =>
+            val fqn    = s"${wf.name}.${cVar.name}"
+            val dxName = s"${cVar.name}"
+            cif.checkAndBind(fqn, dxName, cVar)
+        }
+      case Some(wf: IR.Workflow) if wf.stages.isEmpty =>
+        // edge case: workflow, with zero stages
+        ()
 
-        def handleTask(applet: IR.Applet) : Unit = {
-            applet.inputs.foreach { cVar =>
-                val fqn = s"${applet.name}.${cVar.name}"
-                val dxName = s"${cVar.name}"
-                cif.checkAndBind(fqn, dxName, cVar)
-            }
+      case Some(wf: IR.Workflow) =>
+        // unlocked workflow with at least one stage.
+        // Workflow inputs go into the common stage
+        val commonStage = wf.stages.head.id.getId
+        wf.inputs.foreach {
+          case (cVar, _) =>
+            val fqn    = s"${wf.name}.${cVar.name}"
+            val dxName = s"${commonStage}.${cVar.name}"
+            cif.checkAndBind(fqn, dxName, cVar)
         }
 
-        // If there is one task, we can generate one input file for it.
-        val tasks : Vector[IR.Applet] = bundle.allCallables.collect{
-            case (_, callable : IR.Applet) => callable
-        }.toVector
-
-        bundle.primaryCallable match {
-            // File with WDL tasks only, no workflows
-            case None if tasks.size == 0 =>
-                ()
-            case None if tasks.size == 1 =>
-                handleTask(tasks.head)
+        // filter out auxiliary stages
+        val auxStages = Set(s"stage-${COMMON}", s"stage-${OUTPUT_SECTION}", s"stage-${REORG}")
+        val middleStages = wf.stages.filter { stg =>
+          !(auxStages contains stg.id.getId)
+        }
+        // Inputs for top level calls
+        middleStages.foreach { stg =>
+          // Find the input definitions for the stage, by locating the callee
+          val callee: IR.Callable = bundle.allCallables.get(stg.calleeName) match {
             case None =>
-                throw new Exception(s"Cannot generate one input file for ${tasks.size} tasks")
-            case Some(task: IR.Applet) =>
-                handleTask(task)
-
-            case Some(wf : IR.Workflow) if wf.locked =>
-                // Locked workflow. A user can set workflow level
-                // inputs; nothing else.
-                wf.inputs.foreach { case (cVar, sArg) =>
-                    val fqn = s"${wf.name}.${cVar.name}"
-                    val dxName = s"${cVar.name}"
-                    cif.checkAndBind(fqn, dxName, cVar)
-                }
-            case Some(wf : IR.Workflow) if wf.stages.isEmpty =>
-                // edge case: workflow, with zero stages
-                ()
-
-            case Some(wf : IR.Workflow) =>
-                // unlocked workflow with at least one stage.
-                // Workflow inputs go into the common stage
-                val commonStage = wf.stages.head.id.getId
-                wf.inputs.foreach { case (cVar, _) =>
-                    val fqn = s"${wf.name}.${cVar.name}"
-                    val dxName = s"${commonStage}.${cVar.name}"
-                    cif.checkAndBind(fqn, dxName, cVar)
-                }
-
-                // filter out auxiliary stages
-                val auxStages = Set(s"stage-${COMMON}",
-                                    s"stage-${OUTPUT_SECTION}",
-                                    s"stage-${REORG}")
-                val middleStages = wf.stages.filter{ stg =>
-                    !(auxStages contains stg.id.getId)
-                }
-                // Inputs for top level calls
-                middleStages.foreach{ stg =>
-                    // Find the input definitions for the stage, by locating the callee
-                    val callee : IR.Callable = bundle.allCallables.get(stg.calleeName) match {
-                        case None =>
-                            throw new Exception(s"callable ${stg.calleeName} is missing")
-                        case Some(x) => x
-                    }
-                    callee.inputVars.foreach { cVar =>
-                        val fqn = s"${wf.name}.${stg.description}.${cVar.name}"
-                        val dxName = s"${stg.description}.${cVar.name}"
-                        cif.checkAndBind(fqn, dxName, cVar)
-                    }
-                }
-
-            case other =>
-                throw new Exception(s"Unknown case ${other.getClass}")
+              throw new Exception(s"callable ${stg.calleeName} is missing")
+            case Some(x) => x
+          }
+          callee.inputVars.foreach { cVar =>
+            val fqn    = s"${wf.name}.${stg.description}.${cVar.name}"
+            val dxName = s"${stg.description}.${cVar.name}"
+            cif.checkAndBind(fqn, dxName, cVar)
+          }
         }
 
-        cif.checkAllUsed()
-
-        Utils.traceLevelDec()
-
-        JsObject(cif.dxKeyValues.toMap)
+      case other =>
+        throw new Exception(s"Unknown case ${other.getClass}")
     }
+
+    cif.checkAllUsed()
+
+    Utils.traceLevelDec()
+
+    JsObject(cif.dxKeyValues.toMap)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/InputFile.scala
+++ b/src/main/scala/dxWDL/compiler/InputFile.scala
@@ -41,11 +41,21 @@ import IR.{CVar, SArg, COMMON, OUTPUT_SECTION, REORG}
 // }
 //
 
-case class InputFileScanResults(path2file: Map[String, DxFile], dxFiles: Vector[DxFile])
+case class InputFileScanResults(
+    path2file: Map[String, DxFile],
+    dxFiles: Vector[DxFile]
+)
 
-case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbose) {
+case class InputFileScan(
+    bundle: IR.Bundle,
+    dxProject: DxProject,
+    verbose: Verbose
+) {
 
-  private def findDxFiles(womType: WomType, jsValue: JsValue): Vector[JsValue] = {
+  private def findDxFiles(
+      womType: WomType,
+      jsValue: JsValue
+  ): Vector[JsValue] = {
     (womType, jsValue) match {
       // base case: primitive types
       case (WomBooleanType, _)      => Vector.empty
@@ -97,7 +107,9 @@ case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbo
         }.toVector
 
       case _ =>
-        throw new AppInternalException(s"Unsupported combination ${womType} ${jsValue.prettyPrint}")
+        throw new AppInternalException(
+          s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
+        )
     }
   }
 
@@ -174,7 +186,9 @@ case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, verbose: Verbo
         case (key, dxobj) if dxobj.isInstanceOf[DxFile] =>
           key -> dxobj.asInstanceOf[DxFile]
         case (key, dxobj) =>
-          throw new Exception(s"Scanning the input file produced ${dxobj} which is not a file")
+          throw new Exception(
+            s"Scanning the input file produced ${dxobj} which is not a file"
+          )
       }
       .toMap
 
@@ -189,12 +203,16 @@ case class InputFile(
     verbose: Verbose
 ) {
   val verbose2: Boolean = verbose.containsKey("InputFile")
-  private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
 
   // Convert a job input to a WomValue. Do not download any files, convert them
   // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
   //
-  private def womValueFromCromwellJSON(womType: WomType, jsValue: JsValue): WomValue = {
+  private def womValueFromCromwellJSON(
+      womType: WomType,
+      jsValue: JsValue
+  ): WomValue = {
     (womType, jsValue) match {
       // base case: primitive types
       case (WomBooleanType, JsBoolean(b))   => WomBoolean(b.booleanValue)
@@ -285,7 +303,10 @@ case class InputFile(
     inputFields
   }
 
-  private def getExactlyOnce(fields: HashMap[String, JsValue], fqn: String): Option[JsValue] = {
+  private def getExactlyOnce(
+      fields: HashMap[String, JsValue],
+      fqn: String
+  ): Option[JsValue] = {
     fields.get(fqn) match {
       case None =>
         Utils.trace(verbose2, s"getExactlyOnce ${fqn} => None")
@@ -305,7 +326,10 @@ case class InputFile(
       callee: IR.Callable,
       defaultFields: HashMap[String, JsValue]
   ): IR.Stage = {
-    Utils.trace(verbose2, s"addDefaultToStage ${stg.id.getId}, ${stg.description}")
+    Utils.trace(
+      verbose2,
+      s"addDefaultToStage ${stg.id.getId}, ${stg.description}"
+    )
     val inputsFull: Vector[(SArg, CVar)] = stg.inputs.zipWithIndex.map {
       case (sArg, idx) =>
         val cVar = callee.inputVars(idx)
@@ -375,7 +399,8 @@ case class InputFile(
     val wfWithDefaults =
       if (wf.locked) {
         // Locked workflows, we have workflow level inputs
-        val wfInputsWithDefaults = addDefaultsToWorkflowInputs(wf.inputs, wf.name, defaultFields)
+        val wfInputsWithDefaults =
+          addDefaultsToWorkflowInputs(wf.inputs, wf.name, defaultFields)
         wf.copy(inputs = wfInputsWithDefaults)
       } else {
         // Workflow is unlocked, we don't have proper
@@ -386,7 +411,12 @@ case class InputFile(
           if (stg.id.getId == s"stage-${COMMON}") {
             addDefaultsToStage(stg, wf.name, callee, defaultFields)
           } else {
-            addDefaultsToStage(stg, s"${wf.name}.${stg.description}", callee, defaultFields)
+            addDefaultsToStage(
+              stg,
+              s"${wf.name}.${stg.description}",
+              callee,
+              defaultFields
+            )
           }
         }
         wf.copy(stages = stagesWithDefaults)
@@ -408,7 +438,8 @@ case class InputFile(
     Utils.trace(verbose.on, s"Embedding defaults into the IR")
 
     // read the default inputs file (xxxx.json)
-    val wdlDefaults: JsObject = Utils.readFileContent(defaultInputs).parseJson.asJsObject
+    val wdlDefaults: JsObject =
+      Utils.readFileContent(defaultInputs).parseJson.asJsObject
     val defaultFields: HashMap[String, JsValue] = preprocessInputs(wdlDefaults)
 
     val callablesWithDefaults = bundle.allCallables.map {
@@ -429,10 +460,15 @@ case class InputFile(
         Some(embedDefaultsIntoWorkflow(wf, bundle.allCallables, defaultFields))
     }
     if (!defaultFields.isEmpty) {
-      throw new Exception(s"""|Could not map all default fields.
-                                    |These were left: ${defaultFields}""".stripMargin)
+      throw new Exception(
+        s"""|Could not map all default fields.
+                                    |These were left: ${defaultFields}""".stripMargin
+      )
     }
-    bundle.copy(primaryCallable = primaryCallable, allCallables = callablesWithDefaults)
+    bundle.copy(
+      primaryCallable = primaryCallable,
+      allCallables = callablesWithDefaults
+    )
   }
 
   // Converting a Cromwell style input JSON file, into a valid DNAx input file
@@ -463,8 +499,10 @@ case class InputFile(
     def checkAllUsed(): Unit = {
       if (inputFields.isEmpty)
         return
-      throw new Exception(s"""|Could not map all default fields.
-                                    |These were left: ${inputFields}""".stripMargin)
+      throw new Exception(
+        s"""|Could not map all default fields.
+                                    |These were left: ${inputFields}""".stripMargin
+      )
     }
   }
 
@@ -479,7 +517,8 @@ case class InputFile(
     Utils.traceLevelInc()
 
     // read the input file xxxx.json
-    val wdlInputs: JsObject = Utils.readFileContent(inputPath).parseJson.asJsObject
+    val wdlInputs: JsObject =
+      Utils.readFileContent(inputPath).parseJson.asJsObject
     val inputFields: HashMap[String, JsValue] = preprocessInputs(wdlInputs)
     val cif = CromwellInputFileState(inputFields, HashMap.empty)
 
@@ -503,7 +542,9 @@ case class InputFile(
       case None if tasks.size == 1 =>
         handleTask(tasks.head)
       case None =>
-        throw new Exception(s"Cannot generate one input file for ${tasks.size} tasks")
+        throw new Exception(
+          s"Cannot generate one input file for ${tasks.size} tasks"
+        )
       case Some(task: IR.Applet) =>
         handleTask(task)
 
@@ -532,18 +573,20 @@ case class InputFile(
         }
 
         // filter out auxiliary stages
-        val auxStages = Set(s"stage-${COMMON}", s"stage-${OUTPUT_SECTION}", s"stage-${REORG}")
+        val auxStages =
+          Set(s"stage-${COMMON}", s"stage-${OUTPUT_SECTION}", s"stage-${REORG}")
         val middleStages = wf.stages.filter { stg =>
           !(auxStages contains stg.id.getId)
         }
         // Inputs for top level calls
         middleStages.foreach { stg =>
           // Find the input definitions for the stage, by locating the callee
-          val callee: IR.Callable = bundle.allCallables.get(stg.calleeName) match {
-            case None =>
-              throw new Exception(s"callable ${stg.calleeName} is missing")
-            case Some(x) => x
-          }
+          val callee: IR.Callable =
+            bundle.allCallables.get(stg.calleeName) match {
+              case None =>
+                throw new Exception(s"callable ${stg.calleeName} is missing")
+              case Some(x) => x
+            }
           callee.inputVars.foreach { cVar =>
             val fqn = s"${wf.name}.${stg.description}.${cVar.name}"
             val dxName = s"${stg.description}.${cVar.name}"

--- a/src/main/scala/dxWDL/compiler/InputFile.scala
+++ b/src/main/scala/dxWDL/compiler/InputFile.scala
@@ -108,7 +108,7 @@ case class InputFileScan(
 
       case _ =>
         throw new AppInternalException(
-          s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
+            s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
         )
     }
   }
@@ -187,7 +187,7 @@ case class InputFileScan(
           key -> dxobj.asInstanceOf[DxFile]
         case (key, dxobj) =>
           throw new Exception(
-            s"Scanning the input file produced ${dxobj} which is not a file"
+              s"Scanning the input file produced ${dxobj} which is not a file"
           )
       }
       .toMap
@@ -281,7 +281,7 @@ case class InputFile(
 
       case _ =>
         throw new AppInternalException(
-          s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
+            s"Unsupported combination ${womType} ${jsValue.prettyPrint}"
         )
     }
   }
@@ -327,8 +327,8 @@ case class InputFile(
       defaultFields: HashMap[String, JsValue]
   ): IR.Stage = {
     Utils.trace(
-      verbose2,
-      s"addDefaultToStage ${stg.id.getId}, ${stg.description}"
+        verbose2,
+        s"addDefaultToStage ${stg.id.getId}, ${stg.description}"
     )
     val inputsFull: Vector[(SArg, CVar)] = stg.inputs.zipWithIndex.map {
       case (sArg, idx) =>
@@ -412,10 +412,10 @@ case class InputFile(
             addDefaultsToStage(stg, wf.name, callee, defaultFields)
           } else {
             addDefaultsToStage(
-              stg,
-              s"${wf.name}.${stg.description}",
-              callee,
-              defaultFields
+                stg,
+                s"${wf.name}.${stg.description}",
+                callee,
+                defaultFields
             )
           }
         }
@@ -461,13 +461,13 @@ case class InputFile(
     }
     if (!defaultFields.isEmpty) {
       throw new Exception(
-        s"""|Could not map all default fields.
+          s"""|Could not map all default fields.
                                     |These were left: ${defaultFields}""".stripMargin
       )
     }
     bundle.copy(
-      primaryCallable = primaryCallable,
-      allCallables = callablesWithDefaults
+        primaryCallable = primaryCallable,
+        allCallables = callablesWithDefaults
     )
   }
 
@@ -500,7 +500,7 @@ case class InputFile(
       if (inputFields.isEmpty)
         return
       throw new Exception(
-        s"""|Could not map all default fields.
+          s"""|Could not map all default fields.
                                     |These were left: ${inputFields}""".stripMargin
       )
     }
@@ -543,7 +543,7 @@ case class InputFile(
         handleTask(tasks.head)
       case None =>
         throw new Exception(
-          s"Cannot generate one input file for ${tasks.size} tasks"
+            s"Cannot generate one input file for ${tasks.size} tasks"
         )
       case Some(task: IR.Applet) =>
         handleTask(task)

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -74,16 +74,16 @@ case class Native(
           case Some(x) => x
           case None =>
             throw new Exception(
-              s"record does not have an archive field ${details}"
+                s"record does not have an archive field ${details}"
             )
         }
         val dxFile = DxUtils.dxFileFromJsValue(dxLink)
         val name = dxFile.describe().name
         Some(
-          JsObject(
-            "name" -> JsString(name),
-            "id" -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
-          )
+            JsObject(
+                "name" -> JsString(name),
+                "id" -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
+            )
         )
     }
 
@@ -122,39 +122,39 @@ case class Native(
     }
     def mkPrimitive(dxType: String, optional: Boolean): Vector[JsValue] = {
       Vector(
-        JsObject(
-          Map("name" -> JsString(name), "class" -> JsString(dxType))
-            ++ jsMapFromOptional(optional)
-            ++ jsMapFromDefault(name)
-        )
+          JsObject(
+              Map("name" -> JsString(name), "class" -> JsString(dxType))
+                ++ jsMapFromOptional(optional)
+                ++ jsMapFromDefault(name)
+          )
       )
     }
     def mkPrimitiveArray(dxType: String, optional: Boolean): Vector[JsValue] = {
       Vector(
-        JsObject(
-          Map("name" -> JsString(name), "class" -> JsString("array:" ++ dxType))
-            ++ jsMapFromOptional(optional)
-            ++ jsMapFromDefault(name)
-        )
+          JsObject(
+              Map("name" -> JsString(name), "class" -> JsString("array:" ++ dxType))
+                ++ jsMapFromOptional(optional)
+                ++ jsMapFromDefault(name)
+          )
       )
     }
     def mkComplex(optional: Boolean): Vector[JsValue] = {
       // A large JSON structure passed as a hash, and a
       // vector of platform files.
       Vector(
-        JsObject(
-          Map("name" -> JsString(name), "class" -> JsString("hash"))
-            ++ jsMapFromOptional(optional)
-            ++ jsMapFromDefault(name)
-        ),
-        JsObject(
-          Map(
-            "name" -> JsString(name + Utils.FLAT_FILES_SUFFIX),
-            "class" -> JsString("array:file"),
-            "optional" -> JsBoolean(true)
+          JsObject(
+              Map("name" -> JsString(name), "class" -> JsString("hash"))
+                ++ jsMapFromOptional(optional)
+                ++ jsMapFromDefault(name)
+          ),
+          JsObject(
+              Map(
+                  "name" -> JsString(name + Utils.FLAT_FILES_SUFFIX),
+                  "class" -> JsString("array:file"),
+                  "optional" -> JsBoolean(true)
+              )
+                ++ jsMapFromDefault(name + Utils.FLAT_FILES_SUFFIX)
           )
-            ++ jsMapFromDefault(name + Utils.FLAT_FILES_SUFFIX)
-        )
       )
     }
     def handleType(wdlType: WomType, optional: Boolean): Vector[JsValue] = {
@@ -211,7 +211,7 @@ case class Native(
         } catch {
           case e: Throwable =>
             throw new Exception(
-              s"""|credentials has to point to a platform file.
+                s"""|credentials has to point to a platform file.
                                                 |It is now:
                                                 |   ${credentials}
                                                 |Error:
@@ -373,11 +373,11 @@ case class Native(
     val body: String = applet.kind match {
       case IR.AppletKindNative(_) =>
         throw new Exception(
-          "Sanity: generating a bash script for a native applet"
+            "Sanity: generating a bash script for a native applet"
         )
       case IR.AppletKindWorkflowCustomReorg(_) =>
         throw new Exception(
-          "Sanity: generating a bash script for a custom reorg applet"
+            "Sanity: generating a bash script for a custom reorg applet"
         )
       case IR.AppletKindWfFragment(_, _, _) =>
         genBashScriptWfFragment()
@@ -437,8 +437,8 @@ case class Native(
       fields: Map[String, JsValue]
   ): (String, JsValue) = {
     Utils.trace(
-      verbose2,
-      s"""|${name} -> checksum request
+        verbose2,
+        s"""|${name} -> checksum request
                                   |fields = ${JsObject(fields).prettyPrint}
                                   |
                                   |""".stripMargin
@@ -457,20 +457,20 @@ case class Native(
         case other                 => throw new Exception(s"Bad properties json value ${other}")
       }
     val props = preExistingProps ++ Map(
-      Utils.VERSION_PROP -> JsString(Utils.getVersion()),
-      Utils.CHECKSUM_PROP -> JsString(digest)
+        Utils.VERSION_PROP -> JsString(Utils.getVersion()),
+        Utils.CHECKSUM_PROP -> JsString(digest)
     )
 
     // Add properties and attributes we don't want to fall under the checksum
     // This allows, for example, moving the dx:executable, while
     // still being able to reuse it.
     val req = JsObject(
-      fields ++ Map(
-        "project" -> JsString(dxProject.id),
-        "folder" -> JsString(folder),
-        "parents" -> JsBoolean(true),
-        "properties" -> JsObject(props)
-      )
+        fields ++ Map(
+            "project" -> JsString(dxProject.id),
+            "folder" -> JsString(folder),
+            "parents" -> JsBoolean(true),
+            "properties" -> JsObject(props)
+        )
     )
     (digest, req)
   }
@@ -493,13 +493,13 @@ case class Native(
             Utils.trace(verbose.on, s"Found existing version of app ${name}")
           case apl: DxAppletDescribe =>
             Utils.trace(
-              verbose.on,
-              s"Found existing version of applet ${name} in folder ${apl.folder}"
+                verbose.on,
+                s"Found existing version of applet ${name} in folder ${apl.folder}"
             )
           case wf: DxWorkflowDescribe =>
             Utils.trace(
-              verbose.on,
-              s"Found existing version of workflow ${name} in folder ${wf.folder}"
+                verbose.on,
+                s"Found existing version of workflow ${name} in folder ${wf.folder}"
             )
           case other =>
             throw new Exception(s"bad object ${other}")
@@ -516,26 +516,26 @@ case class Native(
         dxObjInfo.digest match {
           case None =>
             throw new Exception(
-              s"There is an existing non-dxWDL applet ${name}"
+                s"There is an existing non-dxWDL applet ${name}"
             )
           case Some(digest2) if digest != digest2 =>
             Utils.trace(
-              verbose.on,
-              s"${dxObjInfo.dxClass} ${name} has changed, rebuild required"
+                verbose.on,
+                s"${dxObjInfo.dxClass} ${name} has changed, rebuild required"
             )
             true
           case Some(_) =>
             Utils.trace(
-              verbose.on,
-              s"${dxObjInfo.dxClass} ${name} has not changed"
+                verbose.on,
+                s"${dxObjInfo.dxClass} ${name} has not changed"
             )
             false
         }
       case _ =>
         val dxClass = existingDxObjs.head.dxClass
         Utils.warning(
-          verbose,
-          s"""|More than one ${dxClass} ${name} found in
+            verbose,
+            s"""|More than one ${dxClass} ${name} found in
                                            |path ${dxProject.id}:${folder}""".stripMargin
         )
         true
@@ -555,7 +555,7 @@ case class Native(
         } else {
           val dxClass = existingDxObjs.head.dxClass
           throw new Exception(
-            s"""|${dxClass} ${name} already exists in
+              s"""|${dxClass} ${name} already exists in
                                             | ${dxProject.id}:${folder}""".stripMargin
           )
         }
@@ -629,30 +629,30 @@ case class Native(
     }
     //System.out.println(s"Native: instanceType chosen = ${instanceType}")
     val runSpec: Map[String, JsValue] = Map(
-      "code" -> JsString(bashScript),
-      "interpreter" -> JsString("bash"),
-      "systemRequirements" ->
-        JsObject(
-          "main" ->
-            JsObject("instanceType" -> JsString(instanceType))
-        ),
-      "distribution" -> JsString("Ubuntu"),
-      "release" -> JsString(Utils.UBUNTU_VERSION)
+        "code" -> JsString(bashScript),
+        "interpreter" -> JsString("bash"),
+        "systemRequirements" ->
+          JsObject(
+              "main" ->
+                JsObject("instanceType" -> JsString(instanceType))
+          ),
+        "distribution" -> JsString("Ubuntu"),
+        "release" -> JsString(Utils.UBUNTU_VERSION)
     )
 
     // Add default timeout
     val defaultTimeout: Map[String, JsValue] =
       DxRunSpec(
-        None,
-        None,
-        None,
-        Some(
-          DxTimeout(
-            Some(Utils.DEFAULT_APPLET_TIMEOUT_IN_DAYS),
-            Some(0),
-            Some(0)
+          None,
+          None,
+          None,
+          Some(
+              DxTimeout(
+                  Some(Utils.DEFAULT_APPLET_TIMEOUT_IN_DAYS),
+                  Some(0),
+                  Some(0)
+              )
           )
-        )
       ).toRunSpecJson
 
     // Start with the default dx-attribute section, and override
@@ -785,13 +785,13 @@ case class Native(
         case IR.AppletKindWfFragment(calls, blockPath, fqnDictTypes) =>
           // meta information used for running workflow fragments
           Map(
-            "execLinkInfo" -> JsObject(linkInfo),
-            "blockPath" -> JsArray(blockPath.map(JsNumber(_))),
-            "fqnDictTypes" -> JsObject(fqnDictTypes.map {
-              case (k, t) =>
-                val tStr = WomTypeSerialization(typeAliases).toString(t)
-                k -> JsString(tStr)
-            }.toMap)
+              "execLinkInfo" -> JsObject(linkInfo),
+              "blockPath" -> JsArray(blockPath.map(JsNumber(_))),
+              "fqnDictTypes" -> JsObject(fqnDictTypes.map {
+                case (k, t) =>
+                  val tStr = WomTypeSerialization(typeAliases).toString(t)
+                  k -> JsString(tStr)
+              }.toMap)
           )
 
         case IR.AppletKindWfInputs | IR.AppletKindWfOutputs | IR.AppletKindWfCustomReorgOutputs |
@@ -826,9 +826,9 @@ case class Native(
       case Some(ext) => ext.defaultRuntimeAttributes.toJson
     }
     val auxInfo = Map(
-      "womSourceCode" -> JsString(womSourceCode),
-      "instanceTypeDB" -> JsString(dbOpaqueInstance),
-      "runtimeAttrs" -> runtimeAttrs
+        "womSourceCode" -> JsString(womSourceCode),
+        "instanceTypeDB" -> JsString(dbOpaqueInstance),
+        "runtimeAttrs" -> runtimeAttrs
     )
 
     // Links to applets that could get called at runtime. If
@@ -836,7 +836,7 @@ case class Native(
     val dxLinks = aplLinks.map {
       case (name, execLinkInfo) =>
         ("link_" + name) -> JsObject(
-          "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId)
+            "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId)
         )
     }.toMap
     val (runSpec: JsValue, details: Map[String, JsValue]) =
@@ -856,14 +856,14 @@ case class Native(
 
     // pack all the core arguments into a single request
     val reqCore = Map(
-      "name" -> JsString(applet.name),
-      "inputSpec" -> JsArray(inputSpec),
-      "outputSpec" -> JsArray(outputSpec),
-      "runSpec" -> runSpec,
-      "dxapi" -> JsString("1.0.0"),
-      "tags" -> JsArray(JsString("dxWDL")),
-      "details" -> jsDetails,
-      "hidden" -> JsBoolean(hidden)
+        "name" -> JsString(applet.name),
+        "inputSpec" -> JsArray(inputSpec),
+        "outputSpec" -> JsArray(outputSpec),
+        "runSpec" -> runSpec,
+        "dxapi" -> JsString("1.0.0"),
+        "tags" -> JsArray(JsString("dxWDL")),
+        "details" -> jsDetails,
+        "hidden" -> JsBoolean(hidden)
     )
     val accessField =
       if (access == JsNull) Map.empty
@@ -912,8 +912,8 @@ case class Native(
       case None =>
         // Compile a WDL snippet into an applet.
         val rep = DXAPI.appletNew(
-          DxUtils.jsonNodeOfJsValue(appletApiRequest),
-          classOf[JsonNode]
+            DxUtils.jsonNodeOfJsValue(appletApiRequest),
+            classOf[JsonNode]
         )
         val id = apiParseReplyID(rep)
         val dxApplet = DxApplet.getInstance(id)
@@ -947,8 +947,8 @@ case class Native(
               m ++ fields.toMap
             case IR.SArgLink(dxStage, argName) =>
               val wvl = WdlVarLinks(
-                cVar.womType,
-                DxlStage(dxStage, IORef.Output, argName.dxVarName)
+                  cVar.womType,
+                  DxlStage(dxStage, IORef.Output, argName.dxVarName)
               )
               val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
               m ++ fields.toMap
@@ -1010,12 +1010,12 @@ case class Native(
       case IR.SArgConst(wdlValue) =>
         // constant
         throw new Exception(
-          s"Constant workflow outputs not currently handled (${cVar}, ${sArg}, ${wdlValue})"
+            s"Constant workflow outputs not currently handled (${cVar}, ${sArg}, ${wdlValue})"
         )
       case IR.SArgLink(dxStage, argName: CVar) =>
         val wvl = WdlVarLinks(
-          cVar.womType,
-          DxlStage(dxStage, IORef.Output, argName.dxVarName)
+            cVar.womType,
+            DxlStage(dxStage, IORef.Output, argName.dxVarName)
         )
         wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
       case IR.SArgWorkflowInput(argName: CVar) =>
@@ -1030,8 +1030,8 @@ case class Native(
       case (fieldName, outputJs) =>
         val specJs: JsValue = oSpecMap(fieldName)
         JsObject(
-          specJs.asJsObject.fields ++
-            Map("outputSource" -> outputJs)
+            specJs.asJsObject.fields ++
+              Map("outputSource" -> outputJs)
         )
     }.toVector
   }
@@ -1052,12 +1052,12 @@ case class Native(
           val inputs = genStageInputs(linkedInputs)
           // convert the per-stage metadata into JSON
           val stageReqDesc = JsObject(
-            Map(
-              "id" -> JsString(stg.id.getId),
-              "executable" -> JsString(dxExec.getId),
-              "name" -> JsString(stg.description),
-              "input" -> inputs
-            )
+              Map(
+                  "id" -> JsString(stg.id.getId),
+                  "executable" -> JsString(dxExec.getId),
+                  "name" -> JsString(stg.description),
+                  "input" -> inputs
+              )
           )
           stagesReq :+ stageReqDesc
       }
@@ -1075,10 +1075,10 @@ case class Native(
 
     // pack all the arguments into a single API call
     val reqFields = Map(
-      "name" -> JsString(wf.name),
-      "stages" -> JsArray(stagesReq),
-      "tags" -> JsArray(JsString("dxWDL")),
-      "hidden" -> JsBoolean(hidden)
+        "name" -> JsString(wf.name),
+        "stages" -> JsArray(stagesReq),
+        "tags" -> JsArray(JsString("dxWDL")),
+        "hidden" -> JsBoolean(hidden)
     )
 
     val wfInputOutput: Map[String, JsValue] =
@@ -1093,8 +1093,8 @@ case class Native(
           .map { case (cVar, sArg) => buildWorkflowOutputSpec(cVar, sArg) }
           .flatten
         Map(
-          "inputs" -> JsArray(wfInputSpec),
-          "outputs" -> JsArray(wfOutputSpec)
+            "inputs" -> JsArray(wfInputSpec),
+            "outputs" -> JsArray(wfOutputSpec)
         )
       } else {
         Map.empty
@@ -1112,7 +1112,7 @@ case class Native(
     val dxLinks: Map[String, JsValue] = transitiveDependencies.map {
       case execLinkInfo =>
         ("link_" + execLinkInfo.name) -> JsObject(
-          "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId)
+            "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId)
         )
     }.toMap
 
@@ -1129,11 +1129,11 @@ case class Native(
     // still being able to reuse it.
     val reqWithEverything =
       JsObject(
-        reqWithChecksum.asJsObject.fields ++ Map(
-          "project" -> JsString(dxProject.id),
-          "folder" -> JsString(folder),
-          "parents" -> JsBoolean(true)
-        )
+          reqWithChecksum.asJsObject.fields ++ Map(
+              "project" -> JsString(dxProject.id),
+              "folder" -> JsString(folder),
+              "parents" -> JsBoolean(true)
+          )
       )
     (digest, reqWithEverything)
   }

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -21,174 +21,187 @@ import IR.{CVar, SArg}
 // An overall design principal here, is that the json requests
 // have to be deterministic. This is because the checksums rely
 // on that property.
-case class Native(dxWDLrtId: Option[String],
-                  folder: String,
-                  dxProject: DxProject,
-                  dxObjDir: DxObjectDirectory,
-                  instanceTypeDB: InstanceTypeDB,
-                  dxPathConfig: DxPathConfig,
-                  fileInfoDir : Map[String, (DxFile, DxFileDescribe)],
-                  typeAliases: Map[String, WomType],
-                  extras: Option[Extras],
-                  runtimeDebugLevel: Option[Int],
-                  leaveWorkflowsOpen: Boolean,
-                  force: Boolean,
-                  archive: Boolean,
-                  locked: Boolean,
-                  verbose: Verbose) {
-    case class ExecRecord(callable: IR.Callable,
-                          dxExec: DxExecutable,
-                          links: Vector[ExecLinkInfo])
+case class Native(
+    dxWDLrtId: Option[String],
+    folder: String,
+    dxProject: DxProject,
+    dxObjDir: DxObjectDirectory,
+    instanceTypeDB: InstanceTypeDB,
+    dxPathConfig: DxPathConfig,
+    fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
+    typeAliases: Map[String, WomType],
+    extras: Option[Extras],
+    runtimeDebugLevel: Option[Int],
+    leaveWorkflowsOpen: Boolean,
+    force: Boolean,
+    archive: Boolean,
+    locked: Boolean,
+    verbose: Verbose
+) {
+  case class ExecRecord(callable: IR.Callable, dxExec: DxExecutable, links: Vector[ExecLinkInfo])
 
-    private val verbose2:Boolean = verbose.containsKey("Native")
-    private val rtDebugLvl = runtimeDebugLevel.getOrElse(Utils.DEFAULT_RUNTIME_DEBUG_LEVEL)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
-    private val streamAllFiles:Boolean = dxPathConfig.streamAllFiles
+  private val verbose2: Boolean       = verbose.containsKey("Native")
+  private val rtDebugLvl              = runtimeDebugLevel.getOrElse(Utils.DEFAULT_RUNTIME_DEBUG_LEVEL)
+  private val wdlVarLinksConverter    = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
+  private val streamAllFiles: Boolean = dxPathConfig.streamAllFiles
 
-    // Are we setting up a private docker registry?
-    private val dockerRegistryInfo : Option[DockerRegistry]= extras match {
-        case None => None
-        case Some(extras) =>
-            extras.dockerRegistry match {
-                case None => None
-                case Some(x) => Some(x)
-            }
+  // Are we setting up a private docker registry?
+  private val dockerRegistryInfo: Option[DockerRegistry] = extras match {
+    case None => None
+    case Some(extras) =>
+      extras.dockerRegistry match {
+        case None    => None
+        case Some(x) => Some(x)
+      }
+  }
+
+  lazy val runtimeLibrary: Option[JsValue] =
+    dxWDLrtId match {
+      case None     => None
+      case Some(id) =>
+        // Open the archive
+        // Extract the archive from the details field
+        val record  = DxRecord.getInstance(id)
+        val desc    = record.describe(Set(Field.Details))
+        val details = desc.details.get
+        val dxLink = details.asJsObject.fields.get("archiveFileId") match {
+          case Some(x) => x
+          case None    => throw new Exception(s"record does not have an archive field ${details}")
+        }
+        val dxFile = DxUtils.dxFileFromJsValue(dxLink)
+        val name   = dxFile.describe().name
+        Some(
+          JsObject(
+            "name" -> JsString(name),
+            "id"   -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
+          )
+        )
     }
 
-    lazy val runtimeLibrary: Option[JsValue] =
-        dxWDLrtId match {
-            case None => None
-            case Some(id) =>
-                // Open the archive
-                // Extract the archive from the details field
-                val record = DxRecord.getInstance(id)
-                val desc = record.describe(Set(Field.Details))
-                val details = desc.details.get
-                val dxLink = details.asJsObject.fields.get("archiveFileId") match {
-                    case Some(x) => x
-                    case None => throw new Exception(s"record does not have an archive field ${details}")
-                }
-                val dxFile = DxUtils.dxFileFromJsValue(dxLink)
-                val name = dxFile.describe().name
-                Some(JsObject(
-                         "name" -> JsString(name),
-                         "id" -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
-                     ))
-        }
-
-    // For primitive types, and arrays of such types, we can map directly
-    // to the equivalent dx types. For example,
-    //   Int  -> int
-    //   Array[String] -> array:string
-    //
-    // Arrays can be empty, which is why they are always marked "optional".
-    // This notifies the platform runtime system not to throw an exception
-    // for an empty input/output array.
-    //
-    // Ragged arrays, maps, and objects, cannot be mapped in such a trivial way.
-    // These are called "Complex Types", or "Complex". They are handled
-    // by passing a JSON structure and a vector of dx:files.
-    private def cVarToSpec(cVar: CVar) : Vector[JsValue] = {
-        val name = cVar.dxVarName
-        val defaultVals:Map[String, JsValue] = cVar.default match {
-            case None => Map.empty
-            case Some(wdlValue) =>
-                val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wdlValue)
-                wdlVarLinksConverter.genFields(wvl, name).toMap
-        }
-        def jsMapFromDefault(name: String) : Map[String, JsValue] = {
-            defaultVals.get(name) match {
-                case None => Map.empty
-                case Some(jsv) => Map("default" -> jsv)
-            }
-        }
-        def jsMapFromOptional(optional: Boolean) : Map[String, JsValue] = {
-            if (optional) {
-                Map("optional" -> JsBoolean(true))
-            } else {
-                Map.empty[String, JsValue]
-            }
-        }
-        def mkPrimitive(dxType: String, optional: Boolean) : Vector[JsValue] = {
-            Vector(JsObject(Map("name" -> JsString(name),
-                                "class" -> JsString(dxType))
-                                ++ jsMapFromOptional(optional)
-                                ++ jsMapFromDefault(name)))
-        }
-        def mkPrimitiveArray(dxType: String, optional:Boolean) : Vector[JsValue] = {
-            Vector(JsObject(Map("name" -> JsString(name),
-                                "class" -> JsString("array:" ++ dxType))
-                                ++ jsMapFromOptional(optional)
-                                ++ jsMapFromDefault(name)))
-        }
-        def mkComplex(optional: Boolean) : Vector[JsValue] = {
-            // A large JSON structure passed as a hash, and a
-            // vector of platform files.
-            Vector(JsObject(Map("name" -> JsString(name),
-                                "class" -> JsString("hash"))
-                                ++ jsMapFromOptional(optional)
-                                ++ jsMapFromDefault(name)),
-                   JsObject(Map("name" -> JsString(name + Utils.FLAT_FILES_SUFFIX),
-                                "class" -> JsString("array:file"),
-                                "optional" -> JsBoolean(true))
-                                ++ jsMapFromDefault(name + Utils.FLAT_FILES_SUFFIX)))
-        }
-        def handleType(wdlType: WomType,
-                       optional: Boolean) : Vector[JsValue] = {
-            wdlType match {
-                // primitive types
-                case WomBooleanType => mkPrimitive("boolean", optional)
-                case WomIntegerType => mkPrimitive("int", optional)
-                case WomFloatType => mkPrimitive("float", optional)
-                case WomStringType =>mkPrimitive("string", optional)
-                case WomSingleFileType => mkPrimitive("file", optional)
-
-                // single dimension arrays of primitive types
-                case WomNonEmptyArrayType(WomBooleanType) => mkPrimitiveArray("boolean", optional)
-                case WomNonEmptyArrayType(WomIntegerType) => mkPrimitiveArray("int", optional)
-                case WomNonEmptyArrayType(WomFloatType) => mkPrimitiveArray("float", optional)
-                case WomNonEmptyArrayType(WomStringType) => mkPrimitiveArray("string", optional)
-                case WomNonEmptyArrayType(WomSingleFileType) => mkPrimitiveArray("file", optional)
-                case WomMaybeEmptyArrayType(WomBooleanType) => mkPrimitiveArray("boolean", true)
-                case WomMaybeEmptyArrayType(WomIntegerType) => mkPrimitiveArray("int", true)
-                case WomMaybeEmptyArrayType(WomFloatType) => mkPrimitiveArray("float", true)
-                case WomMaybeEmptyArrayType(WomStringType) => mkPrimitiveArray("string", true)
-                case WomMaybeEmptyArrayType(WomSingleFileType) => mkPrimitiveArray("file", true)
-
-                // complex type, that may contains files
-                case _ => mkComplex(optional)
-            }
-        }
-        cVar.womType match {
-            case WomOptionalType(t) => handleType(t, true)
-            case t => handleType(t, false)
-        }
+  // For primitive types, and arrays of such types, we can map directly
+  // to the equivalent dx types. For example,
+  //   Int  -> int
+  //   Array[String] -> array:string
+  //
+  // Arrays can be empty, which is why they are always marked "optional".
+  // This notifies the platform runtime system not to throw an exception
+  // for an empty input/output array.
+  //
+  // Ragged arrays, maps, and objects, cannot be mapped in such a trivial way.
+  // These are called "Complex Types", or "Complex". They are handled
+  // by passing a JSON structure and a vector of dx:files.
+  private def cVarToSpec(cVar: CVar): Vector[JsValue] = {
+    val name = cVar.dxVarName
+    val defaultVals: Map[String, JsValue] = cVar.default match {
+      case None => Map.empty
+      case Some(wdlValue) =>
+        val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wdlValue)
+        wdlVarLinksConverter.genFields(wvl, name).toMap
     }
+    def jsMapFromDefault(name: String): Map[String, JsValue] = {
+      defaultVals.get(name) match {
+        case None      => Map.empty
+        case Some(jsv) => Map("default" -> jsv)
+      }
+    }
+    def jsMapFromOptional(optional: Boolean): Map[String, JsValue] = {
+      if (optional) {
+        Map("optional" -> JsBoolean(true))
+      } else {
+        Map.empty[String, JsValue]
+      }
+    }
+    def mkPrimitive(dxType: String, optional: Boolean): Vector[JsValue] = {
+      Vector(
+        JsObject(
+          Map("name" -> JsString(name), "class" -> JsString(dxType))
+            ++ jsMapFromOptional(optional)
+            ++ jsMapFromDefault(name)
+        )
+      )
+    }
+    def mkPrimitiveArray(dxType: String, optional: Boolean): Vector[JsValue] = {
+      Vector(
+        JsObject(
+          Map("name" -> JsString(name), "class" -> JsString("array:" ++ dxType))
+            ++ jsMapFromOptional(optional)
+            ++ jsMapFromDefault(name)
+        )
+      )
+    }
+    def mkComplex(optional: Boolean): Vector[JsValue] = {
+      // A large JSON structure passed as a hash, and a
+      // vector of platform files.
+      Vector(
+        JsObject(
+          Map("name" -> JsString(name), "class" -> JsString("hash"))
+            ++ jsMapFromOptional(optional)
+            ++ jsMapFromDefault(name)
+        ),
+        JsObject(
+          Map(
+            "name"     -> JsString(name + Utils.FLAT_FILES_SUFFIX),
+            "class"    -> JsString("array:file"),
+            "optional" -> JsBoolean(true)
+          )
+            ++ jsMapFromDefault(name + Utils.FLAT_FILES_SUFFIX)
+        )
+      )
+    }
+    def handleType(wdlType: WomType, optional: Boolean): Vector[JsValue] = {
+      wdlType match {
+        // primitive types
+        case WomBooleanType    => mkPrimitive("boolean", optional)
+        case WomIntegerType    => mkPrimitive("int", optional)
+        case WomFloatType      => mkPrimitive("float", optional)
+        case WomStringType     => mkPrimitive("string", optional)
+        case WomSingleFileType => mkPrimitive("file", optional)
 
+        // single dimension arrays of primitive types
+        case WomNonEmptyArrayType(WomBooleanType)      => mkPrimitiveArray("boolean", optional)
+        case WomNonEmptyArrayType(WomIntegerType)      => mkPrimitiveArray("int", optional)
+        case WomNonEmptyArrayType(WomFloatType)        => mkPrimitiveArray("float", optional)
+        case WomNonEmptyArrayType(WomStringType)       => mkPrimitiveArray("string", optional)
+        case WomNonEmptyArrayType(WomSingleFileType)   => mkPrimitiveArray("file", optional)
+        case WomMaybeEmptyArrayType(WomBooleanType)    => mkPrimitiveArray("boolean", true)
+        case WomMaybeEmptyArrayType(WomIntegerType)    => mkPrimitiveArray("int", true)
+        case WomMaybeEmptyArrayType(WomFloatType)      => mkPrimitiveArray("float", true)
+        case WomMaybeEmptyArrayType(WomStringType)     => mkPrimitiveArray("string", true)
+        case WomMaybeEmptyArrayType(WomSingleFileType) => mkPrimitiveArray("file", true)
 
-    // Create a bunch of bash export declarations, describing
-    // the variables required to login to the docker private repository (if needed).
-     private def dockerPreamble(dockerImage: IR.DockerImage) : String = {
-         dockerRegistryInfo match {
-            case None => ""
-            case Some(DockerRegistry(registry, username, credentials)) =>
-                // check that the credentials file is a valid platform path
-                try {
-                    val dxFile = DxPath.resolveDxURLFile(credentials)
-                    Utils.ignore(dxFile)
-                } catch {
-                    case e : Throwable =>
-                        throw new Exception(s"""|credentials has to point to a platform file.
+        // complex type, that may contains files
+        case _ => mkComplex(optional)
+      }
+    }
+    cVar.womType match {
+      case WomOptionalType(t) => handleType(t, true)
+      case t                  => handleType(t, false)
+    }
+  }
+
+  // Create a bunch of bash export declarations, describing
+  // the variables required to login to the docker private repository (if needed).
+  private def dockerPreamble(dockerImage: IR.DockerImage): String = {
+    dockerRegistryInfo match {
+      case None                                                  => ""
+      case Some(DockerRegistry(registry, username, credentials)) =>
+        // check that the credentials file is a valid platform path
+        try {
+          val dxFile = DxPath.resolveDxURLFile(credentials)
+          Utils.ignore(dxFile)
+        } catch {
+          case e: Throwable =>
+            throw new Exception(s"""|credentials has to point to a platform file.
                                                 |It is now:
                                                 |   ${credentials}
                                                 |Error:
                                                 |  ${e}
                                                 |""".stripMargin)
-                }
+        }
 
-                // strip the URL from the dx:// prefix, so we can use dx-download directly
-                val credentialsWithoutPrefix = credentials.substring(Utils.DX_URL_PREFIX.length)
-                s"""|
+        // strip the URL from the dx:// prefix, so we can use dx-download directly
+        val credentialsWithoutPrefix = credentials.substring(Utils.DX_URL_PREFIX.length)
+        s"""|
                     |# if we need to set up a private docker registry,
                     |# download the credentials file and login. Do not expose the
                     |# credentials to the logs or to stdout.
@@ -210,11 +223,11 @@ case class Native(dxWDLrtId: Option[String],
                     |cat $${HOME}/docker_credentials | docker login $${DOCKER_REGISTRY} -u $${DOCKER_USERNAME} --password-stdin
                     |rm -f $${HOME}/docker_credentials
                     |""".stripMargin
-         }
-     }
+    }
+  }
 
-    private def genBashScriptTaskBody(): String = {
-        s"""|    # evaluate input arguments, and download input files
+  private def genBashScriptTaskBody(): String = {
+    s"""|    # evaluate input arguments, and download input files
             |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal taskProlog $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
             |
             |    # run the dx-download-agent (dxda) on a manifest of files
@@ -313,52 +326,51 @@ case class Native(dxWDLrtId: Option[String],
             |        sudo umount ${dxPathConfig.dxfuseMountpoint}
             |    fi
             |""".stripMargin.trim
-    }
+  }
 
-    private def genBashScriptWfFragment() : String = {
-        s"""|main() {
+  private def genBashScriptWfFragment(): String = {
+    s"""|main() {
             |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal wfFragment $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
             |}
             |
             |collect() {
             |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal collect $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
             |}""".stripMargin.trim
-    }
+  }
 
-    private def genBashScriptCmd(cmd: String) : String = {
-        s"""|main() {
+  private def genBashScriptCmd(cmd: String): String = {
+    s"""|main() {
             |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal ${cmd} $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
             |}""".stripMargin.trim
-    }
+  }
 
-    private def genBashScript(applet: IR.Applet,
-                              instanceType: IR.InstanceType) : String = {
-        val body:String = applet.kind match {
-            case IR.AppletKindNative(_) =>
-                throw new Exception("Sanity: generating a bash script for a native applet")
-            case IR.AppletKindWorkflowCustomReorg(_) =>
-                throw new Exception("Sanity: generating a bash script for a custom reorg applet")
-            case IR.AppletKindWfFragment(_, _, _) =>
-                genBashScriptWfFragment()
-            case IR.AppletKindWfInputs =>
-                genBashScriptCmd("wfInputs")
-            case IR.AppletKindWfOutputs =>
-                genBashScriptCmd("wfOutputs")
-            case IR.AppletKindWfCustomReorgOutputs =>
-                genBashScriptCmd("wfCustomReorgOutputs")
-            case IR.AppletKindWorkflowOutputReorg =>
-                genBashScriptCmd("workflowOutputReorg")
-            case IR.AppletKindTask(_) =>
-                instanceType match {
-                    case IR.InstanceTypeDefault | IR.InstanceTypeConst(_,_,_,_,_) =>
-                        s"""|${dockerPreamble(applet.docker)}
+  private def genBashScript(applet: IR.Applet, instanceType: IR.InstanceType): String = {
+    val body: String = applet.kind match {
+      case IR.AppletKindNative(_) =>
+        throw new Exception("Sanity: generating a bash script for a native applet")
+      case IR.AppletKindWorkflowCustomReorg(_) =>
+        throw new Exception("Sanity: generating a bash script for a custom reorg applet")
+      case IR.AppletKindWfFragment(_, _, _) =>
+        genBashScriptWfFragment()
+      case IR.AppletKindWfInputs =>
+        genBashScriptCmd("wfInputs")
+      case IR.AppletKindWfOutputs =>
+        genBashScriptCmd("wfOutputs")
+      case IR.AppletKindWfCustomReorgOutputs =>
+        genBashScriptCmd("wfCustomReorgOutputs")
+      case IR.AppletKindWorkflowOutputReorg =>
+        genBashScriptCmd("workflowOutputReorg")
+      case IR.AppletKindTask(_) =>
+        instanceType match {
+          case IR.InstanceTypeDefault | IR.InstanceTypeConst(_, _, _, _, _) =>
+            s"""|${dockerPreamble(applet.docker)}
                             |
                             |set -e -o pipefail
                             |main() {
                             |${genBashScriptTaskBody()}
                             |}""".stripMargin
-                    case IR.InstanceTypeRuntime =>
-                        s"""|${dockerPreamble(applet.docker)}
+          case IR.InstanceTypeRuntime =>
+            s"""|${dockerPreamble(applet.docker)}
                             |
                             |set -e -o pipefail
                             |main() {
@@ -376,720 +388,745 @@ case class Native(dxWDLrtId: Option[String],
                             |body() {
                             |${genBashScriptTaskBody()}
                             |}""".stripMargin.trim
-                }
         }
+    }
 
-        s"""|#!/bin/bash -ex
+    s"""|#!/bin/bash -ex
             |
             |${body}""".stripMargin
-    }
+  }
 
-    // Calculate the MD5 checksum of a string
-    private def chksum(s: String) : String = {
-        val digest = MessageDigest.getInstance("MD5").digest(s.getBytes)
-        digest.map("%02X" format _).mkString
-    }
+  // Calculate the MD5 checksum of a string
+  private def chksum(s: String): String = {
+    val digest = MessageDigest.getInstance("MD5").digest(s.getBytes)
+    digest.map("%02X" format _).mkString
+  }
 
-    // Add a checksum to a request
-    private def checksumReq(name: String,
-                            fields: Map[String, JsValue]) : (String, JsValue) = {
-        Utils.trace(verbose2, s"""|${name} -> checksum request
+  // Add a checksum to a request
+  private def checksumReq(name: String, fields: Map[String, JsValue]): (String, JsValue) = {
+    Utils.trace(
+      verbose2,
+      s"""|${name} -> checksum request
                                   |fields = ${JsObject(fields).prettyPrint}
                                   |
-                                  |""".stripMargin)
+                                  |""".stripMargin
+    )
 
-        // We need to sort the hash-tables. They are natually unsorted,
-        // causing the same object to have different checksums.
-        val jsDet = Utils.makeDeterministic(JsObject(fields))
-        val digest = chksum(jsDet.prettyPrint)
+    // We need to sort the hash-tables. They are natually unsorted,
+    // causing the same object to have different checksums.
+    val jsDet  = Utils.makeDeterministic(JsObject(fields))
+    val digest = chksum(jsDet.prettyPrint)
 
-        // Add the checksum to the properies
-        val preExistingProps : Map[String, JsValue] =
-            fields.get("properties") match {
-                case Some(JsObject(props)) => props
-                case None => Map.empty
-                case other => throw new Exception(s"Bad properties json value ${other}")
-            }
-        val props = preExistingProps ++ Map(
-            Utils.VERSION_PROP -> JsString(Utils.getVersion()),
-            Utils.CHECKSUM_PROP -> JsString(digest)
-        )
+    // Add the checksum to the properies
+    val preExistingProps: Map[String, JsValue] =
+      fields.get("properties") match {
+        case Some(JsObject(props)) => props
+        case None                  => Map.empty
+        case other                 => throw new Exception(s"Bad properties json value ${other}")
+      }
+    val props = preExistingProps ++ Map(
+      Utils.VERSION_PROP  -> JsString(Utils.getVersion()),
+      Utils.CHECKSUM_PROP -> JsString(digest)
+    )
 
-        // Add properties and attributes we don't want to fall under the checksum
-        // This allows, for example, moving the dx:executable, while
-	// still being able to reuse it.
-        val req = JsObject(fields ++ Map(
-                               "project" -> JsString(dxProject.id),
-                               "folder" -> JsString(folder),
-                               "parents" -> JsBoolean(true),
-                               "properties" -> JsObject(props)
-                           ))
-        (digest, req)
+    // Add properties and attributes we don't want to fall under the checksum
+    // This allows, for example, moving the dx:executable, while
+    // still being able to reuse it.
+    val req = JsObject(
+      fields ++ Map(
+        "project"    -> JsString(dxProject.id),
+        "folder"     -> JsString(folder),
+        "parents"    -> JsBoolean(true),
+        "properties" -> JsObject(props)
+      )
+    )
+    (digest, req)
+  }
+
+  // Do we need to build this applet/workflow?
+  //
+  // Returns:
+  //   None: build is required
+  //   Some(dxobject) : the right object is already on the platform
+  private def isBuildRequired(name: String, digest: String): Option[DxDataObject] = {
+    // Have we built this applet already, but placed it elsewhere in the project?
+    dxObjDir.lookupOtherVersions(name, digest) match {
+      case None => ()
+      case Some((dxObj, desc)) =>
+        dxObj match {
+          case a: DxAppDescribe =>
+            Utils.trace(verbose.on, s"Found existing version of app ${name}")
+          case apl: DxAppletDescribe =>
+            Utils.trace(
+              verbose.on,
+              s"Found existing version of applet ${name} in folder ${apl.folder}"
+            )
+          case wf: DxWorkflowDescribe =>
+            Utils.trace(
+              verbose.on,
+              s"Found existing version of workflow ${name} in folder ${wf.folder}"
+            )
+          case other =>
+            throw new Exception(s"bad object ${other}")
+        }
+        return Some(dxObj)
     }
 
-    // Do we need to build this applet/workflow?
-    //
-    // Returns:
-    //   None: build is required
-    //   Some(dxobject) : the right object is already on the platform
-    private def isBuildRequired(name: String,
-                                digest: String) : Option[DxDataObject] = {
-        // Have we built this applet already, but placed it elsewhere in the project?
-        dxObjDir.lookupOtherVersions(name, digest) match {
-            case None => ()
-            case Some((dxObj, desc)) =>
-                dxObj match {
-                    case a : DxAppDescribe =>
-                        Utils.trace(verbose.on, s"Found existing version of app ${name}")
-                    case apl : DxAppletDescribe =>
-                        Utils.trace(verbose.on, s"Found existing version of applet ${name} in folder ${apl.folder}")
-                    case wf : DxWorkflowDescribe =>
-                        Utils.trace(verbose.on, s"Found existing version of workflow ${name} in folder ${wf.folder}")
-                    case other =>
-                        throw new Exception(s"bad object ${other}")
-                }
-                return Some(dxObj)
+    val existingDxObjs = dxObjDir.lookup(name)
+    val buildRequired: Boolean = existingDxObjs.size match {
+      case 0 => true
+      case 1 =>
+        // Check if applet code has changed
+        val dxObjInfo = existingDxObjs.head
+        dxObjInfo.digest match {
+          case None =>
+            throw new Exception(s"There is an existing non-dxWDL applet ${name}")
+          case Some(digest2) if digest != digest2 =>
+            Utils.trace(verbose.on, s"${dxObjInfo.dxClass} ${name} has changed, rebuild required")
+            true
+          case Some(_) =>
+            Utils.trace(verbose.on, s"${dxObjInfo.dxClass} ${name} has not changed")
+            false
         }
-
-        val existingDxObjs = dxObjDir.lookup(name)
-        val buildRequired:Boolean = existingDxObjs.size match {
-            case 0 => true
-            case 1 =>
-                // Check if applet code has changed
-                val dxObjInfo = existingDxObjs.head
-                dxObjInfo.digest match {
-                    case None =>
-                        throw new Exception(s"There is an existing non-dxWDL applet ${name}")
-                    case Some(digest2) if digest != digest2 =>
-                        Utils.trace(verbose.on,
-                                    s"${dxObjInfo.dxClass} ${name} has changed, rebuild required")
-                        true
-                    case Some(_) =>
-                        Utils.trace(verbose.on, s"${dxObjInfo.dxClass} ${name} has not changed")
-                        false
-                }
-            case _ =>
-                val dxClass = existingDxObjs.head.dxClass
-                Utils.warning(verbose, s"""|More than one ${dxClass} ${name} found in
+      case _ =>
+        val dxClass = existingDxObjs.head.dxClass
+        Utils.warning(verbose, s"""|More than one ${dxClass} ${name} found in
                                            |path ${dxProject.id}:${folder}""".stripMargin)
-                true
-        }
+        true
+    }
 
-        if (buildRequired) {
-            if (existingDxObjs.size > 0) {
-                if (archive) {
-                    // archive the applet/workflow(s)
-                    existingDxObjs.foreach(x => dxObjDir.archiveDxObject(x))
-                } else if (force) {
-                    // the dx:object exists, and needs to be removed. There
-                    // may be several versions, all are removed.
-                    val objs = existingDxObjs.map(_.dxObj)
-                    Utils.trace(verbose.on, s"Removing old ${name} ${objs.map(_.id)}")
-                    dxProject.removeObjects(objs)
-                } else {
-                    val dxClass = existingDxObjs.head.dxClass
-                    throw new Exception(s"""|${dxClass} ${name} already exists in
-                                            | ${dxProject.id}:${folder}""".stripMargin)
-                }
-            }
-            None
+    if (buildRequired) {
+      if (existingDxObjs.size > 0) {
+        if (archive) {
+          // archive the applet/workflow(s)
+          existingDxObjs.foreach(x => dxObjDir.archiveDxObject(x))
+        } else if (force) {
+          // the dx:object exists, and needs to be removed. There
+          // may be several versions, all are removed.
+          val objs = existingDxObjs.map(_.dxObj)
+          Utils.trace(verbose.on, s"Removing old ${name} ${objs.map(_.id)}")
+          dxProject.removeObjects(objs)
         } else {
-            assert(existingDxObjs.size == 1)
-            Some(existingDxObjs.head.dxObj)
+          val dxClass = existingDxObjs.head.dxClass
+          throw new Exception(s"""|${dxClass} ${name} already exists in
+                                            | ${dxProject.id}:${folder}""".stripMargin)
         }
+      }
+      None
+    } else {
+      assert(existingDxObjs.size == 1)
+      Some(existingDxObjs.head.dxObj)
     }
+  }
 
-    // Create linking information for a dx:executable
-    private def genLinkInfo(irCall: IR.Callable,
-                            dxObj: DxExecutable) : ExecLinkInfo = {
-        val callInputDefs: Map[String, WomType] = irCall.inputVars.map{
-            case CVar(name, wdlType, _) => (name -> wdlType)
-        }.toMap
-        val callOutputDefs: Map[String, WomType] = irCall.outputVars.map{
-            case CVar(name, wdlType, _) => (name -> wdlType)
-        }.toMap
-        ExecLinkInfo(irCall.name,
-                     callInputDefs,
-                     callOutputDefs,
-                     dxObj)
+  // Create linking information for a dx:executable
+  private def genLinkInfo(irCall: IR.Callable, dxObj: DxExecutable): ExecLinkInfo = {
+    val callInputDefs: Map[String, WomType] = irCall.inputVars.map {
+      case CVar(name, wdlType, _) => (name -> wdlType)
+    }.toMap
+    val callOutputDefs: Map[String, WomType] = irCall.outputVars.map {
+      case CVar(name, wdlType, _) => (name -> wdlType)
+    }.toMap
+    ExecLinkInfo(irCall.name, callInputDefs, callOutputDefs, dxObj)
+  }
+
+  private def apiParseReplyID(rep: JsonNode): String = {
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
+    repJs.asJsObject.fields.get("id") match {
+      case None              => throw new Exception("API call did not returnd an ID")
+      case Some(JsString(x)) => x
+      case other             => throw new Exception(s"API call returned invalid ID ${other}")
     }
+  }
 
-    private def apiParseReplyID(rep: JsonNode) : String = {
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(rep)
-        repJs.asJsObject.fields.get("id") match {
-            case None => throw new Exception("API call did not returnd an ID")
-            case Some(JsString(x)) => x
-            case other => throw new Exception(s"API call returned invalid ID ${other}")
-        }
-    }
+  private def addLicences(applet: IR.Applet): Map[String, JsValue] = {
 
-    private def addLicences(applet: IR.Applet) : Map[String, JsValue] = {
-
-        val taskSpecificDetails : Map[String, JsValue] =
-            if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
-                // A task can override the default dx attributes
-                extras match {
-                    case None => Map.empty
-                    case Some(ext) => ext.perTaskDxAttributes.get(applet.name) match {
-                        case None => Map.empty
-                        case Some(dta) => dta.getDetailsJson
-                    }
-                }
-            } else {
-                Map("test"->"something".toJson)
+    val taskSpecificDetails: Map[String, JsValue] =
+      if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
+        // A task can override the default dx attributes
+        extras match {
+          case None => Map.empty
+          case Some(ext) =>
+            ext.perTaskDxAttributes.get(applet.name) match {
+              case None      => Map.empty
+              case Some(dta) => dta.getDetailsJson
             }
+        }
+      } else {
+        Map("test" -> "something".toJson)
+      }
 
+    return taskSpecificDetails
+  }
 
-        return taskSpecificDetails
+  // Set the run spec.
+  //
+  private def calcRunSpec(
+      applet: IR.Applet,
+      details: Map[String, JsValue],
+      bashScript: String
+  ): (JsValue, Map[String, JsValue]) = {
+    // find the dxWDL asset
+    val instanceType: String = applet.instanceType match {
+      case x: IR.InstanceTypeConst =>
+        val xDesc = InstanceTypeReq(x.dxInstanceType, x.memoryMB, x.diskGB, x.cpu, x.gpu)
+        instanceTypeDB.apply(xDesc)
+      case IR.InstanceTypeDefault | IR.InstanceTypeRuntime =>
+        instanceTypeDB.defaultInstanceType
+    }
+    //System.out.println(s"Native: instanceType chosen = ${instanceType}")
+    val runSpec: Map[String, JsValue] = Map(
+      "code"        -> JsString(bashScript),
+      "interpreter" -> JsString("bash"),
+      "systemRequirements" ->
+        JsObject(
+          "main" ->
+            JsObject("instanceType" -> JsString(instanceType))
+        ),
+      "distribution" -> JsString("Ubuntu"),
+      "release"      -> JsString(Utils.UBUNTU_VERSION)
+    )
+
+    // Add default timeout
+    val defaultTimeout: Map[String, JsValue] =
+      DxRunSpec(
+        None,
+        None,
+        None,
+        Some(DxTimeout(Some(Utils.DEFAULT_APPLET_TIMEOUT_IN_DAYS), Some(0), Some(0)))
+      ).toRunSpecJson
+
+    // Start with the default dx-attribute section, and override
+    // any field that is specified in the individual task section.
+    val extraRunSpec: Map[String, JsValue] = extras match {
+      case None => Map.empty
+      case Some(ext) =>
+        ext.defaultTaskDxAttributes match {
+          case None      => Map.empty
+          case Some(dta) => dta.getRunSpecJson
+        }
     }
 
-    // Set the run spec.
-    //
-    private def calcRunSpec(applet: IR.Applet,
-                            details: Map[String, JsValue],
-                            bashScript: String) : (JsValue, Map[String, JsValue]) = {
-        // find the dxWDL asset
-        val instanceType:String = applet.instanceType match {
-            case x : IR.InstanceTypeConst =>
-                val xDesc = InstanceTypeReq(x.dxInstanceType,
-                                            x.memoryMB,
-                                            x.diskGB,
-                                            x.cpu,
-                                            x.gpu)
-                instanceTypeDB.apply(xDesc)
-            case IR.InstanceTypeDefault | IR.InstanceTypeRuntime =>
-                instanceTypeDB.defaultInstanceType
+    val taskSpecificRunSpec: Map[String, JsValue] =
+      if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
+        // A task can override the default dx attributes
+        extras match {
+          case None => Map.empty
+          case Some(ext) =>
+            ext.perTaskDxAttributes.get(applet.name) match {
+              case None      => Map.empty
+              case Some(dta) => dta.getRunSpecJson
+            }
         }
-        //System.out.println(s"Native: instanceType chosen = ${instanceType}")
-        val runSpec: Map[String, JsValue] = Map(
-            "code" -> JsString(bashScript),
-            "interpreter" -> JsString("bash"),
-            "systemRequirements" ->
-                JsObject("main" ->
-                             JsObject("instanceType" -> JsString(instanceType))),
-            "distribution" -> JsString("Ubuntu"),
-            "release" -> JsString(Utils.UBUNTU_VERSION),
+      } else {
+        Map.empty
+      }
+
+    val runSpecWithExtras = runSpec ++ defaultTimeout ++ extraRunSpec ++ taskSpecificRunSpec
+
+    // - If the docker image is a tarball, add a link in the details field.
+    val dockerFile: Option[DxFile] = applet.docker match {
+      case IR.DockerImageNone              => None
+      case IR.DockerImageNetwork           => None
+      case IR.DockerImageDxFile(_, dxfile) =>
+        // A docker image stored as a tar ball in a platform file
+        Some(dxfile)
+    }
+    val bundledDepends = runtimeLibrary match {
+      case None        => Map.empty
+      case Some(rtLib) => Map("bundledDepends" -> JsArray(Vector(rtLib)))
+    }
+    val runSpecEverything = JsObject(runSpecWithExtras ++ bundledDepends)
+
+    val details2 = dockerFile match {
+      case None => details
+      case Some(dxfile) =>
+        details + ("docker-image" -> DxUtils.dxFileToJsValue(dxfile))
+    }
+    (runSpecEverything, details2)
+  }
+
+  def calcAccess(applet: IR.Applet): JsValue = {
+    val extraAccess: DxAccess = extras match {
+      case None      => DxAccess.empty
+      case Some(ext) => ext.getDefaultAccess
+    }
+    val taskSpecificAccess: DxAccess =
+      if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
+        // A task can override the default dx attributes
+        extras match {
+          case None      => DxAccess.empty
+          case Some(ext) => ext.getTaskAccess(applet.name)
+        }
+      } else {
+        DxAccess.empty
+      }
+
+    // If we are using a private docker registry, add the allProjects: VIEW
+    // access to tasks.
+    val allProjectsAccess: DxAccess = dockerRegistryInfo match {
+      case None    => DxAccess.empty
+      case Some(_) => DxAccess(None, None, Some(AccessLevel.VIEW), None, None)
+    }
+    val taskAccess = extraAccess.merge(taskSpecificAccess).merge(allProjectsAccess)
+
+    val access: DxAccess = applet.kind match {
+      case IR.AppletKindTask(_) =>
+        if (applet.docker == IR.DockerImageNetwork) {
+          // docker requires network access, because we are downloading
+          // the image from the network
+          taskAccess.merge(DxAccess(Some(Vector("*")), None, None, None, None))
+        } else {
+          taskAccess
+        }
+      case IR.AppletKindWorkflowOutputReorg =>
+        // The WorkflowOutput applet requires higher permissions
+        // to organize the output directory.
+        DxAccess(None, Some(AccessLevel.CONTRIBUTE), None, None, None)
+      case _ =>
+        // Even scatters need network access, because
+        // they spawn subjobs that (may) use dx-docker.
+        // We end up allowing all applets to use the network
+        taskAccess.merge(DxAccess(Some(Vector("*")), None, None, None, None))
+    }
+    val fields = access.toJson
+    if (fields.isEmpty) JsNull
+    else JsObject(fields)
+  }
+
+  // Build an '/applet/new' request
+  //
+  // For applets that call other applets, we pass a directory
+  // of the callees, so they could be found a runtime. This is
+  // equivalent to linking, in a standard C compiler.
+  private def appletNewReq(
+      applet: IR.Applet,
+      bashScript: String,
+      folder: String,
+      aplLinks: Map[String, ExecLinkInfo]
+  ): (String, JsValue) = {
+    Utils.trace(verbose2, s"Building /applet/new request for ${applet.name}")
+
+    val inputSpec: Vector[JsValue] = applet.inputs
+      .sortWith(_.name < _.name)
+      .map(cVar => cVarToSpec(cVar))
+      .flatten
+      .toVector
+
+    // create linking information
+    val linkInfo: Map[String, JsValue] =
+      aplLinks.map {
+        case (name, ali) =>
+          name -> ExecLinkInfo.writeJson(ali, typeAliases)
+      }.toMap
+
+    val metaInfo: Map[String, JsValue] =
+      applet.kind match {
+        case IR.AppletKindWfFragment(calls, blockPath, fqnDictTypes) =>
+          // meta information used for running workflow fragments
+          Map(
+            "execLinkInfo" -> JsObject(linkInfo),
+            "blockPath"    -> JsArray(blockPath.map(JsNumber(_))),
+            "fqnDictTypes" -> JsObject(fqnDictTypes.map {
+              case (k, t) =>
+                val tStr = WomTypeSerialization(typeAliases).toString(t)
+                k -> JsString(tStr)
+            }.toMap)
+          )
+
+        case IR.AppletKindWfInputs | IR.AppletKindWfOutputs | IR.AppletKindWfCustomReorgOutputs |
+            IR.AppletKindWorkflowOutputReorg =>
+          // meta information used for running workflow fragments
+          val fqnDictTypes = JsObject(applet.inputVars.map {
+            case cVar =>
+              val tStr = WomTypeSerialization(typeAliases).toString(cVar.womType)
+              cVar.name -> JsString(tStr)
+          }.toMap)
+          Map("fqnDictTypes" -> fqnDictTypes)
+
+        case _ =>
+          Map.empty
+      }
+
+    val outputSpec: Vector[JsValue] = applet.outputs
+      .sortWith(_.name < _.name)
+      .map(cVar => cVarToSpec(cVar))
+      .flatten
+      .toVector
+
+    // put the wom source code into the details field.
+    // Add the pricing model, and make the prices opaque.
+    val womSourceCode    = Utils.gzipAndBase64Encode(applet.womSourceCode)
+    val dbOpaque         = InstanceTypeDB.opaquePrices(instanceTypeDB)
+    val dbOpaqueInstance = Utils.gzipAndBase64Encode(dbOpaque.toJson.prettyPrint)
+    val runtimeAttrs = extras match {
+      case None      => JsNull
+      case Some(ext) => ext.defaultRuntimeAttributes.toJson
+    }
+    val auxInfo = Map(
+      "womSourceCode"  -> JsString(womSourceCode),
+      "instanceTypeDB" -> JsString(dbOpaqueInstance),
+      "runtimeAttrs"   -> runtimeAttrs
+    )
+
+    // Links to applets that could get called at runtime. If
+    // this applet is copied, we need to maintain referential integrity.
+    val dxLinks = aplLinks.map {
+      case (name, execLinkInfo) =>
+        ("link_" + name) -> JsObject("$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId))
+    }.toMap
+    val (runSpec: JsValue, details: Map[String, JsValue]) =
+      calcRunSpec(applet, auxInfo ++ dxLinks ++ metaInfo, bashScript)
+    val detailsWithLicense: Map[String, JsValue] = addLicences(applet)
+    val jsDetails: JsValue                       = JsObject(details ++ detailsWithLicense)
+    val access: JsValue                          = calcAccess(applet)
+
+    // A fragemnt is hidden, not visible under default settings. This
+    // allows the workflow copying code to traverse it, and link to
+    // anything it calls.
+    val hidden: Boolean =
+      applet.kind match {
+        case _: IR.AppletKindWfFragment => true
+        case _                          => false
+      }
+
+    // pack all the core arguments into a single request
+    val reqCore = Map(
+      "name"       -> JsString(applet.name),
+      "inputSpec"  -> JsArray(inputSpec),
+      "outputSpec" -> JsArray(outputSpec),
+      "runSpec"    -> runSpec,
+      "dxapi"      -> JsString("1.0.0"),
+      "tags"       -> JsArray(JsString("dxWDL")),
+      "details"    -> jsDetails,
+      "hidden"     -> JsBoolean(hidden)
+    )
+    val accessField =
+      if (access == JsNull) Map.empty
+      else Map("access" -> access)
+
+    // Add a checksum
+    checksumReq(applet.name, reqCore ++ accessField)
+  }
+
+  // Rebuild the applet if needed.
+  //
+  // When [force] is true, always rebuild. Otherwise, rebuild only
+  // if the WDL code has changed.
+  private def buildAppletIfNeeded(
+      applet: IR.Applet,
+      execDict: Map[String, ExecRecord]
+  ): (DxApplet, Vector[ExecLinkInfo]) = {
+    Utils.trace(verbose2, s"Compiling applet ${applet.name}")
+
+    // limit the applet dictionary, only to actual dependencies
+    val calls: Vector[String] = applet.kind match {
+      case IR.AppletKindWfFragment(calls, _, _) => calls
+      case _                                    => Vector.empty
+    }
+
+    val aplLinks: Map[String, ExecLinkInfo] = calls.map { tName =>
+      val ExecRecord(irCall, dxObj, _) = execDict(tName)
+      tName -> genLinkInfo(irCall, dxObj)
+    }.toMap
+
+    // Build an applet script
+    val bashScript = genBashScript(applet, applet.instanceType)
+
+    // Calculate a checksum of the inputs that went into the
+    // making of the applet.
+    val (digest, appletApiRequest) = appletNewReq(applet, bashScript, folder, aplLinks)
+    if (verbose2) {
+      val fName   = s"${applet.name}_req.json"
+      val trgPath = Utils.appCompileDirPath.resolve(fName)
+      Utils.writeFileContent(trgPath, appletApiRequest.prettyPrint)
+    }
+
+    val buildRequired = isBuildRequired(applet.name, digest)
+    val dxApplet = buildRequired match {
+      case None =>
+        // Compile a WDL snippet into an applet.
+        val rep      = DXAPI.appletNew(DxUtils.jsonNodeOfJsValue(appletApiRequest), classOf[JsonNode])
+        val id       = apiParseReplyID(rep)
+        val dxApplet = DxApplet.getInstance(id)
+        dxObjDir.insert(applet.name, dxApplet, digest)
+        dxApplet
+      case Some(dxObj) =>
+        // Old applet exists, and it has not changed. Return the
+        // applet-id.
+        dxObj.asInstanceOf[DxApplet]
+    }
+    (dxApplet, aplLinks.values.toVector)
+  }
+
+  // Calculate the stage inputs from the call closure
+  //
+  // It comprises mappings from variable name to WomType.
+  private def genStageInputs(inputs: Vector[(CVar, SArg)]): JsValue = {
+    // sort the inputs, to make the request deterministic
+    val jsInputs: TreeMap[String, JsValue] = inputs.foldLeft(TreeMap.empty[String, JsValue]) {
+      case (m, (cVar, sArg)) =>
+        sArg match {
+          case IR.SArgEmpty =>
+            // We do not have a value for this input at compile time.
+            // For compulsory applet inputs, the user will have to fill
+            // in a value at runtime.
+            m
+          case IR.SArgConst(wValue) =>
+            val wvl    = wdlVarLinksConverter.importFromWDL(cVar.womType, wValue)
+            val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
+            m ++ fields.toMap
+          case IR.SArgLink(dxStage, argName) =>
+            val wvl    = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
+            val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
+            m ++ fields.toMap
+          case IR.SArgWorkflowInput(argName) =>
+            val wvl    = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
+            val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
+            m ++ fields.toMap
+        }
+    }
+    JsObject(jsInputs)
+  }
+
+  // construct the workflow input DNAx types and defaults.
+  //
+  // A WDL input can generate one or two DNAx inputs.  This requires
+  // creating a vector of JSON values from each input.
+  //
+  private def buildWorkflowInputSpec(cVar: CVar, sArg: SArg): Vector[JsValue] = {
+    // deal with default values
+    val sArgDefault: Option[WomValue] = sArg match {
+      case IR.SArgConst(wdlValue) =>
+        Some(wdlValue)
+      case _ =>
+        None
+    }
+
+    // The default value can come from the SArg, or the CVar
+    val default = (sArgDefault, cVar.default) match {
+      case (Some(x), _) => Some(x)
+      case (_, Some(x)) => Some(x)
+      case _            => None
+    }
+
+    val cVarWithDflt = cVar.copy(default = default)
+    cVarToSpec(cVarWithDflt)
+  }
+
+  // Note: a single WDL output can generate one or two JSON outputs.
+  private def buildWorkflowOutputSpec(cVar: CVar, sArg: SArg): Vector[JsValue] = {
+    val oSpec: Vector[JsValue] = cVarToSpec(cVar)
+
+    // add the field names, to help index this structure
+    val oSpecMap: Map[String, JsValue] = oSpec.map { jso =>
+      val nm = jso.asJsObject.fields.get("name") match {
+        case Some(JsString(nm)) => nm
+        case _                  => throw new Exception("sanity")
+      }
+      (nm -> jso)
+    }.toMap
+
+    val outputSources: List[(String, JsValue)] = sArg match {
+      case IR.SArgConst(wdlValue) =>
+        // constant
+        throw new Exception(
+          s"Constant workflow outputs not currently handled (${cVar}, ${sArg}, ${wdlValue})"
         )
-
-        // Add default timeout
-        val defaultTimeout : Map[String, JsValue] =
-            DxRunSpec(None, None, None, Some(DxTimeout(Some(Utils.DEFAULT_APPLET_TIMEOUT_IN_DAYS),
-                                                       Some(0),
-                                                       Some(0)))).toRunSpecJson
-
-        // Start with the default dx-attribute section, and override
-        // any field that is specified in the individual task section.
-        val extraRunSpec : Map[String, JsValue] = extras match {
-            case None => Map.empty
-            case Some(ext) => ext.defaultTaskDxAttributes match {
-                case None => Map.empty
-                case Some(dta) => dta.getRunSpecJson
-            }
-        }
-
-        val taskSpecificRunSpec : Map[String, JsValue] =
-            if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
-                // A task can override the default dx attributes
-                extras match {
-                    case None => Map.empty
-                    case Some(ext) => ext.perTaskDxAttributes.get(applet.name) match {
-                        case None => Map.empty
-                        case Some(dta) => dta.getRunSpecJson
-                    }
-                }
-            } else {
-                Map.empty
-            }
-
-        val runSpecWithExtras = runSpec ++ defaultTimeout ++ extraRunSpec ++ taskSpecificRunSpec
-
-        // - If the docker image is a tarball, add a link in the details field.
-        val dockerFile: Option[DxFile] = applet.docker match {
-            case IR.DockerImageNone => None
-            case IR.DockerImageNetwork => None
-            case IR.DockerImageDxFile(_, dxfile) =>
-                // A docker image stored as a tar ball in a platform file
-                Some(dxfile)
-        }
-        val bundledDepends = runtimeLibrary match {
-            case None => Map.empty
-            case Some(rtLib) => Map("bundledDepends" -> JsArray(Vector(rtLib)))
-        }
-        val runSpecEverything = JsObject(runSpecWithExtras ++ bundledDepends)
-
-        val details2 = dockerFile match {
-            case None => details
-            case Some(dxfile) =>
-                details + ("docker-image" -> DxUtils.dxFileToJsValue(dxfile))
-        }
-        (runSpecEverything, details2)
+      case IR.SArgLink(dxStage, argName: CVar) =>
+        val wvl = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
+        wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
+      case IR.SArgWorkflowInput(argName: CVar) =>
+        val wvl = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
+        wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
+      case other =>
+        throw new Exception(s"Bad value for sArg ${other}")
     }
 
-    def calcAccess(applet: IR.Applet) : JsValue = {
-        val extraAccess: DxAccess = extras match {
-            case None => DxAccess.empty
-            case Some(ext) => ext.getDefaultAccess
-        }
-        val taskSpecificAccess : DxAccess =
-            if (applet.kind.isInstanceOf[IR.AppletKindTask]) {
-                // A task can override the default dx attributes
-                extras match {
-                    case None => DxAccess.empty
-                    case Some(ext) => ext.getTaskAccess(applet.name)
-                }
-            } else {
-                DxAccess.empty
-            }
-
-        // If we are using a private docker registry, add the allProjects: VIEW
-        // access to tasks.
-        val allProjectsAccess: DxAccess = dockerRegistryInfo match {
-            case None => DxAccess.empty
-            case Some(_) => DxAccess(None, None, Some(AccessLevel.VIEW), None, None)
-        }
-        val taskAccess = extraAccess.merge(taskSpecificAccess).merge(allProjectsAccess)
-
-        val access: DxAccess = applet.kind match {
-            case IR.AppletKindTask(_) =>
-                if (applet.docker == IR.DockerImageNetwork) {
-                    // docker requires network access, because we are downloading
-                    // the image from the network
-                    taskAccess.merge(DxAccess(Some(Vector("*")), None,  None,  None,  None))
-                } else {
-                    taskAccess
-                }
-            case IR.AppletKindWorkflowOutputReorg =>
-                // The WorkflowOutput applet requires higher permissions
-                // to organize the output directory.
-                DxAccess(None, Some(AccessLevel.CONTRIBUTE), None, None, None)
-            case _ =>
-                // Even scatters need network access, because
-                // they spawn subjobs that (may) use dx-docker.
-                // We end up allowing all applets to use the network
-                taskAccess.merge(DxAccess(Some(Vector("*")), None,  None,  None,  None))
-        }
-        val fields = access.toJson
-        if (fields.isEmpty) JsNull
-        else JsObject(fields)
-    }
-
-    // Build an '/applet/new' request
-    //
-    // For applets that call other applets, we pass a directory
-    // of the callees, so they could be found a runtime. This is
-    // equivalent to linking, in a standard C compiler.
-    private def appletNewReq(applet: IR.Applet,
-                             bashScript: String,
-                             folder : String,
-                             aplLinks: Map[String, ExecLinkInfo]) : (String, JsValue) = {
-        Utils.trace(verbose2, s"Building /applet/new request for ${applet.name}")
-
-        val inputSpec : Vector[JsValue] = applet.inputs
-            .sortWith(_.name < _.name)
-            .map(cVar => cVarToSpec(cVar))
-            .flatten.toVector
-
-        // create linking information
-        val linkInfo : Map[String, JsValue] =
-            aplLinks.map{ case (name, ali) =>
-                name -> ExecLinkInfo.writeJson(ali, typeAliases)
-            }.toMap
-
-        val metaInfo : Map[String, JsValue] =
-            applet.kind match {
-                case IR.AppletKindWfFragment(calls, blockPath, fqnDictTypes) =>
-                    // meta information used for running workflow fragments
-                    Map("execLinkInfo" -> JsObject(linkInfo),
-                        "blockPath" -> JsArray(blockPath.map(JsNumber(_))),
-                        "fqnDictTypes" -> JsObject(
-                            fqnDictTypes.map{ case (k,t) =>
-                                val tStr = WomTypeSerialization(typeAliases).toString(t)
-                                k -> JsString(tStr)
-                            }.toMap))
-
-                case IR.AppletKindWfInputs |
-                        IR.AppletKindWfOutputs |
-                        IR.AppletKindWfCustomReorgOutputs |
-                        IR.AppletKindWorkflowOutputReorg =>
-                    // meta information used for running workflow fragments
-                    val fqnDictTypes = JsObject(
-                        applet.inputVars.map{
-                            case cVar =>
-                                val tStr = WomTypeSerialization(typeAliases).toString(cVar.womType)
-                                cVar.name -> JsString(tStr)
-                        }.toMap)
-                    Map("fqnDictTypes" -> fqnDictTypes)
-
-                case _ =>
-                    Map.empty
-            }
-
-        val outputSpec : Vector[JsValue] = applet.outputs
-            .sortWith(_.name < _.name)
-            .map(cVar => cVarToSpec(cVar))
-            .flatten.toVector
-
-        // put the wom source code into the details field.
-        // Add the pricing model, and make the prices opaque.
-        val womSourceCode = Utils.gzipAndBase64Encode(applet.womSourceCode)
-        val dbOpaque = InstanceTypeDB.opaquePrices(instanceTypeDB)
-        val dbOpaqueInstance = Utils.gzipAndBase64Encode(dbOpaque.toJson.prettyPrint)
-        val runtimeAttrs = extras match {
-            case None => JsNull
-            case Some(ext) => ext.defaultRuntimeAttributes.toJson
-        }
-        val auxInfo = Map("womSourceCode" -> JsString(womSourceCode),
-                          "instanceTypeDB" -> JsString(dbOpaqueInstance),
-                          "runtimeAttrs" -> runtimeAttrs)
-
-        // Links to applets that could get called at runtime. If
-        // this applet is copied, we need to maintain referential integrity.
-        val dxLinks = aplLinks.map{ case (name, execLinkInfo) =>
-            ("link_" + name) -> JsObject(
-                "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId))
-        }.toMap
-        val (runSpec : JsValue, details: Map[String, JsValue]) =
-            calcRunSpec(applet,
-                        auxInfo ++ dxLinks ++ metaInfo,
-                        bashScript)
-        val detailsWithLicense: Map[String, JsValue] = addLicences(applet)
-        val jsDetails: JsValue = JsObject(details ++ detailsWithLicense)
-        val access : JsValue = calcAccess(applet)
-
-        // A fragemnt is hidden, not visible under default settings. This
-        // allows the workflow copying code to traverse it, and link to
-        // anything it calls.
-        val hidden : Boolean =
-            applet.kind match {
-                case _ : IR.AppletKindWfFragment => true
-                case _ => false
-            }
-
-        // pack all the core arguments into a single request
-        val reqCore = Map(
-            "name" -> JsString(applet.name),
-            "inputSpec" -> JsArray(inputSpec),
-            "outputSpec" -> JsArray(outputSpec),
-            "runSpec" -> runSpec,
-            "dxapi" -> JsString("1.0.0"),
-            "tags" -> JsArray(JsString("dxWDL")),
-            "details" -> jsDetails,
-            "hidden" -> JsBoolean(hidden)
+    // merge the specification and the output sources
+    outputSources.map {
+      case (fieldName, outputJs) =>
+        val specJs: JsValue = oSpecMap(fieldName)
+        JsObject(
+          specJs.asJsObject.fields ++
+            Map("outputSource" -> outputJs)
         )
-        val accessField =
-            if (access == JsNull) Map.empty
-            else Map("access" -> access)
+    }.toVector
+  }
 
-        // Add a checksum
-        checksumReq(applet.name, reqCore ++ accessField)
+  // Create a request for a workflow encapsulated in single API call.
+  // Prepare the list of stages, and the checksum in advance.
+  private def workflowNewReq(
+      wf: IR.Workflow,
+      execDict: Map[String, ExecRecord]
+  ): (String, JsValue) = {
+    Utils.trace(verbose2, s"build workflow ${wf.name}")
+
+    val stagesReq =
+      wf.stages.foldLeft(Vector.empty[JsValue]) {
+        case (stagesReq, stg) =>
+          val ExecRecord(irApplet, dxExec, _)    = execDict(stg.calleeName)
+          val linkedInputs: Vector[(CVar, SArg)] = irApplet.inputVars zip stg.inputs
+          val inputs                             = genStageInputs(linkedInputs)
+          // convert the per-stage metadata into JSON
+          val stageReqDesc = JsObject(
+            Map(
+              "id"         -> JsString(stg.id.getId),
+              "executable" -> JsString(dxExec.getId),
+              "name"       -> JsString(stg.description),
+              "input"      -> inputs
+            )
+          )
+          stagesReq :+ stageReqDesc
+      }
+
+    // Sub-workflow are compiled to hidden objects.
+    val hidden = wf.level == IR.Level.Sub
+
+    // links through applets that run workflow fragments
+    val transitiveDependencies: Vector[ExecLinkInfo] =
+      wf.stages.foldLeft(Vector.empty[ExecLinkInfo]) {
+        case (accu, stg) =>
+          val ExecRecord(_, _, dependencies) = execDict(stg.calleeName)
+          accu ++ dependencies
+      }
+
+    // pack all the arguments into a single API call
+    val reqFields = Map(
+      "name"   -> JsString(wf.name),
+      "stages" -> JsArray(stagesReq),
+      "tags"   -> JsArray(JsString("dxWDL")),
+      "hidden" -> JsBoolean(hidden)
+    )
+
+    val wfInputOutput: Map[String, JsValue] =
+      if (wf.locked) {
+        // Locked workflows have well defined inputs and outputs
+        val wfInputSpec: Vector[JsValue] = wf.inputs
+          .sortWith(_._1.name < _._1.name)
+          .map { case (cVar, sArg) => buildWorkflowInputSpec(cVar, sArg) }
+          .flatten
+        val wfOutputSpec: Vector[JsValue] = wf.outputs
+          .sortWith(_._1.name < _._1.name)
+          .map { case (cVar, sArg) => buildWorkflowOutputSpec(cVar, sArg) }
+          .flatten
+        Map("inputs" -> JsArray(wfInputSpec), "outputs" -> JsArray(wfOutputSpec))
+      } else {
+        Map.empty
+      }
+
+    // Add the workflow WOM source into the details field.
+    // There could be JSON-invalid characters in the source code, so we use base64 encoding.
+    // It could be quite large, so we use compression.
+    val womSourceCode = Utils.gzipAndBase64Encode(wf.womSourceCode)
+    val womSourceCodeField: Map[String, JsValue] =
+      Map("womSourceCode" -> JsString(womSourceCode))
+
+    // link to applets used by the fragments. This notifies the platform that they
+    // need to be cloned when copying workflows.
+    val dxLinks: Map[String, JsValue] = transitiveDependencies.map {
+      case execLinkInfo =>
+        ("link_" + execLinkInfo.name) -> JsObject(
+          "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId)
+        )
+    }.toMap
+
+    val details = Map("details" -> JsObject(womSourceCodeField ++ dxLinks))
+
+    // pack all the arguments into a single API call
+    val reqFieldsAll = reqFields ++ wfInputOutput ++ details
+
+    // Add a checksum
+    val (digest, reqWithChecksum) = checksumReq(wf.name, reqFieldsAll)
+
+    // Add properties we do not want to fall under the checksum.
+    // This allows, for example, moving the dx:executable, while
+    // still being able to reuse it.
+    val reqWithEverything =
+      JsObject(
+        reqWithChecksum.asJsObject.fields ++ Map(
+          "project" -> JsString(dxProject.id),
+          "folder"  -> JsString(folder),
+          "parents" -> JsBoolean(true)
+        )
+      )
+    (digest, reqWithEverything)
+  }
+
+  private def buildWorkflow(req: JsValue): DxWorkflow = {
+    val rep  = DXAPI.workflowNew(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+    val id   = apiParseReplyID(rep)
+    val dxwf = DxWorkflow.getInstance(id)
+
+    // Close the workflow
+    if (!leaveWorkflowsOpen)
+      dxwf.close()
+    dxwf
+  }
+
+  // Compile an entire workflow
+  //
+  // - Calculate the workflow checksum from the intermediate representation
+  // - Do not rebuild the workflow if it has a correct checksum
+  private def buildWorkflowIfNeeded(
+      wf: IR.Workflow,
+      execDict: Map[String, ExecRecord]
+  ): DxWorkflow = {
+    val (digest, wfNewReq) = workflowNewReq(wf, execDict)
+    val buildRequired      = isBuildRequired(wf.name, digest)
+    buildRequired match {
+      case None =>
+        val dxWorkflow = buildWorkflow(wfNewReq)
+        dxObjDir.insert(wf.name, dxWorkflow, digest)
+        dxWorkflow
+      case Some(dxObj) =>
+        // Old workflow exists, and it has not changed.
+        // we need to find a way to get the dependencies.
+        dxObj.asInstanceOf[DxWorkflow]
     }
+  }
 
-    // Rebuild the applet if needed.
-    //
-    // When [force] is true, always rebuild. Otherwise, rebuild only
-    // if the WDL code has changed.
-    private def buildAppletIfNeeded(applet: IR.Applet,
-                                    execDict: Map[String, ExecRecord])
-            : (DxApplet, Vector[ExecLinkInfo]) = {
-        Utils.trace(verbose2, s"Compiling applet ${applet.name}")
+  def apply(bundle: IR.Bundle): CompilationResults = {
+    Utils.trace(verbose.on, "Native pass, generate dx:applets and dx:workflows")
+    Utils.traceLevelInc()
 
-        // limit the applet dictionary, only to actual dependencies
-        val calls: Vector[String] = applet.kind match {
-            case IR.AppletKindWfFragment(calls, _, _) => calls
-            case _ => Vector.empty
-        }
-
-        val aplLinks : Map[String, ExecLinkInfo] = calls.map{ tName =>
-            val ExecRecord(irCall, dxObj, _) = execDict(tName)
-            tName -> genLinkInfo(irCall, dxObj)
-        }.toMap
-
-        // Build an applet script
-        val bashScript = genBashScript(applet, applet.instanceType)
-
-        // Calculate a checksum of the inputs that went into the
-        // making of the applet.
-        val (digest,appletApiRequest) = appletNewReq(applet, bashScript, folder, aplLinks)
-        if (verbose2) {
-            val fName = s"${applet.name}_req.json"
-            val trgPath = Utils.appCompileDirPath.resolve(fName)
-            Utils.writeFileContent(trgPath, appletApiRequest.prettyPrint)
-        }
-
-        val buildRequired = isBuildRequired(applet.name, digest)
-        val dxApplet = buildRequired match {
-            case None =>
-                // Compile a WDL snippet into an applet.
-                val rep = DXAPI.appletNew(DxUtils.jsonNodeOfJsValue(appletApiRequest), classOf[JsonNode])
-                val id = apiParseReplyID(rep)
-                val dxApplet = DxApplet.getInstance(id)
-                dxObjDir.insert(applet.name, dxApplet, digest)
-                dxApplet
-            case Some(dxObj) =>
-                // Old applet exists, and it has not changed. Return the
-                // applet-id.
-                dxObj.asInstanceOf[DxApplet]
-        }
-        (dxApplet, aplLinks.values.toVector)
-    }
-
-    // Calculate the stage inputs from the call closure
-    //
-    // It comprises mappings from variable name to WomType.
-    private def genStageInputs(inputs: Vector[(CVar, SArg)]) : JsValue = {
-        // sort the inputs, to make the request deterministic
-        val jsInputs:TreeMap[String, JsValue] = inputs.foldLeft(TreeMap.empty[String, JsValue]){
-            case (m, (cVar, sArg)) =>
-                sArg match {
-                    case IR.SArgEmpty =>
-                        // We do not have a value for this input at compile time.
-                        // For compulsory applet inputs, the user will have to fill
-                        // in a value at runtime.
-                        m
-                    case IR.SArgConst(wValue) =>
-                        val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wValue)
-                        val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
-                        m ++ fields.toMap
-                    case IR.SArgLink(dxStage, argName) =>
-                        val wvl = WdlVarLinks(cVar.womType,
-                                              DxlStage(dxStage, IORef.Output, argName.dxVarName))
-                        val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
-                        m ++ fields.toMap
-                    case IR.SArgWorkflowInput(argName) =>
-                        val wvl = WdlVarLinks(cVar.womType,
-                                              DxlWorkflowInput(argName.dxVarName))
-                        val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
-                        m ++ fields.toMap
-                }
-        }
-        JsObject(jsInputs)
-    }
-
-    // construct the workflow input DNAx types and defaults.
-    //
-    // A WDL input can generate one or two DNAx inputs.  This requires
-    // creating a vector of JSON values from each input.
-    //
-    private def buildWorkflowInputSpec(cVar:CVar,
-                                       sArg:SArg) : Vector[JsValue] = {
-        // deal with default values
-        val sArgDefault: Option[WomValue] = sArg match {
-            case IR.SArgConst(wdlValue) =>
-                Some(wdlValue)
-            case _ =>
-                None
-        }
-
-        // The default value can come from the SArg, or the CVar
-        val default = (sArgDefault, cVar.default) match {
-            case (Some(x), _) => Some(x)
-            case (_, Some(x)) => Some(x)
-            case _ => None
-        }
-
-        val cVarWithDflt = cVar.copy(default = default)
-        cVarToSpec(cVarWithDflt)
-    }
-
-    // Note: a single WDL output can generate one or two JSON outputs.
-    private def buildWorkflowOutputSpec(cVar:CVar,
-                                        sArg:SArg) : Vector[JsValue] = {
-        val oSpec: Vector[JsValue] = cVarToSpec(cVar)
-
-        // add the field names, to help index this structure
-        val oSpecMap:Map[String, JsValue] = oSpec.map{ jso =>
-            val nm = jso.asJsObject.fields.get("name") match {
-                case Some(JsString(nm)) => nm
-                case _ => throw new Exception("sanity")
+    // build applets and workflows if they aren't on the platform already
+    val execDict = bundle.dependencies.foldLeft(Map.empty[String, ExecRecord]) {
+      case (accu, cName) =>
+        val execIr = bundle.allCallables(cName)
+        execIr match {
+          case apl: IR.Applet =>
+            val execRecord = apl.kind match {
+              case IR.AppletKindNative(id) =>
+                // native applets do not depend on other data-objects
+                val dxExec = DxObject.getInstance(id).asInstanceOf[DxExecutable]
+                ExecRecord(apl, dxExec, Vector.empty)
+              case IR.AppletKindWorkflowCustomReorg(id) =>
+                // does this has to be a different class?
+                val dxExec = DxObject.getInstance(id).asInstanceOf[DxExecutable]
+                ExecRecord(apl, dxExec, Vector.empty)
+              case _ =>
+                val (dxApplet, dependencies) = buildAppletIfNeeded(apl, accu)
+                ExecRecord(apl, dxApplet, dependencies)
             }
-            (nm -> jso)
-        }.toMap
-
-        val outputSources:List[(String, JsValue)] = sArg match {
-            case IR.SArgConst(wdlValue) =>
-                // constant
-                throw new Exception(s"Constant workflow outputs not currently handled (${cVar}, ${sArg}, ${wdlValue})")
-            case IR.SArgLink(dxStage, argName: CVar) =>
-                val wvl = WdlVarLinks(cVar.womType,
-                                      DxlStage(dxStage, IORef.Output, argName.dxVarName))
-                wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
-            case IR.SArgWorkflowInput(argName: CVar) =>
-                val wvl = WdlVarLinks(cVar.womType,
-                                      DxlWorkflowInput(argName.dxVarName))
-                wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
-            case other =>
-                throw new Exception(s"Bad value for sArg ${other}")
-        }
-
-        // merge the specification and the output sources
-        outputSources.map{ case (fieldName, outputJs) =>
-            val specJs:JsValue = oSpecMap(fieldName)
-            JsObject(specJs.asJsObject.fields ++
-                               Map("outputSource" -> outputJs))
-        }.toVector
-    }
-
-    // Create a request for a workflow encapsulated in single API call.
-    // Prepare the list of stages, and the checksum in advance.
-    private def workflowNewReq(wf: IR.Workflow,
-                               execDict: Map[String, ExecRecord]) : (String, JsValue) = {
-        Utils.trace(verbose2, s"build workflow ${wf.name}")
-
-        val stagesReq =
-            wf.stages.foldLeft(Vector.empty[JsValue]) {
-                case (stagesReq, stg) =>
-                    val ExecRecord(irApplet, dxExec, _) = execDict(stg.calleeName)
-                    val linkedInputs : Vector[(CVar, SArg)] = irApplet.inputVars zip stg.inputs
-                    val inputs = genStageInputs(linkedInputs)
-                    // convert the per-stage metadata into JSON
-                    val stageReqDesc = JsObject(Map(
-                        "id" -> JsString(stg.id.getId),
-                        "executable" -> JsString(dxExec.getId),
-                        "name" -> JsString(stg.description),
-                        "input" -> inputs))
-                    stagesReq :+ stageReqDesc
-            }
-
-        // Sub-workflow are compiled to hidden objects.
-        val hidden = wf.level == IR.Level.Sub
-
-        // links through applets that run workflow fragments
-        val transitiveDependencies : Vector[ExecLinkInfo] =
-            wf.stages.foldLeft(Vector.empty[ExecLinkInfo]) {
-                case (accu, stg) =>
-                    val ExecRecord(_, _, dependencies) = execDict(stg.calleeName)
-                    accu ++ dependencies
-            }
-
-        // pack all the arguments into a single API call
-        val reqFields = Map("name" -> JsString(wf.name),
-                            "stages" -> JsArray(stagesReq),
-                            "tags" -> JsArray(JsString("dxWDL")),
-                            "hidden" -> JsBoolean(hidden))
-
-        val wfInputOutput: Map[String, JsValue] =
-            if (wf.locked) {
-                // Locked workflows have well defined inputs and outputs
-                val wfInputSpec:Vector[JsValue] = wf.inputs
-                    .sortWith(_._1.name < _._1.name)
-                    .map{ case (cVar,sArg) => buildWorkflowInputSpec(cVar, sArg) }
-                    .flatten
-                val wfOutputSpec:Vector[JsValue] = wf.outputs
-                    .sortWith(_._1.name < _._1.name)
-                    .map{ case (cVar,sArg) => buildWorkflowOutputSpec(cVar, sArg) }
-                    .flatten
-                Map("inputs" -> JsArray(wfInputSpec),
-                    "outputs" -> JsArray(wfOutputSpec))
-            } else {
-                Map.empty
-            }
-
-        // Add the workflow WOM source into the details field.
-        // There could be JSON-invalid characters in the source code, so we use base64 encoding.
-        // It could be quite large, so we use compression.
-        val womSourceCode =Utils.gzipAndBase64Encode(wf.womSourceCode)
-        val womSourceCodeField: Map[String, JsValue] =
-            Map("womSourceCode" -> JsString(womSourceCode))
-
-        // link to applets used by the fragments. This notifies the platform that they
-        // need to be cloned when copying workflows.
-        val dxLinks : Map[String, JsValue]= transitiveDependencies.map{
-            case execLinkInfo =>
-                ("link_" + execLinkInfo.name) -> JsObject(
-                    "$dnanexus_link" -> JsString(execLinkInfo.dxExec.getId))
-        }.toMap
-
-        val details = Map("details" -> JsObject(womSourceCodeField ++ dxLinks))
-
-        // pack all the arguments into a single API call
-        val reqFieldsAll = reqFields ++ wfInputOutput ++ details
-
-        // Add a checksum
-        val (digest, reqWithChecksum) = checksumReq(wf.name, reqFieldsAll)
-
-        // Add properties we do not want to fall under the checksum.
-        // This allows, for example, moving the dx:executable, while
-	// still being able to reuse it.
-        val reqWithEverything =
-            JsObject(reqWithChecksum.asJsObject.fields ++ Map(
-                         "project" -> JsString(dxProject.id),
-                         "folder" -> JsString(folder),
-                         "parents" -> JsBoolean(true)
-                     ))
-        (digest, reqWithEverything)
-    }
-
-    private def buildWorkflow(req: JsValue) : DxWorkflow = {
-        val rep = DXAPI.workflowNew(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
-        val id = apiParseReplyID(rep)
-        val dxwf = DxWorkflow.getInstance(id)
-
-        // Close the workflow
-        if (!leaveWorkflowsOpen)
-            dxwf.close()
-        dxwf
-    }
-
-    // Compile an entire workflow
-    //
-    // - Calculate the workflow checksum from the intermediate representation
-    // - Do not rebuild the workflow if it has a correct checksum
-    private def buildWorkflowIfNeeded(wf: IR.Workflow,
-                                      execDict: Map[String, ExecRecord]) : DxWorkflow = {
-        val (digest, wfNewReq) = workflowNewReq(wf, execDict)
-        val buildRequired = isBuildRequired(wf.name, digest)
-        buildRequired match {
-            case None =>
-                val dxWorkflow = buildWorkflow(wfNewReq)
-                dxObjDir.insert(wf.name, dxWorkflow, digest)
-                dxWorkflow
-            case Some(dxObj) =>
-                // Old workflow exists, and it has not changed.
-                // we need to find a way to get the dependencies.
-                dxObj.asInstanceOf[DxWorkflow]
+            accu + (apl.name -> execRecord)
+          case wf: IR.Workflow =>
+            val dxwfl = buildWorkflowIfNeeded(wf, accu)
+            accu + (wf.name -> ExecRecord(wf, dxwfl, Vector.empty))
         }
     }
 
-    def apply(bundle: IR.Bundle) : CompilationResults = {
-        Utils.trace(verbose.on, "Native pass, generate dx:applets and dx:workflows")
-        Utils.traceLevelInc()
-
-        // build applets and workflows if they aren't on the platform already
-        val execDict = bundle.dependencies.foldLeft(Map.empty[String, ExecRecord]) {
-            case (accu, cName) =>
-                val execIr = bundle.allCallables(cName)
-                execIr match {
-                    case apl: IR.Applet =>
-                        val execRecord = apl.kind match {
-                            case IR.AppletKindNative(id) =>
-                                // native applets do not depend on other data-objects
-                                val dxExec = DxObject.getInstance(id).asInstanceOf[DxExecutable]
-                                ExecRecord(apl, dxExec, Vector.empty)
-                            case IR.AppletKindWorkflowCustomReorg(id) =>
-                                // does this has to be a different class?
-                                val dxExec = DxObject.getInstance(id).asInstanceOf[DxExecutable]
-                                ExecRecord(apl, dxExec, Vector.empty)
-                            case _ =>
-                                val (dxApplet, dependencies) = buildAppletIfNeeded(apl, accu)
-                                ExecRecord(apl, dxApplet, dependencies)
-                        }
-                        accu + (apl.name -> execRecord)
-                    case wf : IR.Workflow =>
-                        val dxwfl = buildWorkflowIfNeeded(wf, accu)
-                        accu + (wf.name -> ExecRecord(wf, dxwfl, Vector.empty))
-                }
-        }
-
-        // build the toplevel workflow, if it is defined
-        val primary : Option[DxExecutable] = bundle.primaryCallable.flatMap{ callable =>
-            execDict.get(callable.name) match {
-                case None => None
-                case Some(ExecRecord(_, dxExec, _)) => Some(dxExec)
-            }
-        }
-
-        Utils.traceLevelDec()
-        CompilationResults(primary,
-                           execDict.map{ case (name, ExecRecord(_,dxExec, _)) => name -> dxExec }.toMap)
+    // build the toplevel workflow, if it is defined
+    val primary: Option[DxExecutable] = bundle.primaryCallable.flatMap { callable =>
+      execDict.get(callable.name) match {
+        case None                           => None
+        case Some(ExecRecord(_, dxExec, _)) => Some(dxExec)
+      }
     }
+
+    Utils.traceLevelDec()
+    CompilationResults(primary, execDict.map {
+      case (name, ExecRecord(_, dxExec, _)) => name -> dxExec
+    }.toMap)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -40,9 +40,9 @@ case class Native(
 ) {
   case class ExecRecord(callable: IR.Callable, dxExec: DxExecutable, links: Vector[ExecLinkInfo])
 
-  private val verbose2: Boolean       = verbose.containsKey("Native")
-  private val rtDebugLvl              = runtimeDebugLevel.getOrElse(Utils.DEFAULT_RUNTIME_DEBUG_LEVEL)
-  private val wdlVarLinksConverter    = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
+  private val verbose2: Boolean = verbose.containsKey("Native")
+  private val rtDebugLvl = runtimeDebugLevel.getOrElse(Utils.DEFAULT_RUNTIME_DEBUG_LEVEL)
+  private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
   private val streamAllFiles: Boolean = dxPathConfig.streamAllFiles
 
   // Are we setting up a private docker registry?
@@ -61,19 +61,19 @@ case class Native(
       case Some(id) =>
         // Open the archive
         // Extract the archive from the details field
-        val record  = DxRecord.getInstance(id)
-        val desc    = record.describe(Set(Field.Details))
+        val record = DxRecord.getInstance(id)
+        val desc = record.describe(Set(Field.Details))
         val details = desc.details.get
         val dxLink = details.asJsObject.fields.get("archiveFileId") match {
           case Some(x) => x
           case None    => throw new Exception(s"record does not have an archive field ${details}")
         }
         val dxFile = DxUtils.dxFileFromJsValue(dxLink)
-        val name   = dxFile.describe().name
+        val name = dxFile.describe().name
         Some(
           JsObject(
             "name" -> JsString(name),
-            "id"   -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
+            "id" -> JsObject("$dnanexus_link" -> JsString(dxFile.id))
           )
         )
     }
@@ -140,8 +140,8 @@ case class Native(
         ),
         JsObject(
           Map(
-            "name"     -> JsString(name + Utils.FLAT_FILES_SUFFIX),
-            "class"    -> JsString("array:file"),
+            "name" -> JsString(name + Utils.FLAT_FILES_SUFFIX),
+            "class" -> JsString("array:file"),
             "optional" -> JsBoolean(true)
           )
             ++ jsMapFromDefault(name + Utils.FLAT_FILES_SUFFIX)
@@ -414,7 +414,7 @@ case class Native(
 
     // We need to sort the hash-tables. They are natually unsorted,
     // causing the same object to have different checksums.
-    val jsDet  = Utils.makeDeterministic(JsObject(fields))
+    val jsDet = Utils.makeDeterministic(JsObject(fields))
     val digest = chksum(jsDet.prettyPrint)
 
     // Add the checksum to the properies
@@ -425,7 +425,7 @@ case class Native(
         case other                 => throw new Exception(s"Bad properties json value ${other}")
       }
     val props = preExistingProps ++ Map(
-      Utils.VERSION_PROP  -> JsString(Utils.getVersion()),
+      Utils.VERSION_PROP -> JsString(Utils.getVersion()),
       Utils.CHECKSUM_PROP -> JsString(digest)
     )
 
@@ -434,9 +434,9 @@ case class Native(
     // still being able to reuse it.
     val req = JsObject(
       fields ++ Map(
-        "project"    -> JsString(dxProject.id),
-        "folder"     -> JsString(folder),
-        "parents"    -> JsBoolean(true),
+        "project" -> JsString(dxProject.id),
+        "folder" -> JsString(folder),
+        "parents" -> JsBoolean(true),
         "properties" -> JsObject(props)
       )
     )
@@ -576,7 +576,7 @@ case class Native(
     }
     //System.out.println(s"Native: instanceType chosen = ${instanceType}")
     val runSpec: Map[String, JsValue] = Map(
-      "code"        -> JsString(bashScript),
+      "code" -> JsString(bashScript),
       "interpreter" -> JsString("bash"),
       "systemRequirements" ->
         JsObject(
@@ -584,7 +584,7 @@ case class Native(
             JsObject("instanceType" -> JsString(instanceType))
         ),
       "distribution" -> JsString("Ubuntu"),
-      "release"      -> JsString(Utils.UBUNTU_VERSION)
+      "release" -> JsString(Utils.UBUNTU_VERSION)
     )
 
     // Add default timeout
@@ -726,7 +726,7 @@ case class Native(
           // meta information used for running workflow fragments
           Map(
             "execLinkInfo" -> JsObject(linkInfo),
-            "blockPath"    -> JsArray(blockPath.map(JsNumber(_))),
+            "blockPath" -> JsArray(blockPath.map(JsNumber(_))),
             "fqnDictTypes" -> JsObject(fqnDictTypes.map {
               case (k, t) =>
                 val tStr = WomTypeSerialization(typeAliases).toString(t)
@@ -756,17 +756,17 @@ case class Native(
 
     // put the wom source code into the details field.
     // Add the pricing model, and make the prices opaque.
-    val womSourceCode    = Utils.gzipAndBase64Encode(applet.womSourceCode)
-    val dbOpaque         = InstanceTypeDB.opaquePrices(instanceTypeDB)
+    val womSourceCode = Utils.gzipAndBase64Encode(applet.womSourceCode)
+    val dbOpaque = InstanceTypeDB.opaquePrices(instanceTypeDB)
     val dbOpaqueInstance = Utils.gzipAndBase64Encode(dbOpaque.toJson.prettyPrint)
     val runtimeAttrs = extras match {
       case None      => JsNull
       case Some(ext) => ext.defaultRuntimeAttributes.toJson
     }
     val auxInfo = Map(
-      "womSourceCode"  -> JsString(womSourceCode),
+      "womSourceCode" -> JsString(womSourceCode),
       "instanceTypeDB" -> JsString(dbOpaqueInstance),
-      "runtimeAttrs"   -> runtimeAttrs
+      "runtimeAttrs" -> runtimeAttrs
     )
 
     // Links to applets that could get called at runtime. If
@@ -778,8 +778,8 @@ case class Native(
     val (runSpec: JsValue, details: Map[String, JsValue]) =
       calcRunSpec(applet, auxInfo ++ dxLinks ++ metaInfo, bashScript)
     val detailsWithLicense: Map[String, JsValue] = addLicences(applet)
-    val jsDetails: JsValue                       = JsObject(details ++ detailsWithLicense)
-    val access: JsValue                          = calcAccess(applet)
+    val jsDetails: JsValue = JsObject(details ++ detailsWithLicense)
+    val access: JsValue = calcAccess(applet)
 
     // A fragemnt is hidden, not visible under default settings. This
     // allows the workflow copying code to traverse it, and link to
@@ -792,14 +792,14 @@ case class Native(
 
     // pack all the core arguments into a single request
     val reqCore = Map(
-      "name"       -> JsString(applet.name),
-      "inputSpec"  -> JsArray(inputSpec),
+      "name" -> JsString(applet.name),
+      "inputSpec" -> JsArray(inputSpec),
       "outputSpec" -> JsArray(outputSpec),
-      "runSpec"    -> runSpec,
-      "dxapi"      -> JsString("1.0.0"),
-      "tags"       -> JsArray(JsString("dxWDL")),
-      "details"    -> jsDetails,
-      "hidden"     -> JsBoolean(hidden)
+      "runSpec" -> runSpec,
+      "dxapi" -> JsString("1.0.0"),
+      "tags" -> JsArray(JsString("dxWDL")),
+      "details" -> jsDetails,
+      "hidden" -> JsBoolean(hidden)
     )
     val accessField =
       if (access == JsNull) Map.empty
@@ -837,7 +837,7 @@ case class Native(
     // making of the applet.
     val (digest, appletApiRequest) = appletNewReq(applet, bashScript, folder, aplLinks)
     if (verbose2) {
-      val fName   = s"${applet.name}_req.json"
+      val fName = s"${applet.name}_req.json"
       val trgPath = Utils.appCompileDirPath.resolve(fName)
       Utils.writeFileContent(trgPath, appletApiRequest.prettyPrint)
     }
@@ -846,8 +846,8 @@ case class Native(
     val dxApplet = buildRequired match {
       case None =>
         // Compile a WDL snippet into an applet.
-        val rep      = DXAPI.appletNew(DxUtils.jsonNodeOfJsValue(appletApiRequest), classOf[JsonNode])
-        val id       = apiParseReplyID(rep)
+        val rep = DXAPI.appletNew(DxUtils.jsonNodeOfJsValue(appletApiRequest), classOf[JsonNode])
+        val id = apiParseReplyID(rep)
         val dxApplet = DxApplet.getInstance(id)
         dxObjDir.insert(applet.name, dxApplet, digest)
         dxApplet
@@ -873,15 +873,15 @@ case class Native(
             // in a value at runtime.
             m
           case IR.SArgConst(wValue) =>
-            val wvl    = wdlVarLinksConverter.importFromWDL(cVar.womType, wValue)
+            val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wValue)
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
           case IR.SArgLink(dxStage, argName) =>
-            val wvl    = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
+            val wvl = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
           case IR.SArgWorkflowInput(argName) =>
-            val wvl    = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
+            val wvl = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
         }
@@ -965,16 +965,16 @@ case class Native(
     val stagesReq =
       wf.stages.foldLeft(Vector.empty[JsValue]) {
         case (stagesReq, stg) =>
-          val ExecRecord(irApplet, dxExec, _)    = execDict(stg.calleeName)
+          val ExecRecord(irApplet, dxExec, _) = execDict(stg.calleeName)
           val linkedInputs: Vector[(CVar, SArg)] = irApplet.inputVars zip stg.inputs
-          val inputs                             = genStageInputs(linkedInputs)
+          val inputs = genStageInputs(linkedInputs)
           // convert the per-stage metadata into JSON
           val stageReqDesc = JsObject(
             Map(
-              "id"         -> JsString(stg.id.getId),
+              "id" -> JsString(stg.id.getId),
               "executable" -> JsString(dxExec.getId),
-              "name"       -> JsString(stg.description),
-              "input"      -> inputs
+              "name" -> JsString(stg.description),
+              "input" -> inputs
             )
           )
           stagesReq :+ stageReqDesc
@@ -993,9 +993,9 @@ case class Native(
 
     // pack all the arguments into a single API call
     val reqFields = Map(
-      "name"   -> JsString(wf.name),
+      "name" -> JsString(wf.name),
       "stages" -> JsArray(stagesReq),
-      "tags"   -> JsArray(JsString("dxWDL")),
+      "tags" -> JsArray(JsString("dxWDL")),
       "hidden" -> JsBoolean(hidden)
     )
 
@@ -1046,7 +1046,7 @@ case class Native(
       JsObject(
         reqWithChecksum.asJsObject.fields ++ Map(
           "project" -> JsString(dxProject.id),
-          "folder"  -> JsString(folder),
+          "folder" -> JsString(folder),
           "parents" -> JsBoolean(true)
         )
       )
@@ -1054,8 +1054,8 @@ case class Native(
   }
 
   private def buildWorkflow(req: JsValue): DxWorkflow = {
-    val rep  = DXAPI.workflowNew(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
-    val id   = apiParseReplyID(rep)
+    val rep = DXAPI.workflowNew(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+    val id = apiParseReplyID(rep)
     val dxwf = DxWorkflow.getInstance(id)
 
     // Close the workflow
@@ -1073,7 +1073,7 @@ case class Native(
       execDict: Map[String, ExecRecord]
   ): DxWorkflow = {
     val (digest, wfNewReq) = workflowNewReq(wf, execDict)
-    val buildRequired      = isBuildRequired(wf.name, digest)
+    val buildRequired = isBuildRequired(wf.name, digest)
     buildRequired match {
       case None =>
         val dxWorkflow = buildWorkflow(wfNewReq)

--- a/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
+++ b/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
@@ -39,7 +39,7 @@ case class SortTypeAliases(verbose: Verbose) {
       // catch-all for other types not currently supported
       case other =>
         throw new Exception(
-          s"Unsupported WOM type ${other}, ${other.stableName}"
+            s"Unsupported WOM type ${other}, ${other.stableName}"
         )
     }
   }

--- a/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
+++ b/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
@@ -93,7 +93,7 @@ case class SortTypeAliases(verbose: Verbose) {
   }
 
   def apply(typeAliases: Vector[(String, WomType)]): Vector[(String, WomType)] = {
-    val justTypes   = typeAliases.map { case (_, x) => x }
+    val justTypes = typeAliases.map { case (_, x) => x }
     val sortedTypes = apply2(justTypes)
 
     sortedTypes.map {

--- a/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
+++ b/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
@@ -5,104 +5,101 @@ import dxWDL.base.{Utils, Verbose}
 
 // sort the definitions by dependencies
 case class SortTypeAliases(verbose: Verbose) {
-    private val verbose2:Boolean = verbose.containsKey("SortTypeAliases")
+  private val verbose2: Boolean = verbose.containsKey("SortTypeAliases")
 
-    // figure out all the types that type [a] depends on. Ignore
-    // standard types like Int, String, Array, etc.
-    //
-    private def dependencies(a : WomType) : Set[String] = {
-        a match {
-            // Base case: primitive types.
-            case WomNothingType
-                   | WomBooleanType
-                   | WomIntegerType
-                   | WomLongType
-                   | WomFloatType
-                   | WomStringType
-                   | WomSingleFileType => Set.empty
+  // figure out all the types that type [a] depends on. Ignore
+  // standard types like Int, String, Array, etc.
+  //
+  private def dependencies(a: WomType): Set[String] = {
+    a match {
+      // Base case: primitive types.
+      case WomNothingType | WomBooleanType | WomIntegerType | WomLongType | WomFloatType |
+          WomStringType | WomSingleFileType =>
+        Set.empty
 
-            // compound types
-            case WomMaybeEmptyArrayType(memberType) =>
-                dependencies(memberType)
-            case WomMapType(keyType, valueType) =>
-                dependencies(keyType) ++ dependencies(valueType)
-            case WomNonEmptyArrayType(memberType) =>
-                dependencies(memberType)
-            case WomOptionalType(memberType) =>
-                dependencies(memberType)
-            case WomPairType(lType, rType) =>
-                dependencies(lType) ++ dependencies(rType)
+      // compound types
+      case WomMaybeEmptyArrayType(memberType) =>
+        dependencies(memberType)
+      case WomMapType(keyType, valueType) =>
+        dependencies(keyType) ++ dependencies(valueType)
+      case WomNonEmptyArrayType(memberType) =>
+        dependencies(memberType)
+      case WomOptionalType(memberType) =>
+        dependencies(memberType)
+      case WomPairType(lType, rType) =>
+        dependencies(lType) ++ dependencies(rType)
 
-            // structs
-            case WomCompositeType(typeMap, Some(structName)) =>
-                typeMap.foldLeft(Set(structName)) {
-                    case (accu, (_, t)) =>
-                        accu ++ dependencies(t)
-                }
-
-            // catch-all for other types not currently supported
-            case other =>
-                throw new Exception(s"Unsupported WOM type ${other}, ${other.stableName}")
+      // structs
+      case WomCompositeType(typeMap, Some(structName)) =>
+        typeMap.foldLeft(Set(structName)) {
+          case (accu, (_, t)) =>
+            accu ++ dependencies(t)
         }
+
+      // catch-all for other types not currently supported
+      case other =>
+        throw new Exception(s"Unsupported WOM type ${other}, ${other.stableName}")
     }
+  }
 
-    private def dependenciesOuter(a : WomType) : Set[String] = {
-        val d = dependencies(a)
-        a match {
-            case WomCompositeType(_, Some(name)) => d - name
-            case _ => d
-        }
+  private def dependenciesOuter(a: WomType): Set[String] = {
+    val d = dependencies(a)
+    a match {
+      case WomCompositeType(_, Some(name)) => d - name
+      case _                               => d
     }
+  }
 
-    private def next(remaining: Vector[WomType],
-                     alreadySorted: Vector[WomType]) : (Vector[WomType], Vector[WomType]) = {
-        val alreadySortedNames : Set[String] = alreadySorted.collect{
-            case WomCompositeType(_, Some(name)) => name
-        }.toSet
+  private def next(
+      remaining: Vector[WomType],
+      alreadySorted: Vector[WomType]
+  ): (Vector[WomType], Vector[WomType]) = {
+    val alreadySortedNames: Set[String] = alreadySorted.collect {
+      case WomCompositeType(_, Some(name)) => name
+    }.toSet
 
-        val (zeroDeps, top) = remaining.partition {
-            case a : WomCompositeType =>
-                val deps = dependenciesOuter(a)
-                Utils.trace(verbose2, s"dependencies(${a}) === ${deps}")
-                deps.subsetOf(alreadySortedNames)
-            case _ => true
-        }
-        assert(!zeroDeps.isEmpty)
-        (zeroDeps.toVector, top.toVector)
+    val (zeroDeps, top) = remaining.partition {
+      case a: WomCompositeType =>
+        val deps = dependenciesOuter(a)
+        Utils.trace(verbose2, s"dependencies(${a}) === ${deps}")
+        deps.subsetOf(alreadySortedNames)
+      case _ => true
     }
+    assert(!zeroDeps.isEmpty)
+    (zeroDeps.toVector, top.toVector)
+  }
 
-    private def getNames(ta : Vector[WomType]) : Vector[String] = {
-        ta.map{
-            case WomCompositeType(_, Some(name)) => name
-        }.toVector
+  private def getNames(ta: Vector[WomType]): Vector[String] = {
+    ta.map {
+      case WomCompositeType(_, Some(name)) => name
+    }.toVector
+  }
+
+  private def apply2(typeAliases: Vector[WomType]): Vector[WomType] = {
+    val N = typeAliases.size
+
+    var accu = Vector.empty[WomType]
+    var crnt = typeAliases
+
+    while (!crnt.isEmpty) {
+      Utils.trace(verbose2, s"accu=${getNames(accu)}")
+      Utils.trace(verbose2, s"crnt=${getNames(crnt)}")
+      val (zeroDeps, top) = next(crnt, accu)
+      accu = accu ++ zeroDeps
+      crnt = top
     }
+    assert(accu.length == N)
+    accu
+  }
 
-    private def apply2(typeAliases: Vector[WomType]) : Vector[WomType] = {
-        val N = typeAliases.size
+  def apply(typeAliases: Vector[(String, WomType)]): Vector[(String, WomType)] = {
+    val justTypes   = typeAliases.map { case (_, x) => x }
+    val sortedTypes = apply2(justTypes)
 
-        var accu = Vector.empty[WomType]
-        var crnt = typeAliases
-
-        while (!crnt.isEmpty) {
-            Utils.trace(verbose2, s"accu=${getNames(accu)}")
-            Utils.trace(verbose2, s"crnt=${getNames(crnt)}")
-            val (zeroDeps, top) = next(crnt, accu)
-            accu = accu ++ zeroDeps
-            crnt = top
-        }
-        assert(accu.length == N)
-        accu
-    }
-
-
-    def apply(typeAliases: Vector[(String, WomType)]) : Vector[(String, WomType)] = {
-        val justTypes = typeAliases.map{ case (_,x) => x }
-        val sortedTypes = apply2(justTypes)
-
-        sortedTypes.map{
-            case a@WomCompositeType(_, Some(name)) =>
-                (name, a)
-            case _ => throw new Exception("sanity")
-        }.toVector
-    }
+    sortedTypes.map {
+      case a @ WomCompositeType(_, Some(name)) =>
+        (name, a)
+      case _ => throw new Exception("sanity")
+    }.toVector
+  }
 }

--- a/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
+++ b/src/main/scala/dxWDL/compiler/SortTypeAliases.scala
@@ -38,7 +38,9 @@ case class SortTypeAliases(verbose: Verbose) {
 
       // catch-all for other types not currently supported
       case other =>
-        throw new Exception(s"Unsupported WOM type ${other}, ${other.stableName}")
+        throw new Exception(
+          s"Unsupported WOM type ${other}, ${other.stableName}"
+        )
     }
   }
 
@@ -92,7 +94,9 @@ case class SortTypeAliases(verbose: Verbose) {
     accu
   }
 
-  def apply(typeAliases: Vector[(String, WomType)]): Vector[(String, WomType)] = {
+  def apply(
+      typeAliases: Vector[(String, WomType)]
+  ): Vector[(String, WomType)] = {
     val justTypes = typeAliases.map { case (_, x) => x }
     val sortedTypes = apply2(justTypes)
 

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -15,317 +15,334 @@ import dxWDL.dx._
 import dxWDL.util._
 
 // The end result of the compiler
-case class CompilationResults(primaryCallable: Option[DxExecutable],
-                              execDict: Map[String, DxExecutable])
+case class CompilationResults(
+    primaryCallable: Option[DxExecutable],
+    execDict: Map[String, DxExecutable]
+)
 
 case class Top(cOpt: CompilerOptions) {
-    val verbose = cOpt.verbose
+  val verbose = cOpt.verbose
 
-    // The mapping from region to project name is list of (region, proj-name) pairs.
-    // Get the project for this region.
-    private def getProjectWithRuntimeLibrary(region2project: Map[String, String],
-                                             region: String) : (String, String) = {
-        val destination = region2project.get(region) match {
-            case None => throw new Exception(s"Region ${region} is currently unsupported")
-            case Some(dest) => dest
-        }
-
-        // The destionation is something like:
-        val parts = destination.split(":")
-        if (parts.length == 1) {
-            (parts(0), "/")
-        } else if (parts.length == 2) {
-            (parts(0), parts(1))
-        } else {
-            throw new Exception(s"Bad syntax for destination ${destination}")
-        }
+  // The mapping from region to project name is list of (region, proj-name) pairs.
+  // Get the project for this region.
+  private def getProjectWithRuntimeLibrary(
+      region2project: Map[String, String],
+      region: String
+  ): (String, String) = {
+    val destination = region2project.get(region) match {
+      case None       => throw new Exception(s"Region ${region} is currently unsupported")
+      case Some(dest) => dest
     }
 
-    // Find the runtime dxWDL asset with the correct version. Look inside the
-    // project configured for this region.
-    private def getAssetId(region: String) : String = {
-        val region2project = Utils.getRegions()
-        val (projNameRt, folder)  = getProjectWithRuntimeLibrary(region2project, region)
-        val dxProjRt = DxPath.resolveProject(projNameRt)
-        Utils.trace(verbose.on, s"Looking for asset-id in ${projNameRt}:/${folder}")
-
-        val assetDxPath = s"${DX_URL_PREFIX}${dxProjRt.getId}:${folder}/${DX_WDL_ASSET}"
-        val dxObj = DxPath.resolveOnePath(assetDxPath, dxProjRt)
-        if (!dxObj.isInstanceOf[DxRecord])
-            throw new Exception(s"Found dx object of wrong type ${dxObj} at ${assetDxPath}")
-        dxObj.getId
+    // The destionation is something like:
+    val parts = destination.split(":")
+    if (parts.length == 1) {
+      (parts(0), "/")
+    } else if (parts.length == 2) {
+      (parts(0), parts(1))
+    } else {
+      throw new Exception(s"Bad syntax for destination ${destination}")
     }
+  }
 
-    // We need the dxWDL runtime library cloned into this project, so it will
-    // be available to all subjobs we run.
-    private def cloneRtLibraryToProject(region: String,
-                                        dxWDLrtId: String,
-                                        dxProject: DxProject) : Unit = {
-        val region2project = Utils.getRegions()
-        val (projNameRt, folder)  = getProjectWithRuntimeLibrary(region2project, region)
-        val dxProjRt = DxPath.resolveProject(projNameRt)
-        DxUtils.cloneAsset(DxRecord.getInstance(dxWDLrtId),
-                           dxProject,
-                           DX_WDL_ASSET,
-                           dxProjRt,
-                           verbose)
+  // Find the runtime dxWDL asset with the correct version. Look inside the
+  // project configured for this region.
+  private def getAssetId(region: String): String = {
+    val region2project       = Utils.getRegions()
+    val (projNameRt, folder) = getProjectWithRuntimeLibrary(region2project, region)
+    val dxProjRt             = DxPath.resolveProject(projNameRt)
+    Utils.trace(verbose.on, s"Looking for asset-id in ${projNameRt}:/${folder}")
+
+    val assetDxPath = s"${DX_URL_PREFIX}${dxProjRt.getId}:${folder}/${DX_WDL_ASSET}"
+    val dxObj       = DxPath.resolveOnePath(assetDxPath, dxProjRt)
+    if (!dxObj.isInstanceOf[DxRecord])
+      throw new Exception(s"Found dx object of wrong type ${dxObj} at ${assetDxPath}")
+    dxObj.getId
+  }
+
+  // We need the dxWDL runtime library cloned into this project, so it will
+  // be available to all subjobs we run.
+  private def cloneRtLibraryToProject(
+      region: String,
+      dxWDLrtId: String,
+      dxProject: DxProject
+  ): Unit = {
+    val region2project       = Utils.getRegions()
+    val (projNameRt, folder) = getProjectWithRuntimeLibrary(region2project, region)
+    val dxProjRt             = DxPath.resolveProject(projNameRt)
+    DxUtils.cloneAsset(DxRecord.getInstance(dxWDLrtId), dxProject, DX_WDL_ASSET, dxProjRt, verbose)
+  }
+
+  // Backend compiler pass
+  private def compileNative(
+      bundle: IR.Bundle,
+      folder: String,
+      dxProject: DxProject,
+      runtimePathConfig: DxPathConfig,
+      fileInfoDir: Map[String, (DxFile, DxFileDescribe)]
+  ): CompilationResults = {
+    val dxWDLrtId: Option[String] = cOpt.compileMode match {
+      case CompilerFlag.IR =>
+        throw new Exception("Invalid value IR for compilation mode")
+      case CompilerFlag.NativeWithoutRuntimeAsset =>
+        // Testing mode, we don't need the runtime library to check native
+        // compilation.
+        None
+      case CompilerFlag.All =>
+        // get billTo and region from the project, then find the runtime asset
+        // in the current region.
+        val (billTo, region) = DxUtils.projectDescribeExtraInfo(dxProject)
+        val lrtId            = getAssetId(region)
+        cloneRtLibraryToProject(region, lrtId, dxProject)
+        Some(lrtId)
     }
+    // get list of available instance types
+    val instanceTypeDB = InstanceTypeDB.query(dxProject, verbose)
 
-    // Backend compiler pass
-    private def compileNative(bundle: IR.Bundle,
-                              folder: String,
-                              dxProject: DxProject,
-                              runtimePathConfig: DxPathConfig,
-                              fileInfoDir: Map[String, (DxFile, DxFileDescribe)]) : CompilationResults = {
-        val dxWDLrtId: Option[String] = cOpt.compileMode match {
-            case CompilerFlag.IR =>
-                throw new Exception("Invalid value IR for compilation mode")
-            case CompilerFlag.NativeWithoutRuntimeAsset =>
-                // Testing mode, we don't need the runtime library to check native
-                // compilation.
-                None
-            case CompilerFlag.All =>
-                // get billTo and region from the project, then find the runtime asset
-                // in the current region.
-                val (billTo, region) = DxUtils.projectDescribeExtraInfo(dxProject)
-                val lrtId = getAssetId(region)
-                cloneRtLibraryToProject(region, lrtId, dxProject)
-                Some(lrtId)
-        }
-        // get list of available instance types
-        val instanceTypeDB = InstanceTypeDB.query(dxProject, verbose)
+    // Efficiently build a directory of the currently existing applets.
+    // We don't want to build them if we don't have to.
+    val dxObjDir = DxObjectDirectory(bundle, dxProject, folder, cOpt.projectWideReuse, verbose)
 
-        // Efficiently build a directory of the currently existing applets.
-        // We don't want to build them if we don't have to.
-        val dxObjDir = DxObjectDirectory(bundle, dxProject, folder, cOpt.projectWideReuse,
-                                         verbose)
+    // Generate dx:applets and dx:workflow from the IR
+    new Native(
+      dxWDLrtId,
+      folder,
+      dxProject,
+      dxObjDir,
+      instanceTypeDB,
+      runtimePathConfig,
+      fileInfoDir,
+      bundle.typeAliases,
+      cOpt.extras,
+      cOpt.runtimeDebugLevel,
+      cOpt.leaveWorkflowsOpen,
+      cOpt.force,
+      cOpt.archive,
+      cOpt.locked,
+      cOpt.verbose
+    ).apply(bundle)
+  }
 
-        // Generate dx:applets and dx:workflow from the IR
-        new Native(dxWDLrtId, folder, dxProject,
-                   dxObjDir,
-                   instanceTypeDB, runtimePathConfig, fileInfoDir, bundle.typeAliases,
-                   cOpt.extras,
-                   cOpt.runtimeDebugLevel,
-                   cOpt.leaveWorkflowsOpen,
-                   cOpt.force, cOpt.archive, cOpt.locked, cOpt.verbose).apply(bundle)
+  // check the declarations in [graph], and make sure they
+  // do not contain the reserved '___' substring.
+  private def checkDeclarations(varNames: Seq[String]): Unit = {
+    for (varName <- varNames)
+      if (varName contains "___")
+        throw new Exception(s"Variable ${varName} is using the reserved substring ___")
+  }
+
+  // check that streaming annotations are only done for files.
+  private def validate(callable: Callable): Unit = {
+    callable match {
+      case wf: WorkflowDefinition =>
+        if (wf.parameterMeta.size > 0)
+          Utils.warning(verbose, "dxWDL workflows ignore their parameter meta section")
+        val g = wf.innerGraph
+        checkDeclarations(g.inputNodes.map(_.localName).toSeq)
+        checkDeclarations(g.outputNodes.map(_.localName).toSeq)
+        val allDeclarations = g.allNodes.filter(_.isInstanceOf[ExposedExpressionNode])
+        checkDeclarations(allDeclarations.map(_.identifier.localName.value).toSeq)
+
+      case task: CallableTaskDefinition =>
+        checkDeclarations(task.inputs.map(_.name).toSeq)
+        checkDeclarations(task.outputs.map(_.name).toSeq)
+
+      case other =>
+        throw new Exception(s"Unexpected object ${other}")
     }
+  }
 
-    // check the declarations in [graph], and make sure they
-    // do not contain the reserved '___' substring.
-    private def checkDeclarations(varNames : Seq[String]) : Unit = {
-        for (varName <- varNames)
-            if (varName contains "___")
-                throw new Exception(s"Variable ${varName} is using the reserved substring ___")
-    }
+  // Check the uniqueness of tasks, Workflows, and Types
+  // merge everything into one bundle.
+  private def mergeIntoOneBundle(
+      mainBundle: WomBundle,
+      subBundles: Vector[WomBundle]
+  ): WomBundle = {
+    var allCallables   = mainBundle.allCallables
+    var allTypeAliases = mainBundle.typeAliases
 
-    // check that streaming annotations are only done for files.
-    private def validate(callable: Callable) : Unit = {
-        callable match {
-            case wf: WorkflowDefinition =>
-                if (wf.parameterMeta.size > 0)
-                    Utils.warning(verbose, "dxWDL workflows ignore their parameter meta section")
-                val g = wf.innerGraph
-                checkDeclarations(g.inputNodes.map(_.localName).toSeq)
-                checkDeclarations(g.outputNodes.map(_.localName).toSeq)
-                val allDeclarations = g.allNodes.filter(_.isInstanceOf[ExposedExpressionNode])
-                checkDeclarations(allDeclarations.map(_.identifier.localName.value).toSeq)
+    subBundles.foreach { subBund =>
+      subBund.allCallables.foreach {
+        case (key, callable) =>
+          allCallables.get(key) match {
+            case None =>
+              allCallables = allCallables + (key -> callable)
 
-            case task: CallableTaskDefinition =>
-                checkDeclarations(task.inputs.map(_.name).toSeq)
-                checkDeclarations(task.outputs.map(_.name).toSeq)
-
-            case other =>
-                throw new Exception(s"Unexpected object ${other}")
-        }
-    }
-
-    // Check the uniqueness of tasks, Workflows, and Types
-    // merge everything into one bundle.
-    private def mergeIntoOneBundle(mainBundle: WomBundle,
-                                   subBundles: Vector[WomBundle]) : WomBundle = {
-        var allCallables = mainBundle.allCallables
-        var allTypeAliases = mainBundle.typeAliases
-
-        subBundles.foreach{ subBund =>
-            subBund.allCallables.foreach{ case (key, callable) =>
-                allCallables.get(key) match {
-                    case None =>
-                        allCallables = allCallables + (key -> callable)
-
-                    // The comparision is done with "toString", because otherwise two
-                    // identical definitions are somehow, through the magic of Scala,
-                    // unequal.
-                    case Some(existing) if (existing.toString != callable.toString) =>
-                        Utils.error(s"""|${key} appears with two different callable definitions
+            // The comparision is done with "toString", because otherwise two
+            // identical definitions are somehow, through the magic of Scala,
+            // unequal.
+            case Some(existing) if (existing.toString != callable.toString) =>
+              Utils.error(s"""|${key} appears with two different callable definitions
                                         |1)
                                         |${callable}
                                         |
                                         |2)
                                         |${existing}
                                         |""".stripMargin)
-                        throw new Exception(s"${key} appears twice, with two different definitions")
-                    case _ => ()
-                }
-            }
-            subBund.typeAliases.foreach { case (key, definition) =>
-                allTypeAliases.get(key) match {
-                    case None =>
-                        allTypeAliases = allTypeAliases + (key -> definition)
-                    case Some(existing) if (existing != definition) =>
-                        Utils.error(s"""|${key} appears twice, with two different definitions
+              throw new Exception(s"${key} appears twice, with two different definitions")
+            case _ => ()
+          }
+      }
+      subBund.typeAliases.foreach {
+        case (key, definition) =>
+          allTypeAliases.get(key) match {
+            case None =>
+              allTypeAliases = allTypeAliases + (key -> definition)
+            case Some(existing) if (existing != definition) =>
+              Utils.error(s"""|${key} appears twice, with two different definitions
                                         |1)
                                         |${definition}
                                         |
                                         |2)
                                         |${existing}
                                         |""".stripMargin)
-                        throw new Exception(s"${key} type alias appears twice")
-                    case _ => ()
-                }
-            }
-        }
-
-        // Merge all the bundles together
-        WomBundle(mainBundle.primaryCallable,
-                  allCallables,
-                  allTypeAliases,
-                  Set.empty)
+              throw new Exception(s"${key} type alias appears twice")
+            case _ => ()
+          }
+      }
     }
 
+    // Merge all the bundles together
+    WomBundle(mainBundle.primaryCallable, allCallables, allTypeAliases, Set.empty)
+  }
 
-    // Scan the JSON inputs files for dx:files, and batch describe them. This
-    // reduces the number of API calls.
-    private def bulkFileDescribe(bundle: IR.Bundle,
-                                 dxProject: DxProject) : (Map[String, DxFile],
-                                                          Map[String, (DxFile, DxFileDescribe)]) = {
-        val defResults : InputFileScanResults = cOpt.defaults match {
-            case None => InputFileScanResults(Map.empty, Vector.empty)
-            case Some(path) =>
-                InputFileScan(bundle, dxProject, verbose).apply(path)
-        }
-
-        val allResults : InputFileScanResults = cOpt.inputs.foldLeft(defResults) {
-            case (accu : InputFileScanResults, inputFilePath) =>
-                val res = InputFileScan(bundle, dxProject, verbose).apply(inputFilePath)
-                InputFileScanResults(accu.path2file ++ res.path2file,
-                                     accu.dxFiles ++ res.dxFiles)
-        }
-
-        val allDescribe = DxFile.bulkDescribe(allResults.dxFiles)
-        val allFiles : Map[String, (DxFile, DxFileDescribe)] = allDescribe.map{
-            case (f : DxFile, desc) => f.id -> (f, desc)
-            case _ => throw new Exception("has to be all files")
-        }.toMap
-        (allResults.path2file, allFiles)
+  // Scan the JSON inputs files for dx:files, and batch describe them. This
+  // reduces the number of API calls.
+  private def bulkFileDescribe(
+      bundle: IR.Bundle,
+      dxProject: DxProject
+  ): (Map[String, DxFile], Map[String, (DxFile, DxFileDescribe)]) = {
+    val defResults: InputFileScanResults = cOpt.defaults match {
+      case None => InputFileScanResults(Map.empty, Vector.empty)
+      case Some(path) =>
+        InputFileScan(bundle, dxProject, verbose).apply(path)
     }
 
-
-    private def womToIR(source: Path) : IR.Bundle = {
-        val (language, womBundle, allSources, subBundles) =
-            ParseWomSourceFile(verbose.on).apply(source, cOpt.importDirs)
-
-        // Check that each workflow/task appears just one
-        val everythingBundle : WomBundle = mergeIntoOneBundle(womBundle, subBundles)
-
-        // validate
-        everythingBundle.allCallables.foreach{ case (_, c) => validate(c) }
-        everythingBundle.primaryCallable match {
-            case None => ()
-            case Some(x) => validate(x)
-        }
-
-        // Compile the WDL workflow into an Intermediate
-        // Representation (IR)
-        val defaultRuntimeAttrs = cOpt.extras match {
-            case None => WdlRuntimeAttrs(Map.empty)
-            case Some(ex) => ex.defaultRuntimeAttributes
-        }
-
-        val reorgApp: Either[Boolean, ReorgAttrs] = cOpt.extras match {
-
-            case None => Left(cOpt.reorg)
-            case Some(ex) => ex.customReorgAttributes match {
-                case None => Left(cOpt.reorg)
-                case Some(cOrg) => Right(cOrg)
-            }
-
-        }
-
-        new GenerateIR(cOpt.verbose, defaultRuntimeAttrs).apply(everythingBundle, allSources, language,
-                                                                cOpt.locked, reorgApp)
+    val allResults: InputFileScanResults = cOpt.inputs.foldLeft(defResults) {
+      case (accu: InputFileScanResults, inputFilePath) =>
+        val res = InputFileScan(bundle, dxProject, verbose).apply(inputFilePath)
+        InputFileScanResults(accu.path2file ++ res.path2file, accu.dxFiles ++ res.dxFiles)
     }
 
-    // Compile IR only
-    private def handleInputFiles(bundle: IR.Bundle,
-                                 path2file: Map[String, DxFile],
-                                 fileInfoDir: Map[String, (DxFile, DxFileDescribe)]) : IR.Bundle = {
-        val bundle2: IR.Bundle = cOpt.defaults match {
-            case None => bundle
-            case Some(path) =>
-                InputFile(fileInfoDir,
-                          path2file,
-                          bundle.typeAliases,
-                          cOpt.verbose).embedDefaults(bundle, path)
-        }
+    val allDescribe = DxFile.bulkDescribe(allResults.dxFiles)
+    val allFiles: Map[String, (DxFile, DxFileDescribe)] = allDescribe.map {
+      case (f: DxFile, desc) => f.id -> (f, desc)
+      case _                 => throw new Exception("has to be all files")
+    }.toMap
+    (allResults.path2file, allFiles)
+  }
 
-        // generate dx inputs from the Cromwell-style input specification.
-        cOpt.inputs.foreach{ path =>
-            val dxInputs = InputFile(fileInfoDir,
-                                     path2file,
-                                     bundle.typeAliases,
-                                     cOpt.verbose).dxFromCromwell(bundle2, path)
-            // write back out as xxxx.dx.json
-            val filename = Utils.replaceFileSuffix(path, ".dx.json")
-            val parent = path.getParent
-            val dxInputFile =
-                if (parent != null) parent.resolve(filename)
-                else Paths.get(filename)
-            Utils.writeFileContent(dxInputFile, dxInputs.prettyPrint)
-            Utils.trace(cOpt.verbose.on, s"Wrote dx JSON input file ${dxInputFile}")
-        }
-        bundle2
+  private def womToIR(source: Path): IR.Bundle = {
+    val (language, womBundle, allSources, subBundles) =
+      ParseWomSourceFile(verbose.on).apply(source, cOpt.importDirs)
+
+    // Check that each workflow/task appears just one
+    val everythingBundle: WomBundle = mergeIntoOneBundle(womBundle, subBundles)
+
+    // validate
+    everythingBundle.allCallables.foreach { case (_, c) => validate(c) }
+    everythingBundle.primaryCallable match {
+      case None    => ()
+      case Some(x) => validate(x)
     }
 
-    // compile and generate intermediate code only
-    def applyOnlyIR(source: Path,
-                    dxProject: DxProject) : IR.Bundle = {
-        // generate IR
-        val bundle : IR.Bundle = womToIR(source)
-
-        // lookup platform files in bulk
-        val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)
-
-        // handle changes resulting from setting defaults, and
-        // generate DNAx input files.
-        handleInputFiles(bundle, path2dxFile, fileInfoDir)
+    // Compile the WDL workflow into an Intermediate
+    // Representation (IR)
+    val defaultRuntimeAttrs = cOpt.extras match {
+      case None     => WdlRuntimeAttrs(Map.empty)
+      case Some(ex) => ex.defaultRuntimeAttributes
     }
 
-    // Compile up to native dx applets and workflows
-    def apply(source: Path,
-              folder: String,
-              dxProject: DxProject,
-              runtimePathConfig: DxPathConfig) : Option[String] = {
-        val bundle : IR.Bundle = womToIR(source)
+    val reorgApp: Either[Boolean, ReorgAttrs] = cOpt.extras match {
 
-        // lookup platform files in bulk
-        val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)
-
-        // generate IR
-        val bundle2: IR.Bundle = handleInputFiles(bundle, path2dxFile, fileInfoDir)
-
-        // Up to this point, compilation does not require
-        // the dx:project. This allows unit testing without
-        // being logged in to the platform. For the native
-        // pass the dx:project is required to establish
-        // (1) the instance price list and database
-        // (2) the output location of applets and workflows
-        val cResults = compileNative(bundle2, folder, dxProject, runtimePathConfig, fileInfoDir)
-        val execIds = cResults.primaryCallable match {
-            case None =>
-                cResults.execDict.map{ case (_, dxExec) => dxExec.getId }.mkString(",")
-            case Some(wf) =>
-                wf.getId
+      case None => Left(cOpt.reorg)
+      case Some(ex) =>
+        ex.customReorgAttributes match {
+          case None       => Left(cOpt.reorg)
+          case Some(cOrg) => Right(cOrg)
         }
-        Some(execIds)
+
     }
+
+    new GenerateIR(cOpt.verbose, defaultRuntimeAttrs).apply(
+      everythingBundle,
+      allSources,
+      language,
+      cOpt.locked,
+      reorgApp
+    )
+  }
+
+  // Compile IR only
+  private def handleInputFiles(
+      bundle: IR.Bundle,
+      path2file: Map[String, DxFile],
+      fileInfoDir: Map[String, (DxFile, DxFileDescribe)]
+  ): IR.Bundle = {
+    val bundle2: IR.Bundle = cOpt.defaults match {
+      case None => bundle
+      case Some(path) =>
+        InputFile(fileInfoDir, path2file, bundle.typeAliases, cOpt.verbose)
+          .embedDefaults(bundle, path)
+    }
+
+    // generate dx inputs from the Cromwell-style input specification.
+    cOpt.inputs.foreach { path =>
+      val dxInputs = InputFile(fileInfoDir, path2file, bundle.typeAliases, cOpt.verbose)
+        .dxFromCromwell(bundle2, path)
+      // write back out as xxxx.dx.json
+      val filename = Utils.replaceFileSuffix(path, ".dx.json")
+      val parent   = path.getParent
+      val dxInputFile =
+        if (parent != null) parent.resolve(filename)
+        else Paths.get(filename)
+      Utils.writeFileContent(dxInputFile, dxInputs.prettyPrint)
+      Utils.trace(cOpt.verbose.on, s"Wrote dx JSON input file ${dxInputFile}")
+    }
+    bundle2
+  }
+
+  // compile and generate intermediate code only
+  def applyOnlyIR(source: Path, dxProject: DxProject): IR.Bundle = {
+    // generate IR
+    val bundle: IR.Bundle = womToIR(source)
+
+    // lookup platform files in bulk
+    val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)
+
+    // handle changes resulting from setting defaults, and
+    // generate DNAx input files.
+    handleInputFiles(bundle, path2dxFile, fileInfoDir)
+  }
+
+  // Compile up to native dx applets and workflows
+  def apply(
+      source: Path,
+      folder: String,
+      dxProject: DxProject,
+      runtimePathConfig: DxPathConfig
+  ): Option[String] = {
+    val bundle: IR.Bundle = womToIR(source)
+
+    // lookup platform files in bulk
+    val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)
+
+    // generate IR
+    val bundle2: IR.Bundle = handleInputFiles(bundle, path2dxFile, fileInfoDir)
+
+    // Up to this point, compilation does not require
+    // the dx:project. This allows unit testing without
+    // being logged in to the platform. For the native
+    // pass the dx:project is required to establish
+    // (1) the instance price list and database
+    // (2) the output location of applets and workflows
+    val cResults = compileNative(bundle2, folder, dxProject, runtimePathConfig, fileInfoDir)
+    val execIds = cResults.primaryCallable match {
+      case None =>
+        cResults.execDict.map { case (_, dxExec) => dxExec.getId }.mkString(",")
+      case Some(wf) =>
+        wf.getId
+    }
+    Some(execIds)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -60,7 +60,7 @@ case class Top(cOpt: CompilerOptions) {
     val dxObj = DxPath.resolveOnePath(assetDxPath, dxProjRt)
     if (!dxObj.isInstanceOf[DxRecord])
       throw new Exception(
-        s"Found dx object of wrong type ${dxObj} at ${assetDxPath}"
+          s"Found dx object of wrong type ${dxObj} at ${assetDxPath}"
       )
     dxObj.getId
   }
@@ -77,11 +77,11 @@ case class Top(cOpt: CompilerOptions) {
       getProjectWithRuntimeLibrary(region2project, region)
     val dxProjRt = DxPath.resolveProject(projNameRt)
     DxUtils.cloneAsset(
-      DxRecord.getInstance(dxWDLrtId),
-      dxProject,
-      DX_WDL_ASSET,
-      dxProjRt,
-      verbose
+        DxRecord.getInstance(dxWDLrtId),
+        dxProject,
+        DX_WDL_ASSET,
+        dxProjRt,
+        verbose
     )
   }
 
@@ -114,30 +114,30 @@ case class Top(cOpt: CompilerOptions) {
     // Efficiently build a directory of the currently existing applets.
     // We don't want to build them if we don't have to.
     val dxObjDir = DxObjectDirectory(
-      bundle,
-      dxProject,
-      folder,
-      cOpt.projectWideReuse,
-      verbose
+        bundle,
+        dxProject,
+        folder,
+        cOpt.projectWideReuse,
+        verbose
     )
 
     // Generate dx:applets and dx:workflow from the IR
     new Native(
-      dxWDLrtId,
-      folder,
-      dxProject,
-      dxObjDir,
-      instanceTypeDB,
-      runtimePathConfig,
-      fileInfoDir,
-      bundle.typeAliases,
-      cOpt.extras,
-      cOpt.runtimeDebugLevel,
-      cOpt.leaveWorkflowsOpen,
-      cOpt.force,
-      cOpt.archive,
-      cOpt.locked,
-      cOpt.verbose
+        dxWDLrtId,
+        folder,
+        dxProject,
+        dxObjDir,
+        instanceTypeDB,
+        runtimePathConfig,
+        fileInfoDir,
+        bundle.typeAliases,
+        cOpt.extras,
+        cOpt.runtimeDebugLevel,
+        cOpt.leaveWorkflowsOpen,
+        cOpt.force,
+        cOpt.archive,
+        cOpt.locked,
+        cOpt.verbose
     ).apply(bundle)
   }
 
@@ -147,7 +147,7 @@ case class Top(cOpt: CompilerOptions) {
     for (varName <- varNames)
       if (varName contains "___")
         throw new Exception(
-          s"Variable ${varName} is using the reserved substring ___"
+            s"Variable ${varName} is using the reserved substring ___"
         )
   }
 
@@ -157,8 +157,8 @@ case class Top(cOpt: CompilerOptions) {
       case wf: WorkflowDefinition =>
         if (wf.parameterMeta.size > 0)
           Utils.warning(
-            verbose,
-            "dxWDL workflows ignore their parameter meta section"
+              verbose,
+              "dxWDL workflows ignore their parameter meta section"
           )
         val g = wf.innerGraph
         checkDeclarations(g.inputNodes.map(_.localName).toSeq)
@@ -166,7 +166,7 @@ case class Top(cOpt: CompilerOptions) {
         val allDeclarations =
           g.allNodes.filter(_.isInstanceOf[ExposedExpressionNode])
         checkDeclarations(
-          allDeclarations.map(_.identifier.localName.value).toSeq
+            allDeclarations.map(_.identifier.localName.value).toSeq
         )
 
       case task: CallableTaskDefinition =>
@@ -199,7 +199,7 @@ case class Top(cOpt: CompilerOptions) {
             // unequal.
             case Some(existing) if (existing.toString != callable.toString) =>
               Utils.error(
-                s"""|${key} appears with two different callable definitions
+                  s"""|${key} appears with two different callable definitions
                                         |1)
                                         |${callable}
                                         |
@@ -208,7 +208,7 @@ case class Top(cOpt: CompilerOptions) {
                                         |""".stripMargin
               )
               throw new Exception(
-                s"${key} appears twice, with two different definitions"
+                  s"${key} appears twice, with two different definitions"
               )
             case _ => ()
           }
@@ -220,7 +220,7 @@ case class Top(cOpt: CompilerOptions) {
               allTypeAliases = allTypeAliases + (key -> definition)
             case Some(existing) if (existing != definition) =>
               Utils.error(
-                s"""|${key} appears twice, with two different definitions
+                  s"""|${key} appears twice, with two different definitions
                                         |1)
                                         |${definition}
                                         |
@@ -236,10 +236,10 @@ case class Top(cOpt: CompilerOptions) {
 
     // Merge all the bundles together
     WomBundle(
-      mainBundle.primaryCallable,
-      allCallables,
-      allTypeAliases,
-      Set.empty
+        mainBundle.primaryCallable,
+        allCallables,
+        allTypeAliases,
+        Set.empty
     )
   }
 
@@ -259,8 +259,8 @@ case class Top(cOpt: CompilerOptions) {
       case (accu: InputFileScanResults, inputFilePath) =>
         val res = InputFileScan(bundle, dxProject, verbose).apply(inputFilePath)
         InputFileScanResults(
-          accu.path2file ++ res.path2file,
-          accu.dxFiles ++ res.dxFiles
+            accu.path2file ++ res.path2file,
+            accu.dxFiles ++ res.dxFiles
         )
     }
 
@@ -305,11 +305,11 @@ case class Top(cOpt: CompilerOptions) {
     }
 
     new GenerateIR(cOpt.verbose, defaultRuntimeAttrs).apply(
-      everythingBundle,
-      allSources,
-      language,
-      cOpt.locked,
-      reorgApp
+        everythingBundle,
+        allSources,
+        language,
+        cOpt.locked,
+        reorgApp
     )
   }
 

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -48,13 +48,13 @@ case class Top(cOpt: CompilerOptions) {
   // Find the runtime dxWDL asset with the correct version. Look inside the
   // project configured for this region.
   private def getAssetId(region: String): String = {
-    val region2project       = Utils.getRegions()
+    val region2project = Utils.getRegions()
     val (projNameRt, folder) = getProjectWithRuntimeLibrary(region2project, region)
-    val dxProjRt             = DxPath.resolveProject(projNameRt)
+    val dxProjRt = DxPath.resolveProject(projNameRt)
     Utils.trace(verbose.on, s"Looking for asset-id in ${projNameRt}:/${folder}")
 
     val assetDxPath = s"${DX_URL_PREFIX}${dxProjRt.getId}:${folder}/${DX_WDL_ASSET}"
-    val dxObj       = DxPath.resolveOnePath(assetDxPath, dxProjRt)
+    val dxObj = DxPath.resolveOnePath(assetDxPath, dxProjRt)
     if (!dxObj.isInstanceOf[DxRecord])
       throw new Exception(s"Found dx object of wrong type ${dxObj} at ${assetDxPath}")
     dxObj.getId
@@ -67,9 +67,9 @@ case class Top(cOpt: CompilerOptions) {
       dxWDLrtId: String,
       dxProject: DxProject
   ): Unit = {
-    val region2project       = Utils.getRegions()
+    val region2project = Utils.getRegions()
     val (projNameRt, folder) = getProjectWithRuntimeLibrary(region2project, region)
-    val dxProjRt             = DxPath.resolveProject(projNameRt)
+    val dxProjRt = DxPath.resolveProject(projNameRt)
     DxUtils.cloneAsset(DxRecord.getInstance(dxWDLrtId), dxProject, DX_WDL_ASSET, dxProjRt, verbose)
   }
 
@@ -92,7 +92,7 @@ case class Top(cOpt: CompilerOptions) {
         // get billTo and region from the project, then find the runtime asset
         // in the current region.
         val (billTo, region) = DxUtils.projectDescribeExtraInfo(dxProject)
-        val lrtId            = getAssetId(region)
+        val lrtId = getAssetId(region)
         cloneRtLibraryToProject(region, lrtId, dxProject)
         Some(lrtId)
     }
@@ -158,7 +158,7 @@ case class Top(cOpt: CompilerOptions) {
       mainBundle: WomBundle,
       subBundles: Vector[WomBundle]
   ): WomBundle = {
-    var allCallables   = mainBundle.allCallables
+    var allCallables = mainBundle.allCallables
     var allTypeAliases = mainBundle.typeAliases
 
     subBundles.foreach { subBund =>
@@ -292,7 +292,7 @@ case class Top(cOpt: CompilerOptions) {
         .dxFromCromwell(bundle2, path)
       // write back out as xxxx.dx.json
       val filename = Utils.replaceFileSuffix(path, ".dx.json")
-      val parent   = path.getParent
+      val parent = path.getParent
       val dxInputFile =
         if (parent != null) parent.resolve(filename)
         else Paths.get(filename)

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -9,67 +9,69 @@ import dxWDL.base.WomTypeSerialization.typeName
 import dxWDL.util._
 
 // A bunch of WDL source lines
-case class WdlCodeSnippet(value : String)
+case class WdlCodeSnippet(value: String)
 
-case class WdlCodeGen(verbose: Verbose,
-                      typeAliases: Map[String, WomType],
-                      language : Language.Value) {
+case class WdlCodeGen(
+    verbose: Verbose,
+    typeAliases: Map[String, WomType],
+    language: Language.Value
+) {
 
-        // A self contained WDL workflow
-    def versionString() : String = {
-        language match {
-            case Language.WDLvDraft2 => ""
-            case Language.WDLv1_0 => "version 1.0"
-            case Language.WDLv2_0 => "version development"
-            case other =>
-                throw new Exception(s"Unsupported language version ${other}")
-        }
+  // A self contained WDL workflow
+  def versionString(): String = {
+    language match {
+      case Language.WDLvDraft2 => ""
+      case Language.WDLv1_0    => "version 1.0"
+      case Language.WDLv2_0    => "version development"
+      case other =>
+        throw new Exception(s"Unsupported language version ${other}")
     }
+  }
 
-    def genDefaultValueOfType(wdlType: WomType) : WomValue = {
-        wdlType match {
-            case WomBooleanType => WomBoolean(true)
-            case WomIntegerType => WomInteger(0)
-            case WomFloatType => WomFloat(0.0)
-            case WomStringType => WomString("")
-            case WomSingleFileType => WomSingleFile("dummy.txt")
+  def genDefaultValueOfType(wdlType: WomType): WomValue = {
+    wdlType match {
+      case WomBooleanType    => WomBoolean(true)
+      case WomIntegerType    => WomInteger(0)
+      case WomFloatType      => WomFloat(0.0)
+      case WomStringType     => WomString("")
+      case WomSingleFileType => WomSingleFile("dummy.txt")
 
-                // We could convert an optional to a null value, but that causes
-                // problems for the pretty printer.
-                // WomOptionalValue(wdlType, None)
-            case WomOptionalType(t) => genDefaultValueOfType(t)
+      // We could convert an optional to a null value, but that causes
+      // problems for the pretty printer.
+      // WomOptionalValue(wdlType, None)
+      case WomOptionalType(t) => genDefaultValueOfType(t)
 
-                // The WomMap type HAS to appear before the array types, because
-                // otherwise it is coerced into an array. The map has to
-                // contain at least one key-value pair, otherwise you get a type error.
-            case WomMapType(keyType, valueType) =>
-                val k = genDefaultValueOfType(keyType)
-                val v = genDefaultValueOfType(valueType)
-                WomMap(WomMapType(keyType, valueType), Map(k -> v))
+      // The WomMap type HAS to appear before the array types, because
+      // otherwise it is coerced into an array. The map has to
+      // contain at least one key-value pair, otherwise you get a type error.
+      case WomMapType(keyType, valueType) =>
+        val k = genDefaultValueOfType(keyType)
+        val v = genDefaultValueOfType(valueType)
+        WomMap(WomMapType(keyType, valueType), Map(k -> v))
 
-                // an empty array
-            case WomMaybeEmptyArrayType(t) =>
-                WomArray(WomMaybeEmptyArrayType(t), List())
+      // an empty array
+      case WomMaybeEmptyArrayType(t) =>
+        WomArray(WomMaybeEmptyArrayType(t), List())
 
-                // Non empty array
-            case WomNonEmptyArrayType(t) =>
-                WomArray(WomNonEmptyArrayType(t), List(genDefaultValueOfType(t)))
+      // Non empty array
+      case WomNonEmptyArrayType(t) =>
+        WomArray(WomNonEmptyArrayType(t), List(genDefaultValueOfType(t)))
 
-            case WomPairType(lType, rType) => WomPair(genDefaultValueOfType(lType),
-                                                      genDefaultValueOfType(rType))
+      case WomPairType(lType, rType) =>
+        WomPair(genDefaultValueOfType(lType), genDefaultValueOfType(rType))
 
-            case WomCompositeType(typeMap, structName) =>
-                val m = typeMap.map{
-                    case (fieldName, t) =>
-                        fieldName -> genDefaultValueOfType(t)
-                }.toMap
-                WomObject(m, WomObjectType)
+      case WomCompositeType(typeMap, structName) =>
+        val m = typeMap.map {
+          case (fieldName, t) =>
+            fieldName -> genDefaultValueOfType(t)
+        }.toMap
+        WomObject(m, WomObjectType)
 
-            case _ => throw new Exception(s"Unhandled type ${wdlType}")
-        }
+      case _ => throw new Exception(s"Unhandled type ${wdlType}")
     }
+  }
 
-    /*
+  /*
 Create a header for a task/workflow. This is an empty task
 that includes the input and output definitions. It is used
 to
@@ -102,40 +104,44 @@ task Add {
        Int result
    }
   }
-*/
-    private def genTaskHeader(callable: IR.Callable) : WdlCodeSnippet = {
-        /*Utils.trace(verbose.on,
+   */
+  private def genTaskHeader(callable: IR.Callable): WdlCodeSnippet = {
+    /*Utils.trace(verbose.on,
                     s"""|taskHeader  callable=${callable.name}
                         |  inputs= ${callable.inputVars.map(_.name)}
                         |  outputs= ${callable.outputVars.map(_.name)}"""
                         .stripMargin)*/
 
-        // Sort the inputs by name, so the result will be deterministic.
-        val inputs =
-            callable.inputVars
-                .sortWith(_.name < _.name)
-                .map{ case cVar =>
-                    cVar.default match {
-                        case None =>
-                            s"    ${typeName(cVar.womType)} ${cVar.name}"
-                        case Some(womValue) =>
-                            s"    ${typeName(cVar.womType)} ${cVar.name} = ${womValue.toWomString}"
-                    }
-            }.mkString("\n")
+    // Sort the inputs by name, so the result will be deterministic.
+    val inputs =
+      callable.inputVars
+        .sortWith(_.name < _.name)
+        .map {
+          case cVar =>
+            cVar.default match {
+              case None =>
+                s"    ${typeName(cVar.womType)} ${cVar.name}"
+              case Some(womValue) =>
+                s"    ${typeName(cVar.womType)} ${cVar.name} = ${womValue.toWomString}"
+            }
+        }
+        .mkString("\n")
 
-        val outputs =
-            callable.outputVars
-                .sortWith(_.name < _.name)
-                .map{ case cVar =>
-                    val defaultVal = genDefaultValueOfType(cVar.womType)
-                    s"    ${typeName(cVar.womType)} ${cVar.name} = ${defaultVal.toWomString}"
-            }.mkString("\n")
+    val outputs =
+      callable.outputVars
+        .sortWith(_.name < _.name)
+        .map {
+          case cVar =>
+            val defaultVal = genDefaultValueOfType(cVar.womType)
+            s"    ${typeName(cVar.womType)} ${cVar.name} = ${defaultVal.toWomString}"
+        }
+        .mkString("\n")
 
-        language match {
-            case Language.WDLvDraft2 =>
-                // Draft-2 does not support the input block.
-                WdlCodeSnippet(
-                    s"""|task ${callable.name} {
+    language match {
+      case Language.WDLvDraft2 =>
+        // Draft-2 does not support the input block.
+        WdlCodeSnippet(
+          s"""|task ${callable.name} {
                         |${inputs}
                         |
                         |  command {}
@@ -143,10 +149,10 @@ task Add {
                         |${outputs}
                         |  }
                         |}""".stripMargin
-                )
-            case Language.WDLv1_0 | Language.WDLv2_0 =>
-                WdlCodeSnippet(
-                    s"""|task ${callable.name} {
+        )
+      case Language.WDLv1_0 | Language.WDLv2_0 =>
+        WdlCodeSnippet(
+          s"""|task ${callable.name} {
                         |  input {
                         |${inputs}
                         |  }
@@ -155,34 +161,42 @@ task Add {
                         |${outputs}
                         |  }
                         |}""".stripMargin
-                )
-            case other =>
-                throw new Exception(s"Unsupported language version ${other}")
-        }
+        )
+      case other =>
+        throw new Exception(s"Unsupported language version ${other}")
     }
+  }
 
-    def genDnanexusAppletStub(id: String,
-                              appletName: String,
-                              inputSpec: Map[String, WomType],
-                              outputSpec: Map[String, WomType]) : WdlCodeSnippet = {
-        val inputs = inputSpec.map{ case (name, womType) =>
-            s"    ${typeName(womType)} ${name}"
-        }.mkString("\n")
-        val outputs = outputSpec.map{ case (name, womType) =>
-            val defaultVal = genDefaultValueOfType(womType)
-            s"    ${typeName(womType)} $name = ${defaultVal.toWomString}"
-        }.mkString("\n")
+  def genDnanexusAppletStub(
+      id: String,
+      appletName: String,
+      inputSpec: Map[String, WomType],
+      outputSpec: Map[String, WomType]
+  ): WdlCodeSnippet = {
+    val inputs = inputSpec
+      .map {
+        case (name, womType) =>
+          s"    ${typeName(womType)} ${name}"
+      }
+      .mkString("\n")
+    val outputs = outputSpec
+      .map {
+        case (name, womType) =>
+          val defaultVal = genDefaultValueOfType(womType)
+          s"    ${typeName(womType)} $name = ${defaultVal.toWomString}"
+      }
+      .mkString("\n")
 
-        val metaSection =
-            s"""|  meta {
+    val metaSection =
+      s"""|  meta {
                 |     type : "native"
                 |     id : "${id}"
                 |  }""".stripMargin
 
-        val taskSourceCode = language match {
-            case Language.WDLvDraft2 =>
-                // Draft-2 does not support the input block.
-                s"""|task ${appletName} {
+    val taskSourceCode = language match {
+      case Language.WDLvDraft2 =>
+        // Draft-2 does not support the input block.
+        s"""|task ${appletName} {
                     |${inputs}
                     |
                     |  command {}
@@ -191,8 +205,8 @@ task Add {
                     |  }
                     |${metaSection}
                     |}""".stripMargin
-            case Language.WDLv1_0 | Language.WDLv2_0  =>
-                s"""|task ${appletName} {
+      case Language.WDLv1_0 | Language.WDLv2_0 =>
+        s"""|task ${appletName} {
                     |  input {
                     |${inputs}
                     |  }
@@ -203,157 +217,165 @@ task Add {
                     |${metaSection}
                     |}""".stripMargin
 
-            case other =>
-                throw new Exception(s"Unsupported language version ${other}")
-        }
+      case other =>
+        throw new Exception(s"Unsupported language version ${other}")
+    }
 
-        // Make sure this is actually valid WDL
-        //
-        // We need to add the version to this task, to
-        // make it valid WDL
-        val taskStandalone = s"""|${versionString()}
+    // Make sure this is actually valid WDL
+    //
+    // We need to add the version to this task, to
+    // make it valid WDL
+    val taskStandalone = s"""|${versionString()}
                                  |
                                  |${taskSourceCode}
                                  |""".stripMargin
-        ParseWomSourceFile(false).validateWdlCode(taskStandalone, language)
+    ParseWomSourceFile(false).validateWdlCode(taskStandalone, language)
 
-        WdlCodeSnippet(taskSourceCode)
-    }
+    WdlCodeSnippet(taskSourceCode)
+  }
 
-    // A workflow can import other libraries:
-    //
-    // import "library.wdl" as lib
-    // workflow foo {
-    //   call lib.Multiply as mul { ... }
-    //   call lib.Add { ... }
-    //   call lib.Nice as nice { ... }
-    //   call lib.Hello
-    // }
-    //
-    // rewrite the workflow, and remove the calls to external libraries.
-    //
-    // workflow foo {
-    //   call Multiply as mul { ... }
-    //   call Add { ... }
-    //   call Nice as nice { ... }
-    //   call Nice as nice { ... }
-    //   call Hello
-    // }
-    //
-    private val callLibrary:       Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
-    private val callLibraryNoArgs: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s*)".r
-    private def flattenWorkflow(wdlWfSource: String) : String = {
-        val originalLines = wdlWfSource.split("\n").toList
-        val cleanLines = originalLines.map { line =>
-            val allMatches = callLibrary.findAllMatchIn(line).toList
-            assert(allMatches.size <= 1)
-            val newLine =
-                if (allMatches.isEmpty) {
-                    line
-                } else {
-                    val m = allMatches(0)
-                    val callee : String = m.group(4)
-                    val rest = m.group(6)
-                    s"call ${callee} ${rest}"
-                }
-
-            // call with no arguments
-            val allMatches2 = callLibraryNoArgs.findAllMatchIn(newLine).toList
-            assert(allMatches2.size <= 1)
-            if (allMatches2.isEmpty) {
-                newLine
-            } else {
-                val m = allMatches2(0)
-                val callee : String = m.group(4)
-                s"call ${callee}"
-            }
+  // A workflow can import other libraries:
+  //
+  // import "library.wdl" as lib
+  // workflow foo {
+  //   call lib.Multiply as mul { ... }
+  //   call lib.Add { ... }
+  //   call lib.Nice as nice { ... }
+  //   call lib.Hello
+  // }
+  //
+  // rewrite the workflow, and remove the calls to external libraries.
+  //
+  // workflow foo {
+  //   call Multiply as mul { ... }
+  //   call Add { ... }
+  //   call Nice as nice { ... }
+  //   call Nice as nice { ... }
+  //   call Hello
+  // }
+  //
+  private val callLibrary: Regex       = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
+  private val callLibraryNoArgs: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s*)".r
+  private def flattenWorkflow(wdlWfSource: String): String = {
+    val originalLines = wdlWfSource.split("\n").toList
+    val cleanLines = originalLines.map { line =>
+      val allMatches = callLibrary.findAllMatchIn(line).toList
+      assert(allMatches.size <= 1)
+      val newLine =
+        if (allMatches.isEmpty) {
+          line
+        } else {
+          val m              = allMatches(0)
+          val callee: String = m.group(4)
+          val rest           = m.group(6)
+          s"call ${callee} ${rest}"
         }
-        cleanLines.mkString("\n")
+
+      // call with no arguments
+      val allMatches2 = callLibraryNoArgs.findAllMatchIn(newLine).toList
+      assert(allMatches2.size <= 1)
+      if (allMatches2.isEmpty) {
+        newLine
+      } else {
+        val m              = allMatches2(0)
+        val callee: String = m.group(4)
+        s"call ${callee}"
+      }
     }
+    cleanLines.mkString("\n")
+  }
 
-    // Write valid WDL code that defines the type aliases we have.
-    private def typeAliasDefinitions : String = {
-        val sortedTypeAliases = SortTypeAliases(verbose).apply(typeAliases.toVector)
-        val snippetVec = sortedTypeAliases.map{
-            case (name, WomCompositeType(typeMap, _)) =>
-                val fieldLines = typeMap.map{ case (fieldName, womType) =>
-                    s"    ${typeName(womType)} ${fieldName}"
-                }.mkString("\n")
+  // Write valid WDL code that defines the type aliases we have.
+  private def typeAliasDefinitions: String = {
+    val sortedTypeAliases = SortTypeAliases(verbose).apply(typeAliases.toVector)
+    val snippetVec = sortedTypeAliases.map {
+      case (name, WomCompositeType(typeMap, _)) =>
+        val fieldLines = typeMap
+          .map {
+            case (fieldName, womType) =>
+              s"    ${typeName(womType)} ${fieldName}"
+          }
+          .mkString("\n")
 
-                s"""|struct ${name} {
+        s"""|struct ${name} {
                     |${fieldLines}
                     |}""".stripMargin
 
-            case (name, other) =>
-                throw new Exception(s"Unknown type alias ${name} ${other}")
-        }
-        snippetVec.mkString("\n")
+      case (name, other) =>
+        throw new Exception(s"Unknown type alias ${name} ${other}")
     }
+    snippetVec.mkString("\n")
+  }
 
+  def standAloneTask(originalTaskSource: String): WdlCodeSnippet = {
+    val wdlWfSource =
+      List(
+        versionString() + "\n",
+        "# struct definitions",
+        typeAliasDefinitions,
+        "# Task",
+        originalTaskSource
+      ).mkString("\n")
 
-    def standAloneTask(originalTaskSource: String) : WdlCodeSnippet = {
-        val wdlWfSource =
-            List(versionString() + "\n",
-                 "# struct definitions",
-                 typeAliasDefinitions,
-                 "# Task",
-                 originalTaskSource).mkString("\n")
+    // Make sure this is actually valid WDL
+    ParseWomSourceFile(false).validateWdlCode(wdlWfSource, language)
 
-        // Make sure this is actually valid WDL
-        ParseWomSourceFile(false).validateWdlCode(wdlWfSource, language)
+    WdlCodeSnippet(wdlWfSource)
+  }
 
-        WdlCodeSnippet(wdlWfSource)
-    }
+  // A workflow must have definitions for all the tasks it
+  // calls. However, a scatter calls tasks, that are missing from
+  // the WDL file we generate. To ameliorate this, we add stubs for
+  // called tasks. The generated tasks are named by their
+  // unqualified names, not their fully-qualified names. This works
+  // because the WDL workflow must be "flattenable".
+  def standAloneWorkflow(
+      originalWorkflowSource: String,
+      allCalls: Vector[IR.Callable]
+  ): WdlCodeSnippet = {
+    val taskStubs: Map[String, WdlCodeSnippet] =
+      allCalls.foldLeft(Map.empty[String, WdlCodeSnippet]) {
+        case (accu, callable) =>
+          if (accu contains callable.name) {
+            // we have already created a stub for this call
+            accu
+          } else {
+            val sourceCode = callable match {
+              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode) =>
+                // This is a task, include its source code, instead of a header.
+                val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
+                assert(taskDir.size == 1)
+                val taskBody = taskDir.values.head
+                WdlCodeSnippet(taskBody)
 
-    // A workflow must have definitions for all the tasks it
-    // calls. However, a scatter calls tasks, that are missing from
-    // the WDL file we generate. To ameliorate this, we add stubs for
-    // called tasks. The generated tasks are named by their
-    // unqualified names, not their fully-qualified names. This works
-    // because the WDL workflow must be "flattenable".
-    def standAloneWorkflow( originalWorkflowSource: String,
-                            allCalls : Vector[IR.Callable]) : WdlCodeSnippet = {
-        val taskStubs: Map[String, WdlCodeSnippet] =
-            allCalls.foldLeft(Map.empty[String, WdlCodeSnippet]) { case (accu, callable) =>
-                if (accu contains callable.name) {
-                    // we have already created a stub for this call
-                    accu
-                } else {
-                    val sourceCode = callable match {
-                        case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode) =>
-                            // This is a task, include its source code, instead of a header.
-                            val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
-                            assert(taskDir.size == 1)
-                            val taskBody = taskDir.values.head
-                            WdlCodeSnippet(taskBody)
-
-                        case _ =>
-                            // no existing stub, create it
-                            genTaskHeader(callable)
-                    }
-                    accu + (callable.name -> sourceCode)
-                }
+              case _ =>
+                // no existing stub, create it
+                genTaskHeader(callable)
             }
+            accu + (callable.name -> sourceCode)
+          }
+      }
 
-        // sort the task order by name, so the generated code will be deterministic
-        val tasksStr = taskStubs
-            .toVector
-            .sortWith(_._1 < _._1)
-            .map{case (name, wdlCode) => wdlCode.value}
-            .mkString("\n\n")
-        val wfWithoutImportCalls = flattenWorkflow(originalWorkflowSource)
-        val wdlWfSource =
-            List(versionString() + "\n",
-                 "# struct definitions",
-                 typeAliasDefinitions,
-                 "# Task headers",
-                 tasksStr,
-                 "# Workflow with imports made local",
-                 wfWithoutImportCalls).mkString("\n")
+    // sort the task order by name, so the generated code will be deterministic
+    val tasksStr = taskStubs.toVector
+      .sortWith(_._1 < _._1)
+      .map { case (name, wdlCode) => wdlCode.value }
+      .mkString("\n\n")
+    val wfWithoutImportCalls = flattenWorkflow(originalWorkflowSource)
+    val wdlWfSource =
+      List(
+        versionString() + "\n",
+        "# struct definitions",
+        typeAliasDefinitions,
+        "# Task headers",
+        tasksStr,
+        "# Workflow with imports made local",
+        wfWithoutImportCalls
+      ).mkString("\n")
 
-        // Make sure this is actually valid WDL
-        ParseWomSourceFile(false).validateWdlCode(wdlWfSource, language)
+    // Make sure this is actually valid WDL
+    ParseWomSourceFile(false).validateWdlCode(wdlWfSource, language)
 
-        WdlCodeSnippet(wdlWfSource)
-    }
+    WdlCodeSnippet(wdlWfSource)
+  }
 }

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -254,7 +254,7 @@ task Add {
   //   call Hello
   // }
   //
-  private val callLibrary: Regex       = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
+  private val callLibrary: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
   private val callLibraryNoArgs: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s*)".r
   private def flattenWorkflow(wdlWfSource: String): String = {
     val originalLines = wdlWfSource.split("\n").toList
@@ -265,9 +265,9 @@ task Add {
         if (allMatches.isEmpty) {
           line
         } else {
-          val m              = allMatches(0)
+          val m = allMatches(0)
           val callee: String = m.group(4)
-          val rest           = m.group(6)
+          val rest = m.group(6)
           s"call ${callee} ${rest}"
         }
 
@@ -277,7 +277,7 @@ task Add {
       if (allMatches2.isEmpty) {
         newLine
       } else {
-        val m              = allMatches2(0)
+        val m = allMatches2(0)
         val callee: String = m.group(4)
         s"call ${callee}"
       }

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -254,8 +254,10 @@ task Add {
   //   call Hello
   // }
   //
-  private val callLibrary: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
-  private val callLibraryNoArgs: Regex = "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s*)".r
+  private val callLibrary: Regex =
+    "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s+)(.+)".r
+  private val callLibraryNoArgs: Regex =
+    "^(\\s*)call(\\s+)(\\w+)\\.(\\w+)(\\s*)".r
   private def flattenWorkflow(wdlWfSource: String): String = {
     val originalLines = wdlWfSource.split("\n").toList
     val cleanLines = originalLines.map { line =>
@@ -341,9 +343,18 @@ task Add {
             accu
           } else {
             val sourceCode = callable match {
-              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode) =>
+              case IR.Applet(
+                  _,
+                  _,
+                  _,
+                  _,
+                  _,
+                  IR.AppletKindTask(_),
+                  taskSourceCode
+                  ) =>
                 // This is a task, include its source code, instead of a header.
-                val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
+                val taskDir =
+                  ParseWomSourceFile(false).scanForTasks(taskSourceCode)
                 assert(taskDir.size == 1)
                 val taskBody = taskDir.values.head
                 WdlCodeSnippet(taskBody)

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -141,7 +141,7 @@ task Add {
       case Language.WDLvDraft2 =>
         // Draft-2 does not support the input block.
         WdlCodeSnippet(
-          s"""|task ${callable.name} {
+            s"""|task ${callable.name} {
                         |${inputs}
                         |
                         |  command {}
@@ -152,7 +152,7 @@ task Add {
         )
       case Language.WDLv1_0 | Language.WDLv2_0 =>
         WdlCodeSnippet(
-          s"""|task ${callable.name} {
+            s"""|task ${callable.name} {
                         |  input {
                         |${inputs}
                         |  }
@@ -312,11 +312,11 @@ task Add {
   def standAloneTask(originalTaskSource: String): WdlCodeSnippet = {
     val wdlWfSource =
       List(
-        versionString() + "\n",
-        "# struct definitions",
-        typeAliasDefinitions,
-        "# Task",
-        originalTaskSource
+          versionString() + "\n",
+          "# struct definitions",
+          typeAliasDefinitions,
+          "# Task",
+          originalTaskSource
       ).mkString("\n")
 
     // Make sure this is actually valid WDL
@@ -375,13 +375,13 @@ task Add {
     val wfWithoutImportCalls = flattenWorkflow(originalWorkflowSource)
     val wdlWfSource =
       List(
-        versionString() + "\n",
-        "# struct definitions",
-        typeAliasDefinitions,
-        "# Task headers",
-        tasksStr,
-        "# Workflow with imports made local",
-        wfWithoutImportCalls
+          versionString() + "\n",
+          "# struct definitions",
+          typeAliasDefinitions,
+          "# Task headers",
+          tasksStr,
+          "# Workflow with imports made local",
+          wfWithoutImportCalls
       ).mkString("\n")
 
     // Make sure this is actually valid WDL

--- a/src/main/scala/dxWDL/dx/DxAnalysis.scala
+++ b/src/main/scala/dxWDL/dx/DxAnalysis.scala
@@ -22,33 +22,33 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields =
       Set(
-        Field.Project,
-        Field.Id,
-        Field.Name,
-        Field.Folder,
-        Field.Created,
-        Field.Modified
+          Field.Project,
+          Field.Id,
+          Field.Name,
+          Field.Folder,
+          Field.Created,
+          Field.Modified
       )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec +
-        ("fields" -> DxObject.requestFields(allFields))
+        projSpec +
+          ("fields" -> DxObject.requestFields(allFields))
     )
     val response = DXAPI.analysisDescribe(
-      id,
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
       descJs.asJsObject.getFields(
-        "project",
-        "id",
-        "name",
-        "folder",
-        "created",
-        "modified"
+          "project",
+          "id",
+          "name",
+          "folder",
+          "created",
+          "modified"
       ) match {
         case Seq(
             JsString(project),
@@ -59,14 +59,14 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
             JsNumber(modified)
             ) =>
           DxAnalysisDescribe(
-            project,
-            id,
-            name,
-            folder,
-            created.toLong,
-            modified.toLong,
-            None,
-            None
+              project,
+              id,
+              name,
+              folder,
+              created.toLong,
+              modified.toLong,
+              None,
+              None
           )
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
@@ -81,16 +81,16 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
 
   def setProperties(props: Map[String, String]): Unit = {
     val request = JsObject(
-      "properties" -> JsObject(props.map {
-        case (k, v) =>
-          k -> JsString(v)
-      })
+        "properties" -> JsObject(props.map {
+          case (k, v) =>
+            k -> JsString(v)
+        })
     )
     val response = DXAPI.analysisSetProperties(
-      id,
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     Utils.ignore(repJs)

--- a/src/main/scala/dxWDL/dx/DxAnalysis.scala
+++ b/src/main/scala/dxWDL/dx/DxAnalysis.scala
@@ -21,7 +21,14 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
   def describe(fields: Set[Field.Value] = Set.empty): DxAnalysisDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields =
-      Set(Field.Project, Field.Id, Field.Name, Field.Folder, Field.Created, Field.Modified)
+      Set(
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Folder,
+        Field.Created,
+        Field.Modified
+      )
     val allFields = fields ++ defaultFields
     val request = JsObject(
       projSpec +
@@ -35,7 +42,14 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
     )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
-      descJs.asJsObject.getFields("project", "id", "name", "folder", "created", "modified") match {
+      descJs.asJsObject.getFields(
+        "project",
+        "id",
+        "name",
+        "folder",
+        "created",
+        "modified"
+      ) match {
         case Seq(
             JsString(project),
             JsString(id),
@@ -44,13 +58,24 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
             JsNumber(created),
             JsNumber(modified)
             ) =>
-          DxAnalysisDescribe(project, id, name, folder, created.toLong, modified.toLong, None, None)
+          DxAnalysisDescribe(
+            project,
+            id,
+            name,
+            folder,
+            created.toLong,
+            modified.toLong,
+            None,
+            None
+          )
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 

--- a/src/main/scala/dxWDL/dx/DxAnalysis.scala
+++ b/src/main/scala/dxWDL/dx/DxAnalysis.scala
@@ -6,84 +6,86 @@ import spray.json._
 
 import dxWDL.base.Utils
 
-case class DxAnalysisDescribe(project : String,
-                              id  : String,
-                              name : String,
-                              folder : String,
-                              created : Long,
-                              modified : Long,
-                              properties: Option[Map[String, String]],
-                              details : Option[JsValue]) extends DxObjectDescribe
+case class DxAnalysisDescribe(
+    project: String,
+    id: String,
+    name: String,
+    folder: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue]
+) extends DxObjectDescribe
 
-case class DxAnalysis(id : String,
-                      project : Option[DxProject]) extends DxObject with DxExecution {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxAnalysisDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Folder,
-                                Field.Created,
-                                Field.Modified)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec +
-                                   ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.analysisDescribe(id,
-                                              DxUtils.jsonNodeOfJsValue(request),
-                                              classOf[JsonNode],
-                                              DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id", "name", "folder",
-                                               "created", "modified") match {
-            case Seq(JsString(project), JsString(id),
-                     JsString(name), JsString(folder),
-                     JsNumber(created), JsNumber(modified)) =>
-                DxAnalysisDescribe(project,
-                                   id,
-                                   name,
-                                   folder,
-                                   created.toLong,
-                                   modified.toLong,
-                                   None,
-                                   None)
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
+case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject with DxExecution {
+  def describe(fields: Set[Field.Value] = Set.empty): DxAnalysisDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields =
+      Set(Field.Project, Field.Id, Field.Name, Field.Folder, Field.Created, Field.Modified)
+    val allFields = fields ++ defaultFields
+    val request = JsObject(
+      projSpec +
+        ("fields" -> DxObject.requestFields(allFields))
+    )
+    val response = DXAPI.analysisDescribe(
+      id,
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc =
+      descJs.asJsObject.getFields("project", "id", "name", "folder", "created", "modified") match {
+        case Seq(
+            JsString(project),
+            JsString(id),
+            JsString(name),
+            JsString(folder),
+            JsNumber(created),
+            JsNumber(modified)
+            ) =>
+          DxAnalysisDescribe(project, id, name, folder, created.toLong, modified.toLong, None, None)
+        case _ =>
+          throw new Exception(s"Malformed JSON ${descJs}")
+      }
 
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        desc.copy(details = details, properties = props)
-    }
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    desc.copy(details = details, properties = props)
+  }
 
-    def setProperties(props: Map[String, String]) : Unit = {
-        val request = JsObject(
-            "properties" -> JsObject(props.map{ case (k,v) =>
-                                         k -> JsString(v)
-                                     })
-        )
-        val response = DXAPI.analysisSetProperties(id,
-                                                   DxUtils.jsonNodeOfJsValue(request),
-                                                   classOf[JsonNode],
-                                                   DxUtils.dxEnv)
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        Utils.ignore(repJs)
-    }
+  def setProperties(props: Map[String, String]): Unit = {
+    val request = JsObject(
+      "properties" -> JsObject(props.map {
+        case (k, v) =>
+          k -> JsString(v)
+      })
+    )
+    val response = DXAPI.analysisSetProperties(
+      id,
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    Utils.ignore(repJs)
+  }
 }
 
 object DxAnalysis {
-    def getInstance(id : String) : DxAnalysis = {
-        DxObject.getInstance(id, None) match {
-             case j : DxAnalysis => j
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a analysis")
-        }
+  def getInstance(id: String): DxAnalysis = {
+    DxObject.getInstance(id, None) match {
+      case j: DxAnalysis => j
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a analysis")
     }
+  }
 
-    def getInstance(id : String, project : DxProject) : DxAnalysis = {
-        DxObject.getInstance(id, Some(project)) match {
-             case j : DxAnalysis => j
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a analysis")
-        }
+  def getInstance(id: String, project: DxProject): DxAnalysis = {
+    DxObject.getInstance(id, Some(project)) match {
+      case j: DxAnalysis => j
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a analysis")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxAnalysis.scala
+++ b/src/main/scala/dxWDL/dx/DxAnalysis.scala
@@ -50,7 +50,7 @@ case class DxAnalysis(id: String, project: Option[DxProject]) extends DxObject w
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 

--- a/src/main/scala/dxWDL/dx/DxApp.scala
+++ b/src/main/scala/dxWDL/dx/DxApp.scala
@@ -19,30 +19,30 @@ case class DxApp(id: String) extends DxExecutable {
   def describe(fields: Set[Field.Value] = Set.empty): DxAppDescribe = {
     val defaultFields =
       Set(
-        Field.Id,
-        Field.Name,
-        Field.Created,
-        Field.Modified,
-        Field.InputSpec,
-        Field.OutputSpec
+          Field.Id,
+          Field.Name,
+          Field.Created,
+          Field.Modified,
+          Field.InputSpec,
+          Field.OutputSpec
       )
     val allFields = fields ++ defaultFields
     val request = JsObject("fields" -> DxObject.requestFields(allFields))
     val response =
       DXAPI.appDescribe(
-        id,
-        DxUtils.jsonNodeOfJsValue(request),
-        classOf[JsonNode],
-        DxUtils.dxEnv
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
       )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc = descJs.asJsObject.getFields(
-      "id",
-      "name",
-      "created",
-      "modified",
-      "inputSpec",
-      "outputSpec"
+        "id",
+        "name",
+        "created",
+        "modified",
+        "inputSpec",
+        "outputSpec"
     ) match {
       case Seq(
           JsString(id),
@@ -53,14 +53,14 @@ case class DxApp(id: String) extends DxExecutable {
           JsArray(outputSpec)
           ) =>
         DxAppDescribe(
-          id,
-          name,
-          created.toLong,
-          modified.toLong,
-          None,
-          None,
-          Some(DxObject.parseIOSpec(inputSpec.toVector)),
-          Some(DxObject.parseIOSpec(outputSpec.toVector))
+            id,
+            name,
+            created.toLong,
+            modified.toLong,
+            None,
+            None,
+            Some(DxObject.parseIOSpec(inputSpec.toVector)),
+            Some(DxObject.parseIOSpec(outputSpec.toVector))
         )
       case _ =>
         throw new Exception(s"Malformed JSON ${descJs}")

--- a/src/main/scala/dxWDL/dx/DxApp.scala
+++ b/src/main/scala/dxWDL/dx/DxApp.scala
@@ -18,11 +18,23 @@ case class DxAppDescribe(
 case class DxApp(id: String) extends DxExecutable {
   def describe(fields: Set[Field.Value] = Set.empty): DxAppDescribe = {
     val defaultFields =
-      Set(Field.Id, Field.Name, Field.Created, Field.Modified, Field.InputSpec, Field.OutputSpec)
+      Set(
+        Field.Id,
+        Field.Name,
+        Field.Created,
+        Field.Modified,
+        Field.InputSpec,
+        Field.OutputSpec
+      )
     val allFields = fields ++ defaultFields
     val request = JsObject("fields" -> DxObject.requestFields(allFields))
     val response =
-      DXAPI.appDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+      DXAPI.appDescribe(
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
+      )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc = descJs.asJsObject.getFields(
       "id",
@@ -55,7 +67,9 @@ case class DxApp(id: String) extends DxExecutable {
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxApp.scala
+++ b/src/main/scala/dxWDL/dx/DxApp.scala
@@ -20,7 +20,7 @@ case class DxApp(id: String) extends DxExecutable {
     val defaultFields =
       Set(Field.Id, Field.Name, Field.Created, Field.Modified, Field.InputSpec, Field.OutputSpec)
     val allFields = fields ++ defaultFields
-    val request   = JsObject("fields" -> DxObject.requestFields(allFields))
+    val request = JsObject("fields" -> DxObject.requestFields(allFields))
     val response =
       DXAPI.appDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
@@ -55,7 +55,7 @@ case class DxApp(id: String) extends DxExecutable {
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxApp.scala
+++ b/src/main/scala/dxWDL/dx/DxApp.scala
@@ -4,60 +4,68 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxAppDescribe(id  : String,
-                         name : String,
-                         created : Long,
-                         modified : Long,
-                         properties: Option[Map[String, String]],
-                         details : Option[JsValue],
-                         inputSpec : Option[Vector[IOParameter]],
-                         outputSpec : Option[Vector[IOParameter]]) extends DxObjectDescribe
+case class DxAppDescribe(
+    id: String,
+    name: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue],
+    inputSpec: Option[Vector[IOParameter]],
+    outputSpec: Option[Vector[IOParameter]]
+) extends DxObjectDescribe
 
-case class DxApp(id : String) extends DxExecutable {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxAppDescribe = {
-        val defaultFields = Set(Field.Id,
-                                Field.Name,
-                                Field.Created,
-                                Field.Modified,
-                                Field.InputSpec,
-                                Field.OutputSpec)
-        val allFields = fields ++ defaultFields
-        val request = JsObject("fields" -> DxObject.requestFields(allFields))
-        val response = DXAPI.appDescribe(id,
-                                         DxUtils.jsonNodeOfJsValue(request),
-                                         classOf[JsonNode],
-                                         DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("id", "name",
-                                               "created", "modified",
-                                               "inputSpec", "outputSpec") match {
-            case Seq(JsString(id), JsString(name),
-                     JsNumber(created), JsNumber(modified),
-                     JsArray(inputSpec), JsArray(outputSpec)) =>
-                DxAppDescribe(id,
-                              name,
-                              created.toLong,
-                              modified.toLong,
-                              None,
-                              None,
-                              Some(DxObject.parseIOSpec(inputSpec.toVector)),
-                              Some(DxObject.parseIOSpec(outputSpec.toVector)))
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
-
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        desc.copy(details = details, properties = props)
+case class DxApp(id: String) extends DxExecutable {
+  def describe(fields: Set[Field.Value] = Set.empty): DxAppDescribe = {
+    val defaultFields =
+      Set(Field.Id, Field.Name, Field.Created, Field.Modified, Field.InputSpec, Field.OutputSpec)
+    val allFields = fields ++ defaultFields
+    val request   = JsObject("fields" -> DxObject.requestFields(allFields))
+    val response =
+      DXAPI.appDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc = descJs.asJsObject.getFields(
+      "id",
+      "name",
+      "created",
+      "modified",
+      "inputSpec",
+      "outputSpec"
+    ) match {
+      case Seq(
+          JsString(id),
+          JsString(name),
+          JsNumber(created),
+          JsNumber(modified),
+          JsArray(inputSpec),
+          JsArray(outputSpec)
+          ) =>
+        DxAppDescribe(
+          id,
+          name,
+          created.toLong,
+          modified.toLong,
+          None,
+          None,
+          Some(DxObject.parseIOSpec(inputSpec.toVector)),
+          Some(DxObject.parseIOSpec(outputSpec.toVector))
+        )
+      case _ =>
+        throw new Exception(s"Malformed JSON ${descJs}")
     }
+
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    desc.copy(details = details, properties = props)
+  }
 }
 
 object DxApp {
-    def getInstance(id : String) : DxApp = {
-        DxObject.getInstance(id) match {
-             case a : DxApp => a
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't an app")
-        }
+  def getInstance(id: String): DxApp = {
+    DxObject.getInstance(id) match {
+      case a: DxApp => a
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't an app")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -31,7 +31,7 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
       Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
-    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
     val response =
       DXAPI.appletDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
@@ -72,7 +72,7 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -4,78 +4,93 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxAppletDescribe(project : String,
-                            id : String,
-                            name : String,
-                            folder: String,
-                            created : Long,
-                            modified : Long,
-                            properties : Option[Map[String, String]],
-                            details : Option[JsValue],
-                            inputSpec : Option[Vector[IOParameter]],
-                            outputSpec : Option[Vector[IOParameter]]) extends DxObjectDescribe
+case class DxAppletDescribe(
+    project: String,
+    id: String,
+    name: String,
+    folder: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue],
+    inputSpec: Option[Vector[IOParameter]],
+    outputSpec: Option[Vector[IOParameter]]
+) extends DxObjectDescribe
 
-case class DxApplet(id : String,
-                    project : Option[DxProject]) extends DxExecutable {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxAppletDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Folder,
-                                Field.Created,
-                                Field.Modified,
-                                Field.InputSpec,
-                                Field.OutputSpec)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.appletDescribe(id,
-                                            DxUtils.jsonNodeOfJsValue(request),
-                                            classOf[JsonNode],
-                                            DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id",
-                                               "name", "folder",
-                                               "created", "modified",
-                                               "inputSpec", "outputSpec") match {
-            case Seq(JsString(project), JsString(id),
-                     JsString(name), JsString(folder),
-                     JsNumber(created), JsNumber(modified),
-                     JsArray(inputSpec), JsArray(outputSpec)) =>
-                DxAppletDescribe(project,
-                                 id,
-                                 name,
-                                 folder,
-                                 created.toLong,
-                                 modified.toLong,
-                                 None,
-                                 None,
-                                 Some(DxObject.parseIOSpec(inputSpec.toVector)),
-                                 Some(DxObject.parseIOSpec(outputSpec.toVector)))
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
-
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        desc.copy(details = details, properties = props)
+case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable {
+  def describe(fields: Set[Field.Value] = Set.empty): DxAppletDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields = Set(
+      Field.Project,
+      Field.Id,
+      Field.Name,
+      Field.Folder,
+      Field.Created,
+      Field.Modified,
+      Field.InputSpec,
+      Field.OutputSpec
+    )
+    val allFields = fields ++ defaultFields
+    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val response =
+      DXAPI.appletDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc = descJs.asJsObject.getFields(
+      "project",
+      "id",
+      "name",
+      "folder",
+      "created",
+      "modified",
+      "inputSpec",
+      "outputSpec"
+    ) match {
+      case Seq(
+          JsString(project),
+          JsString(id),
+          JsString(name),
+          JsString(folder),
+          JsNumber(created),
+          JsNumber(modified),
+          JsArray(inputSpec),
+          JsArray(outputSpec)
+          ) =>
+        DxAppletDescribe(
+          project,
+          id,
+          name,
+          folder,
+          created.toLong,
+          modified.toLong,
+          None,
+          None,
+          Some(DxObject.parseIOSpec(inputSpec.toVector)),
+          Some(DxObject.parseIOSpec(outputSpec.toVector))
+        )
+      case _ =>
+        throw new Exception(s"Malformed JSON ${descJs}")
     }
+
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    desc.copy(details = details, properties = props)
+  }
 }
 
 object DxApplet {
-    def getInstance(id : String) : DxApplet = {
-        DxObject.getInstance(id) match {
-             case a : DxApplet => a
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't an applet")
-        }
+  def getInstance(id: String): DxApplet = {
+    DxObject.getInstance(id) match {
+      case a: DxApplet => a
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't an applet")
     }
+  }
 
-    def getInstance(id : String, project : DxProject) : DxApplet = {
-        DxObject.getInstance(id, Some(project)) match {
-            case a : DxApplet => a
-            case _ =>
-                throw new IllegalArgumentException(s"${id} isn't an applet")
-        }
+  def getInstance(id: String, project: DxProject): DxApplet = {
+    DxObject.getInstance(id, Some(project)) match {
+      case a: DxApplet => a
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't an applet")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -21,36 +21,36 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
   def describe(fields: Set[Field.Value] = Set.empty): DxAppletDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields = Set(
-      Field.Project,
-      Field.Id,
-      Field.Name,
-      Field.Folder,
-      Field.Created,
-      Field.Modified,
-      Field.InputSpec,
-      Field.OutputSpec
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Folder,
+        Field.Created,
+        Field.Modified,
+        Field.InputSpec,
+        Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec + ("fields" -> DxObject.requestFields(allFields))
+        projSpec + ("fields" -> DxObject.requestFields(allFields))
     )
     val response =
       DXAPI.appletDescribe(
-        id,
-        DxUtils.jsonNodeOfJsValue(request),
-        classOf[JsonNode],
-        DxUtils.dxEnv
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
       )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc = descJs.asJsObject.getFields(
-      "project",
-      "id",
-      "name",
-      "folder",
-      "created",
-      "modified",
-      "inputSpec",
-      "outputSpec"
+        "project",
+        "id",
+        "name",
+        "folder",
+        "created",
+        "modified",
+        "inputSpec",
+        "outputSpec"
     ) match {
       case Seq(
           JsString(project),
@@ -63,16 +63,16 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
           JsArray(outputSpec)
           ) =>
         DxAppletDescribe(
-          project,
-          id,
-          name,
-          folder,
-          created.toLong,
-          modified.toLong,
-          None,
-          None,
-          Some(DxObject.parseIOSpec(inputSpec.toVector)),
-          Some(DxObject.parseIOSpec(outputSpec.toVector))
+            project,
+            id,
+            name,
+            folder,
+            created.toLong,
+            modified.toLong,
+            None,
+            None,
+            Some(DxObject.parseIOSpec(inputSpec.toVector)),
+            Some(DxObject.parseIOSpec(outputSpec.toVector))
         )
       case _ =>
         throw new Exception(s"Malformed JSON ${descJs}")

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -31,9 +31,16 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
       Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
-    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(
+      projSpec + ("fields" -> DxObject.requestFields(allFields))
+    )
     val response =
-      DXAPI.appletDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+      DXAPI.appletDescribe(
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
+      )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc = descJs.asJsObject.getFields(
       "project",
@@ -72,7 +79,9 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxFile.scala
+++ b/src/main/scala/dxWDL/dx/DxFile.scala
@@ -28,34 +28,34 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
   def describe(fields: Set[Field.Value] = Set.empty): DxFileDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields = Set(
-      Field.Project,
-      Field.Id,
-      Field.Name,
-      Field.Folder,
-      Field.Created,
-      Field.Modified,
-      Field.Size
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Folder,
+        Field.Created,
+        Field.Modified,
+        Field.Size
     )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec + ("fields" -> DxObject.requestFields(allFields))
+        projSpec + ("fields" -> DxObject.requestFields(allFields))
     )
     val response =
       DXAPI.fileDescribe(
-        id,
-        DxUtils.jsonNodeOfJsValue(request),
-        classOf[JsonNode],
-        DxUtils.dxEnv
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
       )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
       descJs.asJsObject.getFields(
-        "project",
-        "id",
-        "name",
-        "folder",
-        "created",
-        "modified"
+          "project",
+          "id",
+          "name",
+          "folder",
+          "created",
+          "modified"
       ) match {
         case Seq(
             JsString(project),
@@ -66,16 +66,16 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
             JsNumber(modified)
             ) =>
           DxFileDescribe(
-            project,
-            id,
-            name,
-            folder,
-            created.toLong,
-            modified.toLong,
-            0,
-            None,
-            None,
-            None
+              project,
+              id,
+              name,
+              folder,
+              created.toLong,
+              modified.toLong,
+              0,
+              None,
+              None,
+              None
           )
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
@@ -100,10 +100,10 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
         JsObject("$dnanexus_link" -> JsString(id))
       case Some(p) =>
         JsObject(
-          "$dnanexus_link" -> JsObject(
-            "project" -> JsString(p.id),
-            "id" -> JsString(id)
-          )
+            "$dnanexus_link" -> JsObject(
+                "project" -> JsString(p.id),
+                "id" -> JsString(id)
+            )
         )
     }
   }
@@ -146,7 +146,7 @@ object DxFile {
               DxFilePart(state, size.toLong, md5)
             case _ =>
               throw new Exception(
-                s"malformed part description ${partDesc.prettyPrint}"
+                  s"malformed part description ${partDesc.prettyPrint}"
               )
           }
         partNumber.toInt -> dxPart
@@ -159,10 +159,10 @@ object DxFile {
       extraFields: Vector[String]
   ): Map[DxFile, DxFileDescribe] = {
     val requestFields = Map(
-      "objects" ->
-        JsArray(objs.map { x: DxObject =>
-          JsString(x.id)
-        })
+        "objects" ->
+          JsArray(objs.map { x: DxObject =>
+            JsString(x.id)
+          })
     )
 
     // extra describe options, if specified
@@ -174,17 +174,17 @@ object DxFile {
           fieldName -> JsBoolean(true)
         }.toMap
         Map(
-          "classDescribeOptions" -> JsObject(
-            "*" -> JsObject(m)
-          )
+            "classDescribeOptions" -> JsObject(
+                "*" -> JsObject(m)
+            )
         )
       }
     val request = JsObject(requestFields ++ extraDescribeFields)
 
     val response = DXAPI.systemDescribeDataObjects(
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val resultsPerObj: Vector[JsValue] =
@@ -198,19 +198,19 @@ object DxFile {
         val (dxFile, dxFullDesc) = jsv.asJsObject.fields.get("describe") match {
           case None =>
             throw new ResourceNotFoundException(
-              s""""${objs(i).id}" is not a recognized ID""",
-              404
+                s""""${objs(i).id}" is not a recognized ID""",
+                404
             )
           case Some(descJs) =>
             val (dxFile, dxDesc) =
               descJs.asJsObject.getFields(
-                "name",
-                "folder",
-                "size",
-                "id",
-                "project",
-                "created",
-                "modified"
+                  "name",
+                  "folder",
+                  "size",
+                  "id",
+                  "project",
+                  "created",
+                  "modified"
               ) match {
                 case Seq(
                     JsString(name),
@@ -225,16 +225,16 @@ object DxFile {
                   val dxContainer = DxProject.getInstance(projectId)
                   val dxFile = DxFile.getInstance(oid, dxContainer)
                   val desc = DxFileDescribe(
-                    projectId,
-                    oid,
-                    name,
-                    folder,
-                    created.toLong,
-                    modified.toLong,
-                    size.toLong,
-                    None,
-                    None,
-                    None
+                      projectId,
+                      oid,
+                      name,
+                      folder,
+                      created.toLong,
+                      modified.toLong,
+                      size.toLong,
+                      None,
+                      None,
+                      None
                   )
                   (dxFile, desc)
                 case _ =>

--- a/src/main/scala/dxWDL/dx/DxFile.scala
+++ b/src/main/scala/dxWDL/dx/DxFile.scala
@@ -8,210 +8,251 @@ import spray.json._
 // maximal number of objects in a single API request
 import dxWDL.base.Utils.DXAPI_NUM_OBJECTS_LIMIT
 
-case class DxFilePart(state: String,
-                      size: Long,
-                      md5: String)
+case class DxFilePart(state: String, size: Long, md5: String)
 
-case class DxFileDescribe(project : String,
-                          id : String,
-                          name : String,
-                          folder: String,
-                          created : Long,
-                          modified : Long,
-                          size : Long,
-                          properties : Option[Map[String, String]],
-                          details : Option[JsValue],
-                          parts : Option[Map[Int, DxFilePart]]) extends DxObjectDescribe
+case class DxFileDescribe(
+    project: String,
+    id: String,
+    name: String,
+    folder: String,
+    created: Long,
+    modified: Long,
+    size: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue],
+    parts: Option[Map[Int, DxFilePart]]
+) extends DxObjectDescribe
 
-case class DxFile(id : String,
-                  project : Option[DxProject]) extends DxDataObject {
+case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
 
-    def describe(fields : Set[Field.Value] = Set.empty) : DxFileDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Folder,
-                                Field.Created,
-                                Field.Modified,
-                                Field.Size)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.fileDescribe(id,
-                                          DxUtils.jsonNodeOfJsValue(request),
-                                          classOf[JsonNode],
-                                          DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id", "name", "folder",
-                                               "created", "modified") match {
-            case Seq(JsString(project), JsString(id),
-                     JsString(name), JsString(folder), JsNumber(created), JsNumber(modified)) =>
-                DxFileDescribe(project,
-                               id,
-                               name,
-                               folder,
-                               created.toLong,
-                               modified.toLong,
-                               0,
-                               None,
-                               None,
-                               None)
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
+  def describe(fields: Set[Field.Value] = Set.empty): DxFileDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields = Set(
+      Field.Project,
+      Field.Id,
+      Field.Name,
+      Field.Folder,
+      Field.Created,
+      Field.Modified,
+      Field.Size
+    )
+    val allFields = fields ++ defaultFields
+    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val response =
+      DXAPI.fileDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc =
+      descJs.asJsObject.getFields("project", "id", "name", "folder", "created", "modified") match {
+        case Seq(
+            JsString(project),
+            JsString(id),
+            JsString(name),
+            JsString(folder),
+            JsNumber(created),
+            JsNumber(modified)
+            ) =>
+          DxFileDescribe(
+            project,
+            id,
+            name,
+            folder,
+            created.toLong,
+            modified.toLong,
+            0,
+            None,
+            None,
+            None
+          )
+        case _ =>
+          throw new Exception(s"Malformed JSON ${descJs}")
+      }
 
-        val sizeRaw = descJs.asJsObject.fields.get("size").getOrElse(JsNumber(0))
-        val size = sizeRaw match {
-            case JsNumber(x) => x.toLong
-            case other => throw new Exception(s"size ${other} is not a number")
-        }
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        val parts = descJs.asJsObject.fields.get("parts").map(DxFile.parseFileParts)
-        desc.copy(size = size, details = details, properties = props, parts = parts)
+    val sizeRaw = descJs.asJsObject.fields.get("size").getOrElse(JsNumber(0))
+    val size = sizeRaw match {
+      case JsNumber(x) => x.toLong
+      case other       => throw new Exception(s"size ${other} is not a number")
     }
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val parts   = descJs.asJsObject.fields.get("parts").map(DxFile.parseFileParts)
+    desc.copy(size = size, details = details, properties = props, parts = parts)
+  }
 
-    def getLinkAsJson : JsValue = {
-        project match {
-            case None =>
-                JsObject("$dnanexus_link" -> JsString(id))
-            case Some(p) =>
-                JsObject( "$dnanexus_link" -> JsObject(
-                             "project" -> JsString(p.id),
-                             "id" -> JsString(id)
-                         ))
-        }
+  def getLinkAsJson: JsValue = {
+    project match {
+      case None =>
+        JsObject("$dnanexus_link" -> JsString(id))
+      case Some(p) =>
+        JsObject(
+          "$dnanexus_link" -> JsObject(
+            "project" -> JsString(p.id),
+            "id"      -> JsString(id)
+          )
+        )
     }
+  }
 }
 
 object DxFile {
-    def getInstance(id : String) : DxFile = {
-        DxObject.getInstance(id) match {
-             case f : DxFile => f
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a file")
-        }
+  def getInstance(id: String): DxFile = {
+    DxObject.getInstance(id) match {
+      case f: DxFile => f
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a file")
     }
+  }
 
-    def getInstance(id : String, project : DxProject) : DxFile = {
-        DxObject.getInstance(id, Some(project)) match {
-             case f : DxFile => f
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a file")
-        }
+  def getInstance(id: String, project: DxProject): DxFile = {
+    DxObject.getInstance(id, Some(project)) match {
+      case f: DxFile => f
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a file")
     }
+  }
 
-    // Parse the parts from a description of a file
-    // The format is something like this:
-    // {
-    //  "1": {
-    //    "md5": "71565d7f4dc0760457eb252a31d45964",
-    //    "size": 42,
-    //    "state": "complete"
-    //  }
-    //}
-    //
-    def parseFileParts(jsv: JsValue) : Map[Int, DxFilePart] = {
-        //System.out.println(jsv.prettyPrint)
-        jsv.asJsObject.fields.map{
-            case (partNumber, partDesc) =>
-                val dxPart = partDesc.asJsObject.getFields("md5", "size", "state") match {
-                    case Seq(JsString(md5), JsNumber(size), JsString(state)) =>
-                        DxFilePart(state, size.toLong, md5)
-                    case _ => throw new Exception(s"malformed part description ${partDesc.prettyPrint}")
-                }
-                partNumber.toInt -> dxPart
+  // Parse the parts from a description of a file
+  // The format is something like this:
+  // {
+  //  "1": {
+  //    "md5": "71565d7f4dc0760457eb252a31d45964",
+  //    "size": 42,
+  //    "state": "complete"
+  //  }
+  //}
+  //
+  def parseFileParts(jsv: JsValue): Map[Int, DxFilePart] = {
+    //System.out.println(jsv.prettyPrint)
+    jsv.asJsObject.fields.map {
+      case (partNumber, partDesc) =>
+        val dxPart = partDesc.asJsObject.getFields("md5", "size", "state") match {
+          case Seq(JsString(md5), JsNumber(size), JsString(state)) =>
+            DxFilePart(state, size.toLong, md5)
+          case _ => throw new Exception(s"malformed part description ${partDesc.prettyPrint}")
+        }
+        partNumber.toInt -> dxPart
+    }.toMap
+  }
+
+  // Describe a large number of platform objects in bulk.
+  private def submitRequest(
+      objs: Vector[DxFile],
+      extraFields: Vector[String]
+  ): Map[DxFile, DxFileDescribe] = {
+    val requestFields = Map(
+      "objects" ->
+        JsArray(objs.map { x: DxObject =>
+          JsString(x.id)
+        })
+    )
+
+    // extra describe options, if specified
+    val extraDescribeFields: Map[String, JsValue] =
+      if (extraFields.isEmpty) {
+        Map.empty
+      } else {
+        val m = extraFields.map { fieldName =>
+          fieldName -> JsBoolean(true)
         }.toMap
+        Map(
+          "classDescribeOptions" -> JsObject(
+            "*" -> JsObject(m)
+          )
+        )
+      }
+    val request = JsObject(requestFields ++ extraDescribeFields)
+
+    val response = DXAPI.systemDescribeDataObjects(
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val resultsPerObj: Vector[JsValue] = repJs.asJsObject.fields.get("results") match {
+      case Some(JsArray(x)) => x
+      case other            => throw new Exception(s"API call returned invalid data ${other}")
+    }
+    resultsPerObj.zipWithIndex.map {
+      case (jsv, i) =>
+        val (dxFile, dxFullDesc) = jsv.asJsObject.fields.get("describe") match {
+          case None =>
+            throw new ResourceNotFoundException(s""""${objs(i).id}" is not a recognized ID""", 404)
+          case Some(descJs) =>
+            val (dxFile, dxDesc) =
+              descJs.asJsObject.getFields(
+                "name",
+                "folder",
+                "size",
+                "id",
+                "project",
+                "created",
+                "modified"
+              ) match {
+                case Seq(
+                    JsString(name),
+                    JsString(folder),
+                    JsNumber(size),
+                    JsString(oid),
+                    JsString(projectId),
+                    JsNumber(created),
+                    JsNumber(modified)
+                    ) =>
+                  // This could be a container, not a project.
+                  val dxContainer = DxProject.getInstance(projectId)
+                  val dxFile      = DxFile.getInstance(oid, dxContainer)
+                  val desc = DxFileDescribe(
+                    projectId,
+                    oid,
+                    name,
+                    folder,
+                    created.toLong,
+                    modified.toLong,
+                    size.toLong,
+                    None,
+                    None,
+                    None
+                  )
+                  (dxFile, desc)
+                case _ =>
+                  throw new Exception(s"bad describe object ${descJs}")
+              }
+
+            // The parts may be empty, only files have it, and we don't always ask for it.
+            val parts      = descJs.asJsObject.fields.get("parts").map(parseFileParts)
+            val details    = descJs.asJsObject.fields.get("details")
+            val dxDescFull = dxDesc.copy(parts = parts, details = details)
+            (dxFile, dxDescFull)
+        }
+        dxFile -> dxFullDesc
+    }.toMap
+  }
+
+  // Describe the names of all the files in one batch. This is much more efficient
+  // than submitting file describes one-by-one.
+  def bulkDescribe(
+      objs: Vector[DxFile],
+      extraFields: Set[Field.Value] = Set.empty
+  ): Map[DxFile, DxFileDescribe] = {
+    if (objs.isEmpty) {
+      // avoid an unnessary API call; this is important for unit tests
+      // that do not have a network connection.
+      return Map.empty
     }
 
-    // Describe a large number of platform objects in bulk.
-    private def submitRequest(objs : Vector[DxFile],
-                              extraFields : Vector[String]) : Map[DxFile, DxFileDescribe] = {
-        val requestFields = Map("objects" ->
-                                   JsArray(objs.map{ x : DxObject => JsString(x.id) }))
+    // Limit on number of objects in one API request
+    val slices = objs.grouped(DXAPI_NUM_OBJECTS_LIMIT).toList
 
-        // extra describe options, if specified
-        val extraDescribeFields : Map[String, JsValue] =
-            if (extraFields.isEmpty) {
-                Map.empty
-            } else {
-                val m = extraFields.map{ fieldName =>
-                    fieldName -> JsBoolean(true)
-                }.toMap
-                Map("classDescribeOptions" -> JsObject(
-                        "*" -> JsObject(m)
-                    ))
-            }
-        val request = JsObject(requestFields ++ extraDescribeFields)
+    val extraFieldsStr = extraFields
+      .map {
+        case Field.Details => "details"
+        case Field.Parts   => "parts"
+      }
+      .toSet
+      .toVector
 
-        val response = DXAPI.systemDescribeDataObjects(DxUtils.jsonNodeOfJsValue(request),
-                                                       classOf[JsonNode],
-                                                       DxUtils.dxEnv)
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val resultsPerObj:Vector[JsValue] = repJs.asJsObject.fields.get("results") match {
-            case Some(JsArray(x)) => x
-            case other => throw new Exception(s"API call returned invalid data ${other}")
-        }
-        resultsPerObj.zipWithIndex.map{ case (jsv, i) =>
-            val (dxFile, dxFullDesc) = jsv.asJsObject.fields.get("describe") match {
-                case None =>
-                    throw new ResourceNotFoundException(s""""${objs(i).id}" is not a recognized ID""", 404)
-                case Some(descJs) =>
-                    val (dxFile, dxDesc) =
-                        descJs.asJsObject.getFields("name", "folder", "size", "id", "project", "created", "modified") match {
-                            case Seq(JsString(name), JsString(folder),
-                                     JsNumber(size), JsString(oid), JsString(projectId),
-                                     JsNumber(created), JsNumber(modified)) =>
-                                // This could be a container, not a project.
-                                val dxContainer = DxProject.getInstance(projectId)
-                                val dxFile = DxFile.getInstance(oid, dxContainer)
-                                val desc = DxFileDescribe(projectId,
-                                                          oid,
-                                                          name,
-                                                          folder,
-                                                          created.toLong,
-                                                          modified.toLong,
-                                                          size.toLong,
-                                                          None,
-                                                          None,
-                                                          None)
-                                (dxFile, desc)
-                            case _ =>
-                                throw new Exception(s"bad describe object ${descJs}")
-                        }
-
-                    // The parts may be empty, only files have it, and we don't always ask for it.
-                    val parts = descJs.asJsObject.fields.get("parts").map(parseFileParts)
-                    val details = descJs.asJsObject.fields.get("details")
-                    val dxDescFull = dxDesc.copy(parts = parts, details = details)
-                    (dxFile, dxDescFull)
-            }
-            dxFile -> dxFullDesc
-        }.toMap
+    // iterate on the ranges
+    slices.foldLeft(Map.empty[DxFile, DxFileDescribe]) {
+      case (accu, objRange) =>
+        accu ++ submitRequest(objRange.toVector, extraFieldsStr)
     }
-
-    // Describe the names of all the files in one batch. This is much more efficient
-    // than submitting file describes one-by-one.
-    def bulkDescribe(objs: Vector[DxFile],
-                     extraFields : Set[Field.Value] = Set.empty) : Map[DxFile, DxFileDescribe] = {
-        if (objs.isEmpty) {
-            // avoid an unnessary API call; this is important for unit tests
-            // that do not have a network connection.
-            return Map.empty
-        }
-
-        // Limit on number of objects in one API request
-        val slices = objs.grouped(DXAPI_NUM_OBJECTS_LIMIT).toList
-
-        val extraFieldsStr = extraFields.map{
-            case Field.Details => "details"
-            case Field.Parts => "parts"
-        }.toSet.toVector
-
-        // iterate on the ranges
-        slices.foldLeft(Map.empty[DxFile, DxFileDescribe]) {
-            case (accu, objRange) =>
-                accu ++ submitRequest(objRange.toVector, extraFieldsStr)
-        }
-    }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxFile.scala
+++ b/src/main/scala/dxWDL/dx/DxFile.scala
@@ -37,7 +37,7 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
       Field.Size
     )
     val allFields = fields ++ defaultFields
-    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
     val response =
       DXAPI.fileDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
@@ -73,8 +73,8 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
       case other       => throw new Exception(s"size ${other} is not a number")
     }
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-    val parts   = descJs.asJsObject.fields.get("parts").map(DxFile.parseFileParts)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val parts = descJs.asJsObject.fields.get("parts").map(DxFile.parseFileParts)
     desc.copy(size = size, details = details, properties = props, parts = parts)
   }
 
@@ -86,7 +86,7 @@ case class DxFile(id: String, project: Option[DxProject]) extends DxDataObject {
         JsObject(
           "$dnanexus_link" -> JsObject(
             "project" -> JsString(p.id),
-            "id"      -> JsString(id)
+            "id" -> JsString(id)
           )
         )
     }
@@ -198,7 +198,7 @@ object DxFile {
                     ) =>
                   // This could be a container, not a project.
                   val dxContainer = DxProject.getInstance(projectId)
-                  val dxFile      = DxFile.getInstance(oid, dxContainer)
+                  val dxFile = DxFile.getInstance(oid, dxContainer)
                   val desc = DxFileDescribe(
                     projectId,
                     oid,
@@ -217,8 +217,8 @@ object DxFile {
               }
 
             // The parts may be empty, only files have it, and we don't always ask for it.
-            val parts      = descJs.asJsObject.fields.get("parts").map(parseFileParts)
-            val details    = descJs.asJsObject.fields.get("details")
+            val parts = descJs.asJsObject.fields.get("parts").map(parseFileParts)
+            val details = descJs.asJsObject.fields.get("details")
             val dxDescFull = dxDesc.copy(parts = parts, details = details)
             (dxFile, dxDescFull)
         }

--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -47,44 +47,51 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     val folder = jsv.asJsObject.fields.get("folder") match {
       case None                   => throw new Exception("folder field missing")
       case Some(JsString(folder)) => folder
-      case Some(other)            => throw new Exception(s"malformed folder field ${other}")
-    }
-    val properties: Map[String, String] = jsv.asJsObject.fields.get("properties") match {
-      case None => Map.empty
-      case Some(JsObject(fields)) =>
-        fields.map {
-          case (key, JsString(value)) =>
-            key -> value
-          case (key, other) =>
-            throw new Exception(s"key ${key} has malformed property ${other}")
-        }.toMap
-      case Some(other) => throw new Exception(s"malformed properties field ${other}")
-    }
-    val inputSpec: Option[Vector[IOParameter]] = jsv.asJsObject.fields.get("inputSpec") match {
-      case None         => None
-      case Some(JsNull) => None
-      case Some(JsArray(iSpecVec)) =>
-        Some(iSpecVec.map(parseParamSpec).toVector)
       case Some(other) =>
-        throw new Exception(s"malformed inputSpec field ${other}")
+        throw new Exception(s"malformed folder field ${other}")
     }
-    val outputSpec: Option[Vector[IOParameter]] = jsv.asJsObject.fields.get("outputSpec") match {
-      case None         => None
-      case Some(JsNull) => None
-      case Some(JsArray(oSpecVec)) =>
-        Some(oSpecVec.map(parseParamSpec).toVector)
-      case Some(other) =>
-        throw new Exception(s"malformed output field ${other}")
-    }
+    val properties: Map[String, String] =
+      jsv.asJsObject.fields.get("properties") match {
+        case None => Map.empty
+        case Some(JsObject(fields)) =>
+          fields.map {
+            case (key, JsString(value)) =>
+              key -> value
+            case (key, other) =>
+              throw new Exception(s"key ${key} has malformed property ${other}")
+          }.toMap
+        case Some(other) =>
+          throw new Exception(s"malformed properties field ${other}")
+      }
+    val inputSpec: Option[Vector[IOParameter]] =
+      jsv.asJsObject.fields.get("inputSpec") match {
+        case None         => None
+        case Some(JsNull) => None
+        case Some(JsArray(iSpecVec)) =>
+          Some(iSpecVec.map(parseParamSpec).toVector)
+        case Some(other) =>
+          throw new Exception(s"malformed inputSpec field ${other}")
+      }
+    val outputSpec: Option[Vector[IOParameter]] =
+      jsv.asJsObject.fields.get("outputSpec") match {
+        case None         => None
+        case Some(JsNull) => None
+        case Some(JsArray(oSpecVec)) =>
+          Some(oSpecVec.map(parseParamSpec).toVector)
+        case Some(other) =>
+          throw new Exception(s"malformed output field ${other}")
+      }
     val created: Long = jsv.asJsObject.fields.get("created") match {
       case None                 => throw new Exception("'created' field is missing")
       case Some(JsNumber(date)) => date.toLong
-      case Some(other)          => throw new Exception(s"malformed created field ${other}")
+      case Some(other) =>
+        throw new Exception(s"malformed created field ${other}")
     }
     val modified: Long = jsv.asJsObject.fields.get("modified") match {
       case None                 => throw new Exception("'modified' field is missing")
       case Some(JsNumber(date)) => date.toLong
-      case Some(other)          => throw new Exception(s"malformed created field ${other}")
+      case Some(other) =>
+        throw new Exception(s"malformed created field ${other}")
     }
     val details: Option[JsValue] = jsv.asJsObject.fields.get("details")
 
@@ -152,9 +159,11 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
         val dxDataObj = dxObj.asInstanceOf[DxDataObject]
         (dxDataObj, parseDescribe(desc, dxDataObj, dxProj))
       case _ =>
-        throw new Exception(s"""|malformed result: expecting {project, id, describe} fields, got:
+        throw new Exception(
+          s"""|malformed result: expecting {project, id, describe} fields, got:
                     |${jsv.prettyPrint}
-                    |""".stripMargin)
+                    |""".stripMargin
+        )
     }
   }
 
@@ -268,7 +277,8 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       repJs.asJsObject.fields.get("results") match {
         case None                   => throw new Exception(s"missing results field ${repJs}")
         case Some(JsArray(results)) => results.map(parseOneResult)
-        case Some(other)            => throw new Exception(s"malformed results field ${other.prettyPrint}")
+        case Some(other) =>
+          throw new Exception(s"malformed results field ${other.prettyPrint}")
       }
 
     (results.toMap, next)
@@ -285,7 +295,9 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
   ): Map[DxDataObject, DxObjectDescribe] = {
     klassRestriction.map { k =>
       if (!(Set("record", "file", "applet", "workflow") contains k))
-        throw new Exception("class limitation must be one of {record, file, applet, workflow}")
+        throw new Exception(
+          "class limitation must be one of {record, file, applet, workflow}"
+        )
     }
     val scope = buildScope(dxProject, folder, recurse)
 

--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -6,263 +6,313 @@ import spray.json._
 
 import dxWDL.base.Verbose
 
-case class DxFindDataObjects(limit: Option[Int],
-                             verbose: Verbose) {
+case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
 
-    private def parseParamSpec(jsv: JsValue) : IOParameter = {
-        val ioClass: DxIOClass.Value = jsv.asJsObject.fields.get("class") match {
-            case None => throw new Exception("class field missing")
-            case Some(JsString(ioClass)) => DxIOClass.fromString(ioClass)
-            case other => throw new Exception(s"malformed class field ${other}")
-        }
-
-        val name: String = jsv.asJsObject.fields.get("name") match {
-            case None => throw new Exception("name field missing")
-            case Some(JsString(name)) => name
-            case other => throw new Exception(s"malformed name field ${other}")
-        }
-
-        val optional : Boolean = jsv.asJsObject.fields.get("optional") match {
-            case None => false
-            case Some(JsBoolean(flag)) => flag
-            case other => throw new Exception(s"malformed optional field ${other}")
-        }
-        IOParameter(name, ioClass, optional)
+  private def parseParamSpec(jsv: JsValue): IOParameter = {
+    val ioClass: DxIOClass.Value = jsv.asJsObject.fields.get("class") match {
+      case None                    => throw new Exception("class field missing")
+      case Some(JsString(ioClass)) => DxIOClass.fromString(ioClass)
+      case other                   => throw new Exception(s"malformed class field ${other}")
     }
 
-    private def parseDescribe(jsv: JsValue,
-                              dxobj : DxDataObject,
-                              dxProject: DxProject) : DxObjectDescribe = {
-        val size = jsv.asJsObject.fields.get("size") match {
-            case None => None
-            case Some(JsNumber(size)) => Some(size.toLong)
-            case Some(other) => throw new Exception(s"malformed size field ${other}")
-        }
-        val name: String = jsv.asJsObject.fields.get("name") match {
-            case None => throw new Exception("name field missing")
-            case Some(JsString(name)) => name
-            case other => throw new Exception(s"malformed name field ${other}")
-        }
-        val folder = jsv.asJsObject.fields.get("folder") match {
-            case None => throw new Exception("folder field missing")
-            case Some(JsString(folder)) => folder
-            case Some(other) => throw new Exception(s"malformed folder field ${other}")
-        }
-        val properties : Map[String, String] = jsv.asJsObject.fields.get("properties") match {
-            case None => Map.empty
-            case Some(JsObject(fields)) =>
-                fields.map{
-                    case (key, JsString(value)) =>
-                        key -> value
-                    case (key, other) =>
-                        throw new Exception(s"key ${key} has malformed property ${other}")
-                }.toMap
-            case Some(other) => throw new Exception(s"malformed properties field ${other}")
-        }
-        val inputSpec : Option[Vector[IOParameter]] = jsv.asJsObject.fields.get("inputSpec") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(JsArray(iSpecVec)) =>
-                Some(iSpecVec.map(parseParamSpec).toVector)
-            case Some(other) =>
-                throw new Exception(s"malformed inputSpec field ${other}")
-        }
-        val outputSpec : Option[Vector[IOParameter]]= jsv.asJsObject.fields.get("outputSpec") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(JsArray(oSpecVec)) =>
-                Some(oSpecVec.map(parseParamSpec).toVector)
-            case Some(other) =>
-                throw new Exception(s"malformed output field ${other}")
-        }
-        val created : Long = jsv.asJsObject.fields.get("created") match {
-            case None => throw new Exception("'created' field is missing")
-            case Some(JsNumber(date)) => date.toLong
-            case Some(other) => throw new Exception(s"malformed created field ${other}")
-        }
-        val modified : Long = jsv.asJsObject.fields.get("modified") match {
-            case None => throw new Exception("'modified' field is missing")
-            case Some(JsNumber(date)) => date.toLong
-            case Some(other) => throw new Exception(s"malformed created field ${other}")
-        }
-        val details : Option[JsValue] = jsv.asJsObject.fields.get("details")
-
-        dxobj match {
-            case _ : DxApp =>
-                DxAppDescribe(dxobj.id,
-                              name,
-                              created, modified,
-                              Some(properties), details, inputSpec, outputSpec)
-            case _ : DxApplet =>
-                DxAppletDescribe(dxProject.id, dxobj.id,
-                                 name, folder,
-                                 created, modified,
-                                 Some(properties), details, inputSpec, outputSpec)
-            case _ : DxWorkflow =>
-                DxAppletDescribe(dxProject.id, dxobj.id,
-                                 name, folder,
-                                 created, modified,
-                                 Some(properties), details, inputSpec, outputSpec)
-            case _ : DxFile =>
-                DxFileDescribe(dxProject.id, dxobj.id,
-                               name, folder,
-                               created, modified,
-                               size.get, Some(properties), details, None)
-            case other =>
-                throw new Exception(s"unsupported object ${other}")
-        }
+    val name: String = jsv.asJsObject.fields.get("name") match {
+      case None                 => throw new Exception("name field missing")
+      case Some(JsString(name)) => name
+      case other                => throw new Exception(s"malformed name field ${other}")
     }
 
-    private def parseOneResult(jsv : JsValue) : (DxDataObject, DxObjectDescribe) = {
-        jsv.asJsObject.getFields("project", "id", "describe") match {
-            case Seq(JsString(projectId), JsString(dxid), desc) =>
-                val dxProj = DxProject.getInstance(projectId)
-                val dxObj = DxObject.getInstance(dxid, dxProj)
-                val dxDataObj = dxObj.asInstanceOf[DxDataObject]
-                (dxDataObj, parseDescribe(desc, dxDataObj, dxProj))
-            case _ => throw new Exception(
-                s"""|malformed result: expecting {project, id, describe} fields, got:
+    val optional: Boolean = jsv.asJsObject.fields.get("optional") match {
+      case None                  => false
+      case Some(JsBoolean(flag)) => flag
+      case other                 => throw new Exception(s"malformed optional field ${other}")
+    }
+    IOParameter(name, ioClass, optional)
+  }
+
+  private def parseDescribe(
+      jsv: JsValue,
+      dxobj: DxDataObject,
+      dxProject: DxProject
+  ): DxObjectDescribe = {
+    val size = jsv.asJsObject.fields.get("size") match {
+      case None                 => None
+      case Some(JsNumber(size)) => Some(size.toLong)
+      case Some(other)          => throw new Exception(s"malformed size field ${other}")
+    }
+    val name: String = jsv.asJsObject.fields.get("name") match {
+      case None                 => throw new Exception("name field missing")
+      case Some(JsString(name)) => name
+      case other                => throw new Exception(s"malformed name field ${other}")
+    }
+    val folder = jsv.asJsObject.fields.get("folder") match {
+      case None                   => throw new Exception("folder field missing")
+      case Some(JsString(folder)) => folder
+      case Some(other)            => throw new Exception(s"malformed folder field ${other}")
+    }
+    val properties: Map[String, String] = jsv.asJsObject.fields.get("properties") match {
+      case None => Map.empty
+      case Some(JsObject(fields)) =>
+        fields.map {
+          case (key, JsString(value)) =>
+            key -> value
+          case (key, other) =>
+            throw new Exception(s"key ${key} has malformed property ${other}")
+        }.toMap
+      case Some(other) => throw new Exception(s"malformed properties field ${other}")
+    }
+    val inputSpec: Option[Vector[IOParameter]] = jsv.asJsObject.fields.get("inputSpec") match {
+      case None         => None
+      case Some(JsNull) => None
+      case Some(JsArray(iSpecVec)) =>
+        Some(iSpecVec.map(parseParamSpec).toVector)
+      case Some(other) =>
+        throw new Exception(s"malformed inputSpec field ${other}")
+    }
+    val outputSpec: Option[Vector[IOParameter]] = jsv.asJsObject.fields.get("outputSpec") match {
+      case None         => None
+      case Some(JsNull) => None
+      case Some(JsArray(oSpecVec)) =>
+        Some(oSpecVec.map(parseParamSpec).toVector)
+      case Some(other) =>
+        throw new Exception(s"malformed output field ${other}")
+    }
+    val created: Long = jsv.asJsObject.fields.get("created") match {
+      case None                 => throw new Exception("'created' field is missing")
+      case Some(JsNumber(date)) => date.toLong
+      case Some(other)          => throw new Exception(s"malformed created field ${other}")
+    }
+    val modified: Long = jsv.asJsObject.fields.get("modified") match {
+      case None                 => throw new Exception("'modified' field is missing")
+      case Some(JsNumber(date)) => date.toLong
+      case Some(other)          => throw new Exception(s"malformed created field ${other}")
+    }
+    val details: Option[JsValue] = jsv.asJsObject.fields.get("details")
+
+    dxobj match {
+      case _: DxApp =>
+        DxAppDescribe(
+          dxobj.id,
+          name,
+          created,
+          modified,
+          Some(properties),
+          details,
+          inputSpec,
+          outputSpec
+        )
+      case _: DxApplet =>
+        DxAppletDescribe(
+          dxProject.id,
+          dxobj.id,
+          name,
+          folder,
+          created,
+          modified,
+          Some(properties),
+          details,
+          inputSpec,
+          outputSpec
+        )
+      case _: DxWorkflow =>
+        DxAppletDescribe(
+          dxProject.id,
+          dxobj.id,
+          name,
+          folder,
+          created,
+          modified,
+          Some(properties),
+          details,
+          inputSpec,
+          outputSpec
+        )
+      case _: DxFile =>
+        DxFileDescribe(
+          dxProject.id,
+          dxobj.id,
+          name,
+          folder,
+          created,
+          modified,
+          size.get,
+          Some(properties),
+          details,
+          None
+        )
+      case other =>
+        throw new Exception(s"unsupported object ${other}")
+    }
+  }
+
+  private def parseOneResult(jsv: JsValue): (DxDataObject, DxObjectDescribe) = {
+    jsv.asJsObject.getFields("project", "id", "describe") match {
+      case Seq(JsString(projectId), JsString(dxid), desc) =>
+        val dxProj    = DxProject.getInstance(projectId)
+        val dxObj     = DxObject.getInstance(dxid, dxProj)
+        val dxDataObj = dxObj.asInstanceOf[DxDataObject]
+        (dxDataObj, parseDescribe(desc, dxDataObj, dxProj))
+      case _ =>
+        throw new Exception(s"""|malformed result: expecting {project, id, describe} fields, got:
                     |${jsv.prettyPrint}
                     |""".stripMargin)
-        }
     }
+  }
 
-    private def buildScope(dxProject : DxProject,
-                           folder : Option[String],
-                           recurse : Boolean) : JsValue = {
-        val part1 = Map("project" -> JsString(dxProject.getId))
-        val part2 = folder match {
-            case None => Map.empty
-            case Some(path) => Map("folder" -> JsString(path))
-        }
-        val part3 =
-            if (recurse)
-                Map("recurse" -> JsBoolean(true))
-            else
-                Map("recurse" -> JsBoolean(false))
-        JsObject(part1 ++ part2 ++ part3)
+  private def buildScope(
+      dxProject: DxProject,
+      folder: Option[String],
+      recurse: Boolean
+  ): JsValue = {
+    val part1 = Map("project" -> JsString(dxProject.getId))
+    val part2 = folder match {
+      case None       => Map.empty
+      case Some(path) => Map("folder" -> JsString(path))
     }
+    val part3 =
+      if (recurse)
+        Map("recurse" -> JsBoolean(true))
+      else
+        Map("recurse" -> JsBoolean(false))
+    JsObject(part1 ++ part2 ++ part3)
+  }
 
-    // Submit a request for a limited number of objects
-    private def submitRequest(scope : JsValue,
-                              dxProject: DxProject,
-                              cursor: Option[JsValue],
-                              klass: Option[String],
-                              propertyConstraints: Vector[String],
-                              nameConstraints : Vector[String],
-                              withInputOutputSpec : Boolean) : (Map[DxDataObject, DxObjectDescribe], Option[JsValue]) = {
-        val describeFields = Map("name" -> JsBoolean(true),
-                                 "folder" -> JsBoolean(true),
-                                 "size" -> JsBoolean(true),
-                                 "properties" -> JsBoolean(true))
-        val ioSpec =
-            if (withInputOutputSpec)
-                Map("inputSpec" -> JsBoolean(true),
-                    "outputSpec" -> JsBoolean(true))
-            else
-                Map.empty
+  // Submit a request for a limited number of objects
+  private def submitRequest(
+      scope: JsValue,
+      dxProject: DxProject,
+      cursor: Option[JsValue],
+      klass: Option[String],
+      propertyConstraints: Vector[String],
+      nameConstraints: Vector[String],
+      withInputOutputSpec: Boolean
+  ): (Map[DxDataObject, DxObjectDescribe], Option[JsValue]) = {
+    val describeFields = Map(
+      "name"       -> JsBoolean(true),
+      "folder"     -> JsBoolean(true),
+      "size"       -> JsBoolean(true),
+      "properties" -> JsBoolean(true)
+    )
+    val ioSpec =
+      if (withInputOutputSpec)
+        Map("inputSpec" -> JsBoolean(true), "outputSpec" -> JsBoolean(true))
+      else
+        Map.empty
 
-        val reqFields = Map("visibility" -> JsString("either"),
-                            "project" -> JsString(dxProject.getId),
-                            "describe" -> JsObject(describeFields ++ ioSpec),
-                            "scope" -> scope)
-        val limitField = limit match {
-            case None => Map.empty
-            case Some(lim) =>  Map("limit" -> JsNumber(lim))
-        }
-        val cursorField = cursor match {
-            case None => Map.empty
-            case Some(cursorValue) => Map("starting" -> cursorValue)
-        }
-        val classField = klass match {
-            case None => Map.empty
-            case Some(k) => Map("class" -> JsString(k))
-        }
-        val propertiesField =
-            if (propertyConstraints.isEmpty) {
-                Map.empty
-            } else {
-                Map("properties" -> JsObject(
-                        propertyConstraints.map{
-                            prop => prop -> JsBoolean(true)
-                        }.toMap))
-            }
-
-        val namePcreField =
-            if (nameConstraints.isEmpty) {
-                Map.empty
-            } else if (nameConstraints.size == 1) {
-                // Just one name, no need to use regular expressions
-                Map("name" -> JsString(nameConstraints(0)))
-            } else {
-                // Make a conjunction of all the legal names. For example:
-                // ["Nice", "Foo", "Bar"] ===>
-                //  [(Nice)|(Foo)|(Bar)]
-                val orAll = nameConstraints.map{x => s"(${x})"}.mkString("|")
-                Map("name" -> JsObject(
-                        "regexp" -> JsString(s"[${orAll}]")))
-            }
-
-        val request = JsObject(reqFields ++ cursorField ++ limitField
-                                   ++ classField ++ propertiesField
-                                   ++ namePcreField)
-
-        //Utils.trace(verbose.on, s"submitRequest:\n ${request.prettyPrint}")
-
-        val response = DXAPI.systemFindDataObjects(DxUtils.jsonNodeOfJsValue(request),
-                                                   classOf[JsonNode],
-                                                   DxUtils.dxEnv)
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-
-        val next : Option[JsValue] = repJs.asJsObject.fields.get("next") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(other : JsObject) => Some(other)
-            case Some(other) => throw new Exception(s"malformed ${other.prettyPrint}")
-        }
-        val results : Vector[(DxDataObject, DxObjectDescribe)] =
-            repJs.asJsObject.fields.get("results") match {
-                case None => throw new Exception(s"missing results field ${repJs}")
-                case Some(JsArray(results)) => results.map(parseOneResult)
-                case Some(other) => throw new Exception(s"malformed results field ${other.prettyPrint}")
-            }
-
-        (results.toMap, next)
+    val reqFields = Map(
+      "visibility" -> JsString("either"),
+      "project"    -> JsString(dxProject.getId),
+      "describe"   -> JsObject(describeFields ++ ioSpec),
+      "scope"      -> scope
+    )
+    val limitField = limit match {
+      case None      => Map.empty
+      case Some(lim) => Map("limit" -> JsNumber(lim))
     }
-
-    def apply(dxProject : DxProject,
-              folder : Option[String],
-              recurse: Boolean,
-              klassRestriction : Option[String],
-              withProperties : Vector[String], // object must have these properties
-              nameConstraints : Vector[String], // the object name has to be one of these strings
-              withInputOutputSpec : Boolean  // should the IO spec be described?
-    ) : Map[DxDataObject, DxObjectDescribe] = {
-        klassRestriction.map{ k =>
-            if (!(Set("record", "file", "applet", "workflow") contains k))
-                throw new Exception("class limitation must be one of {record, file, applet, workflow}")
-        }
-        val scope = buildScope(dxProject, folder, recurse)
-
-        var allResults = Map.empty[DxDataObject, DxObjectDescribe]
-        var cursor : Option[JsValue] = None
-        do {
-            val (results, next) = submitRequest(scope, dxProject, cursor, klassRestriction,
-                                                withProperties,
-                                                nameConstraints,
-                                                withInputOutputSpec)
-            allResults = allResults ++ results
-            cursor = next
-        } while (cursor != None);
-
-        if (nameConstraints.isEmpty) {
-            allResults
-        } else {
-            // Ensure the the data objects have names in the allowed set
-            val allowedNames = nameConstraints.toSet
-            allResults.filter{
-                case (appletOrWorkflow, desc) => allowedNames contains desc.name
-            }
-        }
+    val cursorField = cursor match {
+      case None              => Map.empty
+      case Some(cursorValue) => Map("starting" -> cursorValue)
     }
+    val classField = klass match {
+      case None    => Map.empty
+      case Some(k) => Map("class" -> JsString(k))
+    }
+    val propertiesField =
+      if (propertyConstraints.isEmpty) {
+        Map.empty
+      } else {
+        Map("properties" -> JsObject(propertyConstraints.map { prop =>
+          prop -> JsBoolean(true)
+        }.toMap))
+      }
+
+    val namePcreField =
+      if (nameConstraints.isEmpty) {
+        Map.empty
+      } else if (nameConstraints.size == 1) {
+        // Just one name, no need to use regular expressions
+        Map("name" -> JsString(nameConstraints(0)))
+      } else {
+        // Make a conjunction of all the legal names. For example:
+        // ["Nice", "Foo", "Bar"] ===>
+        //  [(Nice)|(Foo)|(Bar)]
+        val orAll = nameConstraints
+          .map { x =>
+            s"(${x})"
+          }
+          .mkString("|")
+        Map("name" -> JsObject("regexp" -> JsString(s"[${orAll}]")))
+      }
+
+    val request = JsObject(
+      reqFields ++ cursorField ++ limitField
+        ++ classField ++ propertiesField
+        ++ namePcreField
+    )
+
+    //Utils.trace(verbose.on, s"submitRequest:\n ${request.prettyPrint}")
+
+    val response = DXAPI.systemFindDataObjects(
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+
+    val next: Option[JsValue] = repJs.asJsObject.fields.get("next") match {
+      case None                  => None
+      case Some(JsNull)          => None
+      case Some(other: JsObject) => Some(other)
+      case Some(other)           => throw new Exception(s"malformed ${other.prettyPrint}")
+    }
+    val results: Vector[(DxDataObject, DxObjectDescribe)] =
+      repJs.asJsObject.fields.get("results") match {
+        case None                   => throw new Exception(s"missing results field ${repJs}")
+        case Some(JsArray(results)) => results.map(parseOneResult)
+        case Some(other)            => throw new Exception(s"malformed results field ${other.prettyPrint}")
+      }
+
+    (results.toMap, next)
+  }
+
+  def apply(
+      dxProject: DxProject,
+      folder: Option[String],
+      recurse: Boolean,
+      klassRestriction: Option[String],
+      withProperties: Vector[String],  // object must have these properties
+      nameConstraints: Vector[String], // the object name has to be one of these strings
+      withInputOutputSpec: Boolean     // should the IO spec be described?
+  ): Map[DxDataObject, DxObjectDescribe] = {
+    klassRestriction.map { k =>
+      if (!(Set("record", "file", "applet", "workflow") contains k))
+        throw new Exception("class limitation must be one of {record, file, applet, workflow}")
+    }
+    val scope = buildScope(dxProject, folder, recurse)
+
+    var allResults              = Map.empty[DxDataObject, DxObjectDescribe]
+    var cursor: Option[JsValue] = None
+    do {
+      val (results, next) = submitRequest(
+        scope,
+        dxProject,
+        cursor,
+        klassRestriction,
+        withProperties,
+        nameConstraints,
+        withInputOutputSpec
+      )
+      allResults = allResults ++ results
+      cursor = next
+    } while (cursor != None);
+
+    if (nameConstraints.isEmpty) {
+      allResults
+    } else {
+      // Ensure the the data objects have names in the allowed set
+      val allowedNames = nameConstraints.toSet
+      allResults.filter {
+        case (appletOrWorkflow, desc) => allowedNames contains desc.name
+      }
+    }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -98,53 +98,53 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     dxobj match {
       case _: DxApp =>
         DxAppDescribe(
-          dxobj.id,
-          name,
-          created,
-          modified,
-          Some(properties),
-          details,
-          inputSpec,
-          outputSpec
+            dxobj.id,
+            name,
+            created,
+            modified,
+            Some(properties),
+            details,
+            inputSpec,
+            outputSpec
         )
       case _: DxApplet =>
         DxAppletDescribe(
-          dxProject.id,
-          dxobj.id,
-          name,
-          folder,
-          created,
-          modified,
-          Some(properties),
-          details,
-          inputSpec,
-          outputSpec
+            dxProject.id,
+            dxobj.id,
+            name,
+            folder,
+            created,
+            modified,
+            Some(properties),
+            details,
+            inputSpec,
+            outputSpec
         )
       case _: DxWorkflow =>
         DxAppletDescribe(
-          dxProject.id,
-          dxobj.id,
-          name,
-          folder,
-          created,
-          modified,
-          Some(properties),
-          details,
-          inputSpec,
-          outputSpec
+            dxProject.id,
+            dxobj.id,
+            name,
+            folder,
+            created,
+            modified,
+            Some(properties),
+            details,
+            inputSpec,
+            outputSpec
         )
       case _: DxFile =>
         DxFileDescribe(
-          dxProject.id,
-          dxobj.id,
-          name,
-          folder,
-          created,
-          modified,
-          size.get,
-          Some(properties),
-          details,
-          None
+            dxProject.id,
+            dxobj.id,
+            name,
+            folder,
+            created,
+            modified,
+            size.get,
+            Some(properties),
+            details,
+            None
         )
       case other =>
         throw new Exception(s"unsupported object ${other}")
@@ -160,7 +160,7 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
         (dxDataObj, parseDescribe(desc, dxDataObj, dxProj))
       case _ =>
         throw new Exception(
-          s"""|malformed result: expecting {project, id, describe} fields, got:
+            s"""|malformed result: expecting {project, id, describe} fields, got:
                     |${jsv.prettyPrint}
                     |""".stripMargin
         )
@@ -196,10 +196,10 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       withInputOutputSpec: Boolean
   ): (Map[DxDataObject, DxObjectDescribe], Option[JsValue]) = {
     val describeFields = Map(
-      "name" -> JsBoolean(true),
-      "folder" -> JsBoolean(true),
-      "size" -> JsBoolean(true),
-      "properties" -> JsBoolean(true)
+        "name" -> JsBoolean(true),
+        "folder" -> JsBoolean(true),
+        "size" -> JsBoolean(true),
+        "properties" -> JsBoolean(true)
     )
     val ioSpec =
       if (withInputOutputSpec)
@@ -208,10 +208,10 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
         Map.empty
 
     val reqFields = Map(
-      "visibility" -> JsString("either"),
-      "project" -> JsString(dxProject.getId),
-      "describe" -> JsObject(describeFields ++ ioSpec),
-      "scope" -> scope
+        "visibility" -> JsString("either"),
+        "project" -> JsString(dxProject.getId),
+        "describe" -> JsObject(describeFields ++ ioSpec),
+        "scope" -> scope
     )
     val limitField = limit match {
       case None      => Map.empty
@@ -253,17 +253,17 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       }
 
     val request = JsObject(
-      reqFields ++ cursorField ++ limitField
-        ++ classField ++ propertiesField
-        ++ namePcreField
+        reqFields ++ cursorField ++ limitField
+          ++ classField ++ propertiesField
+          ++ namePcreField
     )
 
     //Utils.trace(verbose.on, s"submitRequest:\n ${request.prettyPrint}")
 
     val response = DXAPI.systemFindDataObjects(
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
 
@@ -296,7 +296,7 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     klassRestriction.map { k =>
       if (!(Set("record", "file", "applet", "workflow") contains k))
         throw new Exception(
-          "class limitation must be one of {record, file, applet, workflow}"
+            "class limitation must be one of {record, file, applet, workflow}"
         )
     }
     val scope = buildScope(dxProject, folder, recurse)
@@ -305,13 +305,13 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     var cursor: Option[JsValue] = None
     do {
       val (results, next) = submitRequest(
-        scope,
-        dxProject,
-        cursor,
-        klassRestriction,
-        withProperties,
-        nameConstraints,
-        withInputOutputSpec
+          scope,
+          dxProject,
+          cursor,
+          klassRestriction,
+          withProperties,
+          nameConstraints,
+          withInputOutputSpec
       )
       allResults = allResults ++ results
       cursor = next

--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -147,8 +147,8 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
   private def parseOneResult(jsv: JsValue): (DxDataObject, DxObjectDescribe) = {
     jsv.asJsObject.getFields("project", "id", "describe") match {
       case Seq(JsString(projectId), JsString(dxid), desc) =>
-        val dxProj    = DxProject.getInstance(projectId)
-        val dxObj     = DxObject.getInstance(dxid, dxProj)
+        val dxProj = DxProject.getInstance(projectId)
+        val dxObj = DxObject.getInstance(dxid, dxProj)
         val dxDataObj = dxObj.asInstanceOf[DxDataObject]
         (dxDataObj, parseDescribe(desc, dxDataObj, dxProj))
       case _ =>
@@ -187,9 +187,9 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       withInputOutputSpec: Boolean
   ): (Map[DxDataObject, DxObjectDescribe], Option[JsValue]) = {
     val describeFields = Map(
-      "name"       -> JsBoolean(true),
-      "folder"     -> JsBoolean(true),
-      "size"       -> JsBoolean(true),
+      "name" -> JsBoolean(true),
+      "folder" -> JsBoolean(true),
+      "size" -> JsBoolean(true),
       "properties" -> JsBoolean(true)
     )
     val ioSpec =
@@ -200,9 +200,9 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
 
     val reqFields = Map(
       "visibility" -> JsString("either"),
-      "project"    -> JsString(dxProject.getId),
-      "describe"   -> JsObject(describeFields ++ ioSpec),
-      "scope"      -> scope
+      "project" -> JsString(dxProject.getId),
+      "describe" -> JsObject(describeFields ++ ioSpec),
+      "scope" -> scope
     )
     val limitField = limit match {
       case None      => Map.empty
@@ -279,9 +279,9 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       folder: Option[String],
       recurse: Boolean,
       klassRestriction: Option[String],
-      withProperties: Vector[String],  // object must have these properties
+      withProperties: Vector[String], // object must have these properties
       nameConstraints: Vector[String], // the object name has to be one of these strings
-      withInputOutputSpec: Boolean     // should the IO spec be described?
+      withInputOutputSpec: Boolean // should the IO spec be described?
   ): Map[DxDataObject, DxObjectDescribe] = {
     klassRestriction.map { k =>
       if (!(Set("record", "file", "applet", "workflow") contains k))
@@ -289,7 +289,7 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     }
     val scope = buildScope(dxProject, folder, recurse)
 
-    var allResults              = Map.empty[DxDataObject, DxObjectDescribe]
+    var allResults = Map.empty[DxDataObject, DxObjectDescribe]
     var cursor: Option[JsValue] = None
     do {
       val (results, next) = submitRequest(

--- a/src/main/scala/dxWDL/dx/DxFindExecutions.scala
+++ b/src/main/scala/dxWDL/dx/DxFindExecutions.scala
@@ -6,55 +6,59 @@ import spray.json._
 
 object DxFindExecutions {
 
-    private def parseOneResult(value : JsValue) : DxExecution = {
-        value.asJsObject.fields.get("id") match {
-            case None => throw new Exception(s"field id not found in ${value.prettyPrint}")
-            case Some(JsString(id)) if id.startsWith("job-") => DxJob.getInstance(id)
-            case Some(JsString(id)) if id.startsWith("analysis-") => DxAnalysis.getInstance(id)
-            case Some(other) => throw new Exception(s"malformed id field ${other.prettyPrint}")
-        }
+  private def parseOneResult(value: JsValue): DxExecution = {
+    value.asJsObject.fields.get("id") match {
+      case None                                             => throw new Exception(s"field id not found in ${value.prettyPrint}")
+      case Some(JsString(id)) if id.startsWith("job-")      => DxJob.getInstance(id)
+      case Some(JsString(id)) if id.startsWith("analysis-") => DxAnalysis.getInstance(id)
+      case Some(other)                                      => throw new Exception(s"malformed id field ${other.prettyPrint}")
     }
+  }
 
-    private def submitRequest(parentJob: Option[DxJob],
-                              cursor: Option[JsValue]) : (Vector[DxExecution], Option[JsValue]) = {
-        val parentField = parentJob match {
-            case None => Map.empty
-            case Some(job) => Map("parentJob" -> JsString(job.getId))
-        }
-        val cursorField = cursor match {
-            case None => Map.empty
-            case Some(cursorValue) => Map("starting" -> cursorValue)
-        }
-        val request = JsObject(parentField ++ cursorField)
-        val response = DXAPI.systemFindExecutions(DxUtils.jsonNodeOfJsValue(request),
-                                                  classOf[JsonNode],
-                                                  DxUtils.dxEnv)
-        val repJs : JsValue = DxUtils.jsValueOfJsonNode(response)
-
-        val next : Option[JsValue] = repJs.asJsObject.fields.get("next") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(other : JsObject) => Some(other)
-            case Some(other) => throw new Exception(s"malformed ${other.prettyPrint}")
-        }
-        val results : Vector[DxExecution] =
-            repJs.asJsObject.fields.get("results") match {
-                case None => throw new Exception(s"missing results field ${repJs}")
-                case Some(JsArray(results)) => results.map(parseOneResult)
-                case Some(other) => throw new Exception(s"malformed results field ${other.prettyPrint}")
-            }
-
-        (results, next)
+  private def submitRequest(
+      parentJob: Option[DxJob],
+      cursor: Option[JsValue]
+  ): (Vector[DxExecution], Option[JsValue]) = {
+    val parentField = parentJob match {
+      case None      => Map.empty
+      case Some(job) => Map("parentJob" -> JsString(job.getId))
     }
-
-    def apply(parentJob: Option[DxJob]) : Vector[DxExecution] = {
-        var allResults = Vector.empty[DxExecution]
-        var cursor : Option[JsValue] = None
-        do {
-            val (results, next) = submitRequest(parentJob, cursor)
-            allResults = allResults ++ results
-            cursor = next
-        } while (cursor != None);
-        allResults
+    val cursorField = cursor match {
+      case None              => Map.empty
+      case Some(cursorValue) => Map("starting" -> cursorValue)
     }
+    val request = JsObject(parentField ++ cursorField)
+    val response = DXAPI.systemFindExecutions(
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+
+    val next: Option[JsValue] = repJs.asJsObject.fields.get("next") match {
+      case None                  => None
+      case Some(JsNull)          => None
+      case Some(other: JsObject) => Some(other)
+      case Some(other)           => throw new Exception(s"malformed ${other.prettyPrint}")
+    }
+    val results: Vector[DxExecution] =
+      repJs.asJsObject.fields.get("results") match {
+        case None                   => throw new Exception(s"missing results field ${repJs}")
+        case Some(JsArray(results)) => results.map(parseOneResult)
+        case Some(other)            => throw new Exception(s"malformed results field ${other.prettyPrint}")
+      }
+
+    (results, next)
+  }
+
+  def apply(parentJob: Option[DxJob]): Vector[DxExecution] = {
+    var allResults              = Vector.empty[DxExecution]
+    var cursor: Option[JsValue] = None
+    do {
+      val (results, next) = submitRequest(parentJob, cursor)
+      allResults = allResults ++ results
+      cursor = next
+    } while (cursor != None);
+    allResults
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxFindExecutions.scala
+++ b/src/main/scala/dxWDL/dx/DxFindExecutions.scala
@@ -52,7 +52,7 @@ object DxFindExecutions {
   }
 
   def apply(parentJob: Option[DxJob]): Vector[DxExecution] = {
-    var allResults              = Vector.empty[DxExecution]
+    var allResults = Vector.empty[DxExecution]
     var cursor: Option[JsValue] = None
     do {
       val (results, next) = submitRequest(parentJob, cursor)

--- a/src/main/scala/dxWDL/dx/DxFindExecutions.scala
+++ b/src/main/scala/dxWDL/dx/DxFindExecutions.scala
@@ -8,10 +8,13 @@ object DxFindExecutions {
 
   private def parseOneResult(value: JsValue): DxExecution = {
     value.asJsObject.fields.get("id") match {
-      case None                                             => throw new Exception(s"field id not found in ${value.prettyPrint}")
-      case Some(JsString(id)) if id.startsWith("job-")      => DxJob.getInstance(id)
-      case Some(JsString(id)) if id.startsWith("analysis-") => DxAnalysis.getInstance(id)
-      case Some(other)                                      => throw new Exception(s"malformed id field ${other.prettyPrint}")
+      case None =>
+        throw new Exception(s"field id not found in ${value.prettyPrint}")
+      case Some(JsString(id)) if id.startsWith("job-") => DxJob.getInstance(id)
+      case Some(JsString(id)) if id.startsWith("analysis-") =>
+        DxAnalysis.getInstance(id)
+      case Some(other) =>
+        throw new Exception(s"malformed id field ${other.prettyPrint}")
     }
   }
 
@@ -45,7 +48,8 @@ object DxFindExecutions {
       repJs.asJsObject.fields.get("results") match {
         case None                   => throw new Exception(s"missing results field ${repJs}")
         case Some(JsArray(results)) => results.map(parseOneResult)
-        case Some(other)            => throw new Exception(s"malformed results field ${other.prettyPrint}")
+        case Some(other) =>
+          throw new Exception(s"malformed results field ${other.prettyPrint}")
       }
 
     (results, next)

--- a/src/main/scala/dxWDL/dx/DxFindExecutions.scala
+++ b/src/main/scala/dxWDL/dx/DxFindExecutions.scala
@@ -32,9 +32,9 @@ object DxFindExecutions {
     }
     val request = JsObject(parentField ++ cursorField)
     val response = DXAPI.systemFindExecutions(
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
 

--- a/src/main/scala/dxWDL/dx/DxJob.scala
+++ b/src/main/scala/dxWDL/dx/DxJob.scala
@@ -31,7 +31,7 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       Field.Analysis
     )
     val allFields = fields ++ defaultFields
-    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
     val response = DXAPI.analysisDescribe(
       id,
       DxUtils.jsonNodeOfJsValue(request),
@@ -66,7 +66,7 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     val parentJob: Option[DxJob] = descJs.asJsObject.fields.get("parentJob") match {
       case None              => None
       case Some(JsNull)      => None

--- a/src/main/scala/dxWDL/dx/DxJob.scala
+++ b/src/main/scala/dxWDL/dx/DxJob.scala
@@ -31,7 +31,9 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       Field.Analysis
     )
     val allFields = fields ++ defaultFields
-    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(
+      projSpec + ("fields" -> DxObject.requestFields(allFields))
+    )
     val response = DXAPI.analysisDescribe(
       id,
       DxUtils.jsonNodeOfJsValue(request),
@@ -40,7 +42,14 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
     )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
-      descJs.asJsObject.getFields("project", "id", "name", "created", "modified", "applet") match {
+      descJs.asJsObject.getFields(
+        "project",
+        "id",
+        "name",
+        "created",
+        "modified",
+        "applet"
+      ) match {
         case Seq(
             JsString(project),
             JsString(id),
@@ -66,20 +75,28 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-    val parentJob: Option[DxJob] = descJs.asJsObject.fields.get("parentJob") match {
-      case None              => None
-      case Some(JsNull)      => None
-      case Some(JsString(x)) => Some(DxJob.getInstance(x))
-      case Some(other)       => throw new Exception(s"should be a job ${other}")
-    }
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
+    val parentJob: Option[DxJob] =
+      descJs.asJsObject.fields.get("parentJob") match {
+        case None              => None
+        case Some(JsNull)      => None
+        case Some(JsString(x)) => Some(DxJob.getInstance(x))
+        case Some(other)       => throw new Exception(s"should be a job ${other}")
+      }
     val analysis = descJs.asJsObject.fields.get("analysis") match {
       case None              => None
       case Some(JsNull)      => None
       case Some(JsString(x)) => Some(DxAnalysis.getInstance(x))
       case Some(other)       => throw new Exception(s"should be an analysis ${other}")
     }
-    desc.copy(details = details, properties = props, parentJob = parentJob, analysis = analysis)
+    desc.copy(
+      details = details,
+      properties = props,
+      parentJob = parentJob,
+      analysis = analysis
+    )
   }
 }
 

--- a/src/main/scala/dxWDL/dx/DxJob.scala
+++ b/src/main/scala/dxWDL/dx/DxJob.scala
@@ -21,34 +21,34 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
   def describe(fields: Set[Field.Value] = Set.empty): DxJobDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields = Set(
-      Field.Project,
-      Field.Id,
-      Field.Name,
-      Field.Created,
-      Field.Modified,
-      Field.Applet,
-      Field.ParentJob,
-      Field.Analysis
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Created,
+        Field.Modified,
+        Field.Applet,
+        Field.ParentJob,
+        Field.Analysis
     )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec + ("fields" -> DxObject.requestFields(allFields))
+        projSpec + ("fields" -> DxObject.requestFields(allFields))
     )
     val response = DXAPI.analysisDescribe(
-      id,
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
       descJs.asJsObject.getFields(
-        "project",
-        "id",
-        "name",
-        "created",
-        "modified",
-        "applet"
+          "project",
+          "id",
+          "name",
+          "created",
+          "modified",
+          "applet"
       ) match {
         case Seq(
             JsString(project),
@@ -59,16 +59,16 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
             JsString(applet)
             ) =>
           DxJobDescribe(
-            project,
-            id,
-            name,
-            created.toLong,
-            modified.toLong,
-            None,
-            None,
-            DxApplet.getInstance(applet),
-            None,
-            None
+              project,
+              id,
+              name,
+              created.toLong,
+              modified.toLong,
+              None,
+              None,
+              DxApplet.getInstance(applet),
+              None,
+              None
           )
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
@@ -92,10 +92,10 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       case Some(other)       => throw new Exception(s"should be an analysis ${other}")
     }
     desc.copy(
-      details = details,
-      properties = props,
-      parentJob = parentJob,
-      analysis = analysis
+        details = details,
+        properties = props,
+        parentJob = parentJob,
+        analysis = analysis
     )
   }
 }

--- a/src/main/scala/dxWDL/dx/DxJob.scala
+++ b/src/main/scala/dxWDL/dx/DxJob.scala
@@ -4,89 +4,99 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxJobDescribe(project : String,
-                         id  : String,
-                         name : String,
-                         created : Long,
-                         modified : Long,
-                         properties: Option[Map[String, String]],
-                         details : Option[JsValue],
-                         applet : DxApplet,
-                         parentJob : Option[DxJob],
-                         analysis : Option[DxAnalysis]) extends DxObjectDescribe
+case class DxJobDescribe(
+    project: String,
+    id: String,
+    name: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue],
+    applet: DxApplet,
+    parentJob: Option[DxJob],
+    analysis: Option[DxAnalysis]
+) extends DxObjectDescribe
 
-case class DxJob(id : String,
-                 project : Option[DxProject] = None) extends DxObject with DxExecution {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxJobDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Created,
-                                Field.Modified,
-                                Field.Applet,
-                                Field.ParentJob,
-                                Field.Analysis)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.analysisDescribe(id,
-                                              DxUtils.jsonNodeOfJsValue(request),
-                                              classOf[JsonNode],
-                                              DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id", "name",
-                                               "created", "modified", "applet") match {
-            case Seq(JsString(project), JsString(id), JsString(name),
-                     JsNumber(created), JsNumber(modified), JsString(applet)) =>
-                DxJobDescribe(project,
-                              id,
-                              name,
-                              created.toLong,
-                              modified.toLong,
-                              None,
-                              None,
-                              DxApplet.getInstance(applet),
-                              None,
-                              None)
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
+case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject with DxExecution {
+  def describe(fields: Set[Field.Value] = Set.empty): DxJobDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields = Set(
+      Field.Project,
+      Field.Id,
+      Field.Name,
+      Field.Created,
+      Field.Modified,
+      Field.Applet,
+      Field.ParentJob,
+      Field.Analysis
+    )
+    val allFields = fields ++ defaultFields
+    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val response = DXAPI.analysisDescribe(
+      id,
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc =
+      descJs.asJsObject.getFields("project", "id", "name", "created", "modified", "applet") match {
+        case Seq(
+            JsString(project),
+            JsString(id),
+            JsString(name),
+            JsNumber(created),
+            JsNumber(modified),
+            JsString(applet)
+            ) =>
+          DxJobDescribe(
+            project,
+            id,
+            name,
+            created.toLong,
+            modified.toLong,
+            None,
+            None,
+            DxApplet.getInstance(applet),
+            None,
+            None
+          )
+        case _ =>
+          throw new Exception(s"Malformed JSON ${descJs}")
+      }
 
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        val parentJob : Option[DxJob] = descJs.asJsObject.fields.get("parentJob") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(JsString(x)) => Some(DxJob.getInstance(x))
-            case Some(other) => throw new Exception(s"should be a job ${other}")
-        }
-        val analysis = descJs.asJsObject.fields.get("analysis") match {
-            case None => None
-            case Some(JsNull) => None
-            case Some(JsString(x)) => Some(DxAnalysis.getInstance(x))
-            case Some(other) => throw new Exception(s"should be an analysis ${other}")
-        }
-        desc.copy(details = details,
-                  properties = props,
-                  parentJob = parentJob,
-                  analysis = analysis)
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val parentJob: Option[DxJob] = descJs.asJsObject.fields.get("parentJob") match {
+      case None              => None
+      case Some(JsNull)      => None
+      case Some(JsString(x)) => Some(DxJob.getInstance(x))
+      case Some(other)       => throw new Exception(s"should be a job ${other}")
     }
+    val analysis = descJs.asJsObject.fields.get("analysis") match {
+      case None              => None
+      case Some(JsNull)      => None
+      case Some(JsString(x)) => Some(DxAnalysis.getInstance(x))
+      case Some(other)       => throw new Exception(s"should be an analysis ${other}")
+    }
+    desc.copy(details = details, properties = props, parentJob = parentJob, analysis = analysis)
+  }
 }
 
 object DxJob {
-    def getInstance(id : String) : DxJob = {
-        DxObject.getInstance(id, None) match {
-             case j : DxJob => j
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a job")
-        }
+  def getInstance(id: String): DxJob = {
+    DxObject.getInstance(id, None) match {
+      case j: DxJob => j
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a job")
     }
+  }
 
-    def getInstance(id : String, project : DxProject) : DxJob = {
-        DxObject.getInstance(id, Some(project)) match {
-             case j : DxJob => j
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a job")
-        }
+  def getInstance(id: String, project: DxProject): DxJob = {
+    DxObject.getInstance(id, Some(project)) match {
+      case j: DxJob => j
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a job")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxPath.scala
+++ b/src/main/scala/dxWDL/dx/DxPath.scala
@@ -79,14 +79,14 @@ object DxPath {
     // A project name, resolve it
     val req =
       JsObject(
-        "name" -> JsString(projName),
-        "level" -> JsString("VIEW"),
-        "limit" -> JsNumber(2)
+          "name" -> JsString(projName),
+          "level" -> JsString("VIEW"),
+          "limit" -> JsNumber(2)
       )
     val rep = DXAPI.systemFindProjects(
-      jsonNodeOfJsValue(req),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        jsonNodeOfJsValue(req),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = jsValueOfJsonNode(rep)
 
@@ -94,7 +94,7 @@ object DxPath {
       case Some(JsArray(x)) => x
       case _ =>
         throw new Exception(
-          s"Bad response from systemFindProject API call (${repJs.prettyPrint}), when resolving project ${projName}."
+            s"Bad response from systemFindProject API call (${repJs.prettyPrint}), when resolving project ${projName}."
         )
     }
     if (results.length > 1)
@@ -105,7 +105,7 @@ object DxPath {
       case Some(JsString(id)) => DxProject.getInstance(id)
       case _ =>
         throw new Exception(
-          s"Bad response from SystemFindProject API call ${repJs.prettyPrint}"
+            s"Bad response from SystemFindProject API call ${repJs.prettyPrint}"
         )
     }
     projectDict(projName) = dxProject
@@ -116,7 +116,7 @@ object DxPath {
   //   "dx://dxWDL_playground:/test_data/fileB",
   private def makeResolutionReq(components: DxPathComponents): JsValue = {
     val reqFields: Map[String, JsValue] = Map(
-      "name" -> JsString(components.name)
+        "name" -> JsString(components.name)
     )
     val folderField: Map[String, JsValue] = components.folder match {
       case None    => Map.empty
@@ -137,14 +137,14 @@ object DxPath {
   ): Map[String, DxDataObject] = {
     val objectReqs: Vector[JsValue] = dxPaths.map { makeResolutionReq(_) }
     val request = JsObject(
-      "objects" -> JsArray(objectReqs),
-      "project" -> JsString(dxProject.getId)
+        "objects" -> JsArray(objectReqs),
+        "project" -> JsString(dxProject.getId)
     )
 
     val response = DXAPI.systemResolveDataObjects(
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val resultsPerObj: Vector[JsValue] =
@@ -159,12 +159,12 @@ object DxPath {
         val o = descJs match {
           case JsArray(x) if x.isEmpty =>
             throw new Exception(
-              s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.getId}"
+                s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.getId}"
             )
           case JsArray(x) if x.length == 1 => x(0)
           case JsArray(x) =>
             throw new Exception(
-              s"Found more than one dx object in path ${path}"
+                s"Found more than one dx object in path ${path}"
             )
           case obj: JsObject => obj
           case other         => throw new Exception(s"malformed json ${other}")
@@ -251,11 +251,11 @@ object DxPath {
 
     if (found.size == 0)
       throw new Exception(
-        s"Could not find ${dxPath} in project ${dxProject.getId}"
+          s"Could not find ${dxPath} in project ${dxProject.getId}"
       )
     if (found.size > 1)
       throw new Exception(
-        s"Found more than one dx:object in path ${dxPath}, project=${dxProject.getId}"
+          s"Found more than one dx:object in path ${dxPath}, project=${dxProject.getId}"
       )
 
     found.values.head

--- a/src/main/scala/dxWDL/dx/DxPath.scala
+++ b/src/main/scala/dxWDL/dx/DxPath.scala
@@ -78,8 +78,16 @@ object DxPath {
 
     // A project name, resolve it
     val req =
-      JsObject("name" -> JsString(projName), "level" -> JsString("VIEW"), "limit" -> JsNumber(2))
-    val rep = DXAPI.systemFindProjects(jsonNodeOfJsValue(req), classOf[JsonNode], DxUtils.dxEnv)
+      JsObject(
+        "name" -> JsString(projName),
+        "level" -> JsString("VIEW"),
+        "limit" -> JsNumber(2)
+      )
+    val rep = DXAPI.systemFindProjects(
+      jsonNodeOfJsValue(req),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
     val repJs: JsValue = jsValueOfJsonNode(rep)
 
     val results = repJs.asJsObject.fields.get("results") match {
@@ -96,7 +104,9 @@ object DxPath {
     val dxProject = results(0).asJsObject.fields.get("id") match {
       case Some(JsString(id)) => DxProject.getInstance(id)
       case _ =>
-        throw new Exception(s"Bad response from SystemFindProject API call ${repJs.prettyPrint}")
+        throw new Exception(
+          s"Bad response from SystemFindProject API call ${repJs.prettyPrint}"
+        )
     }
     projectDict(projName) = dxProject
     return dxProject
@@ -105,7 +115,9 @@ object DxPath {
   // Create a request from a path like:
   //   "dx://dxWDL_playground:/test_data/fileB",
   private def makeResolutionReq(components: DxPathComponents): JsValue = {
-    val reqFields: Map[String, JsValue] = Map("name" -> JsString(components.name))
+    val reqFields: Map[String, JsValue] = Map(
+      "name" -> JsString(components.name)
+    )
     val folderField: Map[String, JsValue] = components.folder match {
       case None    => Map.empty
       case Some(x) => Map("folder" -> JsString(x))
@@ -124,7 +136,10 @@ object DxPath {
       dxProject: DxProject
   ): Map[String, DxDataObject] = {
     val objectReqs: Vector[JsValue] = dxPaths.map { makeResolutionReq(_) }
-    val request = JsObject("objects" -> JsArray(objectReqs), "project" -> JsString(dxProject.getId))
+    val request = JsObject(
+      "objects" -> JsArray(objectReqs),
+      "project" -> JsString(dxProject.getId)
+    )
 
     val response = DXAPI.systemResolveDataObjects(
       DxUtils.jsonNodeOfJsValue(request),
@@ -132,10 +147,12 @@ object DxPath {
       DxUtils.dxEnv
     )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
-    val resultsPerObj: Vector[JsValue] = repJs.asJsObject.fields.get("results") match {
-      case Some(JsArray(x)) => x
-      case other            => throw new Exception(s"API call returned invalid data ${other}")
-    }
+    val resultsPerObj: Vector[JsValue] =
+      repJs.asJsObject.fields.get("results") match {
+        case Some(JsArray(x)) => x
+        case other =>
+          throw new Exception(s"API call returned invalid data ${other}")
+      }
     resultsPerObj.zipWithIndex.map {
       case (descJs: JsValue, i) =>
         val path = dxPaths(i).sourcePath
@@ -146,7 +163,9 @@ object DxPath {
             )
           case JsArray(x) if x.length == 1 => x(0)
           case JsArray(x) =>
-            throw new Exception(s"Found more than one dx object in path ${path}")
+            throw new Exception(
+              s"Found more than one dx object in path ${path}"
+            )
           case obj: JsObject => obj
           case other         => throw new Exception(s"malformed json ${other}")
         }
@@ -185,7 +204,9 @@ object DxPath {
           case None => dxDataObj
           case Some(pid) =>
             val dxProj = resolveProject(pid)
-            DxObject.getInstance(dxDataObj.getId, dxProj).asInstanceOf[DxDataObject]
+            DxObject
+              .getInstance(dxDataObj.getId, dxProj)
+              .asInstanceOf[DxDataObject]
         }
         alreadyResolved = alreadyResolved + (p -> dxobjWithProj)
       } else {
@@ -197,7 +218,10 @@ object DxPath {
 
   // Describe the names of all the data objects in one batch. This is much more efficient
   // than submitting object describes one-by-one.
-  def resolveBulk(dxPaths: Seq[String], dxProject: DxProject): Map[String, DxDataObject] = {
+  def resolveBulk(
+      dxPaths: Seq[String],
+      dxProject: DxProject
+  ): Map[String, DxDataObject] = {
     if (dxPaths.isEmpty) {
       // avoid an unnessary API call; this is important for unit tests
       // that do not have a network connection.
@@ -226,7 +250,9 @@ object DxPath {
       resolveBulk(Vector(dxPath), dxProject)
 
     if (found.size == 0)
-      throw new Exception(s"Could not find ${dxPath} in project ${dxProject.getId}")
+      throw new Exception(
+        s"Could not find ${dxPath} in project ${dxProject.getId}"
+      )
     if (found.size > 1)
       throw new Exception(
         s"Found more than one dx:object in path ${dxPath}, project=${dxProject.getId}"

--- a/src/main/scala/dxWDL/dx/DxPath.scala
+++ b/src/main/scala/dxWDL/dx/DxPath.scala
@@ -79,7 +79,7 @@ object DxPath {
     // A project name, resolve it
     val req =
       JsObject("name" -> JsString(projName), "level" -> JsString("VIEW"), "limit" -> JsNumber(2))
-    val rep            = DXAPI.systemFindProjects(jsonNodeOfJsValue(req), classOf[JsonNode], DxUtils.dxEnv)
+    val rep = DXAPI.systemFindProjects(jsonNodeOfJsValue(req), classOf[JsonNode], DxUtils.dxEnv)
     val repJs: JsValue = jsValueOfJsonNode(rep)
 
     val results = repJs.asJsObject.fields.get("results") match {
@@ -124,7 +124,7 @@ object DxPath {
       dxProject: DxProject
   ): Map[String, DxDataObject] = {
     val objectReqs: Vector[JsValue] = dxPaths.map { makeResolutionReq(_) }
-    val request                     = JsObject("objects" -> JsArray(objectReqs), "project" -> JsString(dxProject.getId))
+    val request = JsObject("objects" -> JsArray(objectReqs), "project" -> JsString(dxProject.getId))
 
     val response = DXAPI.systemResolveDataObjects(
       DxUtils.jsonNodeOfJsValue(request),
@@ -174,12 +174,12 @@ object DxPath {
       allDxPaths: Seq[String]
   ): (Map[String, DxDataObject], Vector[DxPathComponents]) = {
     var alreadyResolved = Map.empty[String, DxDataObject]
-    var rest            = Vector.empty[DxPathComponents]
+    var rest = Vector.empty[DxPathComponents]
 
     for (p <- allDxPaths) {
       val components = parse(p)
       if (DxObject.isDataObject(components.name)) {
-        val o         = DxObject.getInstance(components.name, None)
+        val o = DxObject.getInstance(components.name, None)
         val dxDataObj = o.asInstanceOf[DxDataObject]
         val dxobjWithProj = components.projName match {
           case None => dxDataObj

--- a/src/main/scala/dxWDL/dx/DxPath.scala
+++ b/src/main/scala/dxWDL/dx/DxPath.scala
@@ -19,238 +19,244 @@ import dxWDL.base.Utils.{DX_URL_PREFIX, DXAPI_NUM_OBJECTS_LIMIT}
 
 object DxPath {
 
-    private case class DxPathComponents(name: String,
-                                        folder: Option[String],
-                                        projName: Option[String],
-                                        objFullName : String,
-                                        sourcePath: String)
+  private case class DxPathComponents(
+      name: String,
+      folder: Option[String],
+      projName: Option[String],
+      objFullName: String,
+      sourcePath: String
+  )
 
-    private def parse(dxPath : String) : DxPathComponents = {
-        // strip the prefix
-        assert(dxPath.startsWith(DX_URL_PREFIX))
-        val s = dxPath.substring(DX_URL_PREFIX.length)
+  private def parse(dxPath: String): DxPathComponents = {
+    // strip the prefix
+    assert(dxPath.startsWith(DX_URL_PREFIX))
+    val s = dxPath.substring(DX_URL_PREFIX.length)
 
-        // take out the project, if it is specified
-        val components = s.split(":").toList
-        val (projName, dxObjectPath) = components match {
-            case Nil =>
-                throw new Exception(s"Path ${dxPath} is invalid")
-            case List(objName) =>
-                (None, objName)
-            case projName :: tail =>
-                val rest = tail.mkString(":")
-                (Some(projName), rest)
-        }
-
-        // split the object path into folder/name
-        val index = dxObjectPath.lastIndexOf('/')
-        val (folderRaw, name) =
-            if (index == -1) {
-                ("/", dxObjectPath)
-            } else {
-                (dxObjectPath.substring(0, index),
-                 dxObjectPath.substring(index + 1))
-            }
-
-        // We don't want a folder if this is a dx-data-object (file-xxxx, record-yyyy)
-        val folder =
-            if (DxUtils.isDxId(name)) None
-            else if (folderRaw == "") Some("/")
-            else Some(folderRaw)
-
-        DxPathComponents(name, folder, projName, dxObjectPath, dxPath)
+    // take out the project, if it is specified
+    val components = s.split(":").toList
+    val (projName, dxObjectPath) = components match {
+      case Nil =>
+        throw new Exception(s"Path ${dxPath} is invalid")
+      case List(objName) =>
+        (None, objName)
+      case projName :: tail =>
+        val rest = tail.mkString(":")
+        (Some(projName), rest)
     }
 
-    // Lookup cache for projects. This saves
-    // repeated searches for projects we already found.
-    private val projectDict = HashMap.empty[String, DxProject]
+    // split the object path into folder/name
+    val index = dxObjectPath.lastIndexOf('/')
+    val (folderRaw, name) =
+      if (index == -1) {
+        ("/", dxObjectPath)
+      } else {
+        (dxObjectPath.substring(0, index), dxObjectPath.substring(index + 1))
+      }
 
-    def resolveProject(projName: String): DxProject = {
-        if (projName.startsWith("project-")) {
-            // A project ID
-            return DxProject.getInstance(projName)
-        }
-        if (projectDict contains projName) {
-            //System.err.println(s"Cached project ${projName}")
-            return projectDict(projName)
-        }
+    // We don't want a folder if this is a dx-data-object (file-xxxx, record-yyyy)
+    val folder =
+      if (DxUtils.isDxId(name)) None
+      else if (folderRaw == "") Some("/")
+      else Some(folderRaw)
 
-        // A project name, resolve it
-        val req = JsObject("name" -> JsString(projName),
-                           "level" -> JsString("VIEW"),
-                           "limit" -> JsNumber(2))
-        val rep = DXAPI.systemFindProjects(jsonNodeOfJsValue(req),
-                                           classOf[JsonNode],
-                                           DxUtils.dxEnv)
-        val repJs:JsValue = jsValueOfJsonNode(rep)
+    DxPathComponents(name, folder, projName, dxObjectPath, dxPath)
+  }
 
-        val results = repJs.asJsObject.fields.get("results") match {
-            case Some(JsArray(x)) => x
-            case _ => throw new Exception(
-                s"Bad response from systemFindProject API call (${repJs.prettyPrint}), when resolving project ${projName}.")
-        }
-        if (results.length > 1)
-            throw new Exception(s"Found more than one project named ${projName}")
-        if (results.length == 0)
-            throw new Exception(s"Project ${projName} not found")
-        val dxProject = results(0).asJsObject.fields.get("id") match {
-            case Some(JsString(id)) => DxProject.getInstance(id)
-            case _ => throw new Exception(s"Bad response from SystemFindProject API call ${repJs.prettyPrint}")
-        }
-        projectDict(projName) = dxProject
-        return dxProject
+  // Lookup cache for projects. This saves
+  // repeated searches for projects we already found.
+  private val projectDict = HashMap.empty[String, DxProject]
+
+  def resolveProject(projName: String): DxProject = {
+    if (projName.startsWith("project-")) {
+      // A project ID
+      return DxProject.getInstance(projName)
+    }
+    if (projectDict contains projName) {
+      //System.err.println(s"Cached project ${projName}")
+      return projectDict(projName)
     }
 
+    // A project name, resolve it
+    val req =
+      JsObject("name" -> JsString(projName), "level" -> JsString("VIEW"), "limit" -> JsNumber(2))
+    val rep            = DXAPI.systemFindProjects(jsonNodeOfJsValue(req), classOf[JsonNode], DxUtils.dxEnv)
+    val repJs: JsValue = jsValueOfJsonNode(rep)
 
-    // Create a request from a path like:
-    //   "dx://dxWDL_playground:/test_data/fileB",
-    private def makeResolutionReq(components: DxPathComponents) : JsValue = {
-        val reqFields : Map[String, JsValue] = Map("name" -> JsString(components.name))
-        val folderField : Map[String, JsValue] = components.folder match {
-            case None => Map.empty
-            case Some(x) => Map("folder" -> JsString(x))
-        }
-        val projectField : Map[String, JsValue] = components.projName match {
-            case None => Map.empty
-            case Some(x) =>
-                val dxProj = resolveProject(x)
-                Map("project" -> JsString(dxProj.getId))
-        }
-        JsObject(reqFields ++ folderField ++ projectField)
+    val results = repJs.asJsObject.fields.get("results") match {
+      case Some(JsArray(x)) => x
+      case _ =>
+        throw new Exception(
+          s"Bad response from systemFindProject API call (${repJs.prettyPrint}), when resolving project ${projName}."
+        )
     }
-
-    private def submitRequest(dxPaths : Vector[DxPathComponents],
-                              dxProject : DxProject) : Map[String, DxDataObject] = {
-        val objectReqs : Vector[JsValue] = dxPaths.map{ makeResolutionReq(_) }
-        val request = JsObject("objects" -> JsArray(objectReqs),
-                               "project" -> JsString(dxProject.getId))
-
-        val response = DXAPI.systemResolveDataObjects(DxUtils.jsonNodeOfJsValue(request),
-                                                      classOf[JsonNode],
-                                                      DxUtils.dxEnv)
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val resultsPerObj:Vector[JsValue] = repJs.asJsObject.fields.get("results") match {
-            case Some(JsArray(x)) => x
-            case other => throw new Exception(s"API call returned invalid data ${other}")
-        }
-        resultsPerObj.zipWithIndex.map{
-            case (descJs : JsValue, i) =>
-                val path = dxPaths(i).sourcePath
-                val o = descJs match {
-                    case JsArray(x) if x.isEmpty =>
-                        throw new Exception(s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.getId}")
-                    case JsArray(x) if x.length == 1 => x(0)
-                    case JsArray(x) =>
-                        throw new Exception(s"Found more than one dx object in path ${path}")
-                    case obj :JsObject => obj
-                    case other => throw new Exception(s"malformed json ${other}")
-                }
-                val fields = o.asJsObject.fields
-                val dxid = fields.get("id") match {
-                    case Some(JsString(x)) => x
-                    case _ => throw new Exception("no id returned")
-                }
-
-                // could be a container, not a project
-                val dxContainer : Option[DxProject] = fields.get("project") match {
-                    case Some(JsString(x)) => Some(DxProject.getInstance(x))
-                    case _ => None
-                }
-
-                // safe conversion to a dx-object
-                val dxobj = DxObject.getInstance(dxid, dxContainer)
-                path -> dxobj.asInstanceOf[DxDataObject]
-        }.toMap
+    if (results.length > 1)
+      throw new Exception(s"Found more than one project named ${projName}")
+    if (results.length == 0)
+      throw new Exception(s"Project ${projName} not found")
+    val dxProject = results(0).asJsObject.fields.get("id") match {
+      case Some(JsString(id)) => DxProject.getInstance(id)
+      case _ =>
+        throw new Exception(s"Bad response from SystemFindProject API call ${repJs.prettyPrint}")
     }
+    projectDict(projName) = dxProject
+    return dxProject
+  }
 
-    // split between files that have already been resolved (we have their file-id), and
-    // those that require lookup.
-    private def triage(allDxPaths: Seq[String]) : (Map[String, DxDataObject],
-                                                   Vector[DxPathComponents]) = {
-        var alreadyResolved = Map.empty[String, DxDataObject]
-        var rest = Vector.empty[DxPathComponents]
-
-        for (p <- allDxPaths) {
-            val components = parse(p)
-            if (DxObject.isDataObject(components.name)) {
-                val o = DxObject.getInstance(components.name, None)
-                val dxDataObj = o.asInstanceOf[DxDataObject]
-                val dxobjWithProj = components.projName match {
-                    case None => dxDataObj
-                    case Some(pid) =>
-                        val dxProj = resolveProject(pid)
-                        DxObject.getInstance(dxDataObj.getId, dxProj).asInstanceOf[DxDataObject]
-                }
-                alreadyResolved = alreadyResolved + (p -> dxobjWithProj)
-            } else {
-                rest = rest :+ components
-            }
-        }
-        (alreadyResolved, rest)
+  // Create a request from a path like:
+  //   "dx://dxWDL_playground:/test_data/fileB",
+  private def makeResolutionReq(components: DxPathComponents): JsValue = {
+    val reqFields: Map[String, JsValue] = Map("name" -> JsString(components.name))
+    val folderField: Map[String, JsValue] = components.folder match {
+      case None    => Map.empty
+      case Some(x) => Map("folder" -> JsString(x))
     }
+    val projectField: Map[String, JsValue] = components.projName match {
+      case None => Map.empty
+      case Some(x) =>
+        val dxProj = resolveProject(x)
+        Map("project" -> JsString(dxProj.getId))
+    }
+    JsObject(reqFields ++ folderField ++ projectField)
+  }
 
-    // Describe the names of all the data objects in one batch. This is much more efficient
-    // than submitting object describes one-by-one.
-    def resolveBulk(dxPaths: Seq[String],
-                    dxProject: DxProject) : Map[String, DxDataObject] = {
-        if (dxPaths.isEmpty) {
-            // avoid an unnessary API call; this is important for unit tests
-            // that do not have a network connection.
-            return Map.empty
+  private def submitRequest(
+      dxPaths: Vector[DxPathComponents],
+      dxProject: DxProject
+  ): Map[String, DxDataObject] = {
+    val objectReqs: Vector[JsValue] = dxPaths.map { makeResolutionReq(_) }
+    val request                     = JsObject("objects" -> JsArray(objectReqs), "project" -> JsString(dxProject.getId))
+
+    val response = DXAPI.systemResolveDataObjects(
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val resultsPerObj: Vector[JsValue] = repJs.asJsObject.fields.get("results") match {
+      case Some(JsArray(x)) => x
+      case other            => throw new Exception(s"API call returned invalid data ${other}")
+    }
+    resultsPerObj.zipWithIndex.map {
+      case (descJs: JsValue, i) =>
+        val path = dxPaths(i).sourcePath
+        val o = descJs match {
+          case JsArray(x) if x.isEmpty =>
+            throw new Exception(
+              s"Path ${path} not found req=${objectReqs(i)}, i=${i}, project=${dxProject.getId}"
+            )
+          case JsArray(x) if x.length == 1 => x(0)
+          case JsArray(x) =>
+            throw new Exception(s"Found more than one dx object in path ${path}")
+          case obj: JsObject => obj
+          case other         => throw new Exception(s"malformed json ${other}")
+        }
+        val fields = o.asJsObject.fields
+        val dxid = fields.get("id") match {
+          case Some(JsString(x)) => x
+          case _                 => throw new Exception("no id returned")
         }
 
-        // peel off objects that have already been resolved
-        val (alreadyResolved, dxPathsToResolve) = triage(dxPaths)
-        if (dxPathsToResolve.isEmpty)
-            return alreadyResolved
-
-        // Limit on number of objects in one API request
-        val slices = dxPathsToResolve.grouped(DXAPI_NUM_OBJECTS_LIMIT).toList
-
-        // iterate on the ranges
-        val resolved = slices.foldLeft(Map.empty[String, DxDataObject]) {
-            case (accu, pathsRange) =>
-                accu ++ submitRequest(pathsRange.toVector, dxProject)
+        // could be a container, not a project
+        val dxContainer: Option[DxProject] = fields.get("project") match {
+          case Some(JsString(x)) => Some(DxProject.getInstance(x))
+          case _                 => None
         }
 
-        alreadyResolved ++ resolved
-    }
+        // safe conversion to a dx-object
+        val dxobj = DxObject.getInstance(dxid, dxContainer)
+        path -> dxobj.asInstanceOf[DxDataObject]
+    }.toMap
+  }
 
-    def resolveOnePath(dxPath: String,
-                       dxProject : DxProject) : DxDataObject = {
-        val found : Map[String, DxDataObject] =
-            resolveBulk(Vector(dxPath), dxProject)
+  // split between files that have already been resolved (we have their file-id), and
+  // those that require lookup.
+  private def triage(
+      allDxPaths: Seq[String]
+  ): (Map[String, DxDataObject], Vector[DxPathComponents]) = {
+    var alreadyResolved = Map.empty[String, DxDataObject]
+    var rest            = Vector.empty[DxPathComponents]
 
-        if (found.size == 0)
-            throw new Exception(s"Could not find ${dxPath} in project ${dxProject.getId}")
-        if (found.size > 1)
-            throw new Exception(s"Found more than one dx:object in path ${dxPath}, project=${dxProject.getId}")
-
-        found.values.head
-    }
-
-    private def resolveDxPath(dxPath: String) : DxDataObject = {
-        val components = parse(dxPath)
-        components.projName match {
-            case None =>
-                resolveOnePath(dxPath, DxUtils.dxCrntProject)
-            case Some(pName) =>
-                resolveOnePath(dxPath, resolveProject(pName))
+    for (p <- allDxPaths) {
+      val components = parse(p)
+      if (DxObject.isDataObject(components.name)) {
+        val o         = DxObject.getInstance(components.name, None)
+        val dxDataObj = o.asInstanceOf[DxDataObject]
+        val dxobjWithProj = components.projName match {
+          case None => dxDataObj
+          case Some(pid) =>
+            val dxProj = resolveProject(pid)
+            DxObject.getInstance(dxDataObj.getId, dxProj).asInstanceOf[DxDataObject]
         }
+        alreadyResolved = alreadyResolved + (p -> dxobjWithProj)
+      } else {
+        rest = rest :+ components
+      }
+    }
+    (alreadyResolved, rest)
+  }
+
+  // Describe the names of all the data objects in one batch. This is much more efficient
+  // than submitting object describes one-by-one.
+  def resolveBulk(dxPaths: Seq[String], dxProject: DxProject): Map[String, DxDataObject] = {
+    if (dxPaths.isEmpty) {
+      // avoid an unnessary API call; this is important for unit tests
+      // that do not have a network connection.
+      return Map.empty
     }
 
-    // More accurate types
-    def resolveDxURLRecord(buf: String) : DxRecord = {
-        val dxObj = resolveDxPath(buf)
-        if (!dxObj.isInstanceOf[DxRecord])
-            throw new Exception(s"Found dx:object of the wrong type ${dxObj}")
-        dxObj.asInstanceOf[DxRecord]
+    // peel off objects that have already been resolved
+    val (alreadyResolved, dxPathsToResolve) = triage(dxPaths)
+    if (dxPathsToResolve.isEmpty)
+      return alreadyResolved
+
+    // Limit on number of objects in one API request
+    val slices = dxPathsToResolve.grouped(DXAPI_NUM_OBJECTS_LIMIT).toList
+
+    // iterate on the ranges
+    val resolved = slices.foldLeft(Map.empty[String, DxDataObject]) {
+      case (accu, pathsRange) =>
+        accu ++ submitRequest(pathsRange.toVector, dxProject)
     }
 
-    def resolveDxURLFile(buf: String) : DxFile = {
-        val dxObj = resolveDxPath(buf)
-        if (!dxObj.isInstanceOf[DxFile])
-            throw new Exception(s"Found dx:object of the wrong type ${dxObj}")
-        dxObj.asInstanceOf[DxFile]
+    alreadyResolved ++ resolved
+  }
+
+  def resolveOnePath(dxPath: String, dxProject: DxProject): DxDataObject = {
+    val found: Map[String, DxDataObject] =
+      resolveBulk(Vector(dxPath), dxProject)
+
+    if (found.size == 0)
+      throw new Exception(s"Could not find ${dxPath} in project ${dxProject.getId}")
+    if (found.size > 1)
+      throw new Exception(
+        s"Found more than one dx:object in path ${dxPath}, project=${dxProject.getId}"
+      )
+
+    found.values.head
+  }
+
+  private def resolveDxPath(dxPath: String): DxDataObject = {
+    val components = parse(dxPath)
+    components.projName match {
+      case None =>
+        resolveOnePath(dxPath, DxUtils.dxCrntProject)
+      case Some(pName) =>
+        resolveOnePath(dxPath, resolveProject(pName))
     }
+  }
+
+  // More accurate types
+  def resolveDxURLRecord(buf: String): DxRecord = {
+    val dxObj = resolveDxPath(buf)
+    if (!dxObj.isInstanceOf[DxRecord])
+      throw new Exception(s"Found dx:object of the wrong type ${dxObj}")
+    dxObj.asInstanceOf[DxRecord]
+  }
+
+  def resolveDxURLFile(buf: String): DxFile = {
+    val dxObj = resolveDxPath(buf)
+    if (!dxObj.isInstanceOf[DxFile])
+      throw new Exception(s"Found dx:object of the wrong type ${dxObj}")
+    dxObj.asInstanceOf[DxFile]
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxProject.scala
+++ b/src/main/scala/dxWDL/dx/DxProject.scala
@@ -15,7 +15,10 @@ case class DxProjectDescribe(
     details: Option[JsValue]
 ) extends DxObjectDescribe
 
-case class FolderContents(dataObjects: Vector[DxDataObject], subFolders: Vector[String])
+case class FolderContents(
+    dataObjects: Vector[DxDataObject],
+    subFolders: Vector[String]
+)
 
 // A project is a subtype of a container
 case class DxProject(id: String) extends DxDataObject {
@@ -38,14 +41,29 @@ case class DxProject(id: String) extends DxDataObject {
           DxUtils.dxEnv
         )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
-    val desc = descJs.asJsObject.getFields("id", "name", "created", "modified") match {
-      case Seq(JsString(id), JsString(name), JsNumber(created), JsNumber(modified)) =>
-        DxProjectDescribe(id, name, created.toLong, modified.toLong, None, None)
-      case _ =>
-        throw new Exception(s"malformed JSON ${descJs}")
-    }
+    val desc =
+      descJs.asJsObject.getFields("id", "name", "created", "modified") match {
+        case Seq(
+            JsString(id),
+            JsString(name),
+            JsNumber(created),
+            JsNumber(modified)
+            ) =>
+          DxProjectDescribe(
+            id,
+            name,
+            created.toLong,
+            modified.toLong,
+            None,
+            None
+          )
+        case _ =>
+          throw new Exception(s"malformed JSON ${descJs}")
+      }
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 
@@ -131,7 +149,10 @@ case class DxProject(id: String) extends DxDataObject {
     Utils.ignore(repJs)
   }
 
-  def moveObjects(objs: Vector[DxDataObject], destinationFolder: String): Unit = {
+  def moveObjects(
+      objs: Vector[DxDataObject],
+      destinationFolder: String
+  ): Unit = {
     val request = JsObject(
       "objects" -> JsArray(objs.map { x =>
         JsString(x.id)
@@ -148,7 +169,12 @@ case class DxProject(id: String) extends DxDataObject {
           DxUtils.dxEnv
         )
       case _ if (id.startsWith("project-")) =>
-        DXAPI.projectMove(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+        DXAPI.projectMove(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
       case _ =>
         throw new Exception(s"invalid project id ${id}")
     }

--- a/src/main/scala/dxWDL/dx/DxProject.scala
+++ b/src/main/scala/dxWDL/dx/DxProject.scala
@@ -28,17 +28,17 @@ case class DxProject(id: String) extends DxDataObject {
     val response =
       if (id.startsWith("project-"))
         DXAPI.projectDescribe(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       else
         DXAPI.containerDescribe(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
@@ -50,12 +50,12 @@ case class DxProject(id: String) extends DxDataObject {
             JsNumber(modified)
             ) =>
           DxProjectDescribe(
-            id,
-            name,
-            created.toLong,
-            modified.toLong,
-            None,
-            None
+              id,
+              name,
+              created.toLong,
+              modified.toLong,
+              None,
+              None
           )
         case _ =>
           throw new Exception(s"malformed JSON ${descJs}")
@@ -72,17 +72,17 @@ case class DxProject(id: String) extends DxDataObject {
     val response = id match {
       case _ if (id.startsWith("container-")) =>
         DXAPI.containerListFolder(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ if (id.startsWith("project-")) =>
         DXAPI.projectListFolder(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ =>
         throw new Exception(s"invalid project id ${id}")
@@ -123,24 +123,24 @@ case class DxProject(id: String) extends DxDataObject {
 
   def newFolder(folderPath: String, parents: Boolean): Unit = {
     val request = JsObject(
-      "project" -> JsString(id),
-      "folder" -> JsString(folderPath),
-      "parents" -> (if (parents) JsTrue else JsFalse)
+        "project" -> JsString(id),
+        "folder" -> JsString(folderPath),
+        "parents" -> (if (parents) JsTrue else JsFalse)
     )
     val response = id match {
       case _ if (id.startsWith("container-")) =>
         DXAPI.containerNewFolder(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ if (id.startsWith("project-")) =>
         DXAPI.projectNewFolder(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ =>
         throw new Exception(s"invalid project id ${id}")
@@ -154,26 +154,26 @@ case class DxProject(id: String) extends DxDataObject {
       destinationFolder: String
   ): Unit = {
     val request = JsObject(
-      "objects" -> JsArray(objs.map { x =>
-        JsString(x.id)
-      }.toVector),
-      "folders" -> JsArray(Vector.empty[JsString]),
-      "destination" -> JsString(destinationFolder)
+        "objects" -> JsArray(objs.map { x =>
+          JsString(x.id)
+        }.toVector),
+        "folders" -> JsArray(Vector.empty[JsString]),
+        "destination" -> JsString(destinationFolder)
     )
     val response = id match {
       case _ if (id.startsWith("container-")) =>
         DXAPI.containerMove(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ if (id.startsWith("project-")) =>
         DXAPI.projectMove(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ =>
         throw new Exception(s"invalid project id ${id}")
@@ -189,17 +189,17 @@ case class DxProject(id: String) extends DxDataObject {
     val response = id match {
       case _ if (id.startsWith("container-")) =>
         DXAPI.containerRemoveObjects(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ if (id.startsWith("project-")) =>
         DXAPI.projectRemoveObjects(
-          id,
-          DxUtils.jsonNodeOfJsValue(request),
-          classOf[JsonNode],
-          DxUtils.dxEnv
+            id,
+            DxUtils.jsonNodeOfJsValue(request),
+            classOf[JsonNode],
+            DxUtils.dxEnv
         )
       case _ =>
         throw new Exception(s"invalid project id ${id}")

--- a/src/main/scala/dxWDL/dx/DxProject.scala
+++ b/src/main/scala/dxWDL/dx/DxProject.scala
@@ -6,175 +6,189 @@ import spray.json._
 
 import dxWDL.base.Utils
 
-case class DxProjectDescribe(id : String,
-                             name : String,
-                             created : Long,
-                             modified : Long,
-                             properties : Option[Map[String, String]],
-                             details : Option[JsValue]) extends DxObjectDescribe
+case class DxProjectDescribe(
+    id: String,
+    name: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue]
+) extends DxObjectDescribe
 
-case class FolderContents(dataObjects: Vector[DxDataObject],
-                          subFolders : Vector[String])
-
+case class FolderContents(dataObjects: Vector[DxDataObject], subFolders: Vector[String])
 
 // A project is a subtype of a container
 case class DxProject(id: String) extends DxDataObject {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxProjectDescribe = {
-        val defaultFields = Set(Field.Id,
-                                Field.Name,
-                                Field.Created,
-                                Field.Modified)
-        val request = JsObject("fields" -> DxObject.requestFields(defaultFields))
-        val response =
-            if (id.startsWith("project-"))
-                DXAPI.projectDescribe(id,
-                                      DxUtils.jsonNodeOfJsValue(request),
-                                      classOf[JsonNode],
-                                      DxUtils.dxEnv)
-            else
-                DXAPI.containerDescribe(id,
-                                        DxUtils.jsonNodeOfJsValue(request),
-                                        classOf[JsonNode],
-                                        DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("id", "name", "created", "modified") match {
-            case Seq(JsString(id), JsString(name), JsNumber(created), JsNumber(modified)) =>
-                DxProjectDescribe(id,
-                                  name,
-                                  created.toLong,
-                                  modified.toLong,
-                                  None,
-                                  None)
-            case _ =>
-                throw new Exception(s"malformed JSON ${descJs}")
-        }
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        desc.copy(details = details, properties = props)
+  def describe(fields: Set[Field.Value] = Set.empty): DxProjectDescribe = {
+    val defaultFields = Set(Field.Id, Field.Name, Field.Created, Field.Modified)
+    val request       = JsObject("fields" -> DxObject.requestFields(defaultFields))
+    val response =
+      if (id.startsWith("project-"))
+        DXAPI.projectDescribe(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      else
+        DXAPI.containerDescribe(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc = descJs.asJsObject.getFields("id", "name", "created", "modified") match {
+      case Seq(JsString(id), JsString(name), JsNumber(created), JsNumber(modified)) =>
+        DxProjectDescribe(id, name, created.toLong, modified.toLong, None, None)
+      case _ =>
+        throw new Exception(s"malformed JSON ${descJs}")
     }
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    desc.copy(details = details, properties = props)
+  }
 
-    def listFolder(path : String) : FolderContents = {
-        val request = JsObject("folder" -> JsString(path))
-        val response = id match {
-            case _ if (id.startsWith("container-")) =>
-                DXAPI.containerListFolder(id,
-                                          DxUtils.jsonNodeOfJsValue(request),
-                                          classOf[JsonNode],
-                                          DxUtils.dxEnv)
-            case _  if (id.startsWith("project-")) =>
-                DXAPI.projectListFolder(id,
-                                        DxUtils.jsonNodeOfJsValue(request),
-                                        classOf[JsonNode],
-                                        DxUtils.dxEnv)
-            case _ =>
-                throw new Exception(s"invalid project id ${id}" )
-        }
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-
-        // extract object ids
-        val objsJs = repJs.asJsObject.fields("objects") match {
-            case JsArray(a) => a
-            case _ => throw new Exception("not an array")
-        }
-        val objs = objsJs.map{
-            case JsObject(fields) =>
-                fields.get("id") match {
-                    case Some(JsString(id)) =>
-                        val o = DxObject.getInstance(id, Some(this))
-                        o.asInstanceOf[DxDataObject]
-                    case other =>
-                        throw new Exception(s"malformed json reply ${other}")
-                }
-            case other =>
-                throw new Exception(s"malformed json reply ${other}")
-        }.toVector
-
-        // extract sub folders
-	val subdirsJs = repJs.asJsObject.fields("folders") match {
-            case JsArray(a) => a
-            case _ => throw new Exception("not an array")
-        }
-        val subdirs = subdirsJs.map{
-            case JsString(x) => x
-            case other =>
-                throw new Exception(s"malformed json reply ${other}")
-        }.toVector
-
-        FolderContents(objs, subdirs)
+  def listFolder(path: String): FolderContents = {
+    val request = JsObject("folder" -> JsString(path))
+    val response = id match {
+      case _ if (id.startsWith("container-")) =>
+        DXAPI.containerListFolder(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ if (id.startsWith("project-")) =>
+        DXAPI.projectListFolder(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ =>
+        throw new Exception(s"invalid project id ${id}")
     }
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
 
-    def newFolder(folderPath : String, parents : Boolean) : Unit = {
-        val request = JsObject("project" -> JsString(id),
-                               "folder" -> JsString(folderPath),
-                               "parents" -> (if (parents) JsTrue else JsFalse))
-        val response = id match {
-            case _ if (id.startsWith("container-")) =>
-                DXAPI.containerNewFolder(id,
-                                         DxUtils.jsonNodeOfJsValue(request),
-                                         classOf[JsonNode],
-                                         DxUtils.dxEnv)
-            case _  if (id.startsWith("project-")) =>
-                DXAPI.projectNewFolder(id,
-                                       DxUtils.jsonNodeOfJsValue(request),
-                                       classOf[JsonNode],
-                                       DxUtils.dxEnv)
-            case _ =>
-                throw new Exception(s"invalid project id ${id}" )
-        }
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        Utils.ignore(repJs)
+    // extract object ids
+    val objsJs = repJs.asJsObject.fields("objects") match {
+      case JsArray(a) => a
+      case _          => throw new Exception("not an array")
     }
+    val objs = objsJs.map {
+      case JsObject(fields) =>
+        fields.get("id") match {
+          case Some(JsString(id)) =>
+            val o = DxObject.getInstance(id, Some(this))
+            o.asInstanceOf[DxDataObject]
+          case other =>
+            throw new Exception(s"malformed json reply ${other}")
+        }
+      case other =>
+        throw new Exception(s"malformed json reply ${other}")
+    }.toVector
 
-    def moveObjects(objs: Vector[DxDataObject], destinationFolder : String) : Unit = {
-        val request = JsObject("objects" -> JsArray(objs.map{ x => JsString(x.id) }.toVector),
-                               "folders" -> JsArray(Vector.empty[JsString]),
-                               "destination" -> JsString(destinationFolder))
-        val response = id match {
-            case _ if (id.startsWith("container-")) =>
-                DXAPI.containerMove(id,
-                                    DxUtils.jsonNodeOfJsValue(request),
-                                    classOf[JsonNode],
-                                    DxUtils.dxEnv)
-            case _  if (id.startsWith("project-")) =>
-                DXAPI.projectMove(id,
-                                  DxUtils.jsonNodeOfJsValue(request),
-                                  classOf[JsonNode],
-                                  DxUtils.dxEnv)
-            case _ =>
-                throw new Exception(s"invalid project id ${id}" )
-        }
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        Utils.ignore(repJs)
+    // extract sub folders
+    val subdirsJs = repJs.asJsObject.fields("folders") match {
+      case JsArray(a) => a
+      case _          => throw new Exception("not an array")
     }
+    val subdirs = subdirsJs.map {
+      case JsString(x) => x
+      case other =>
+        throw new Exception(s"malformed json reply ${other}")
+    }.toVector
 
-    def removeObjects(objs : Vector[DxDataObject]) : Unit = {
-        val request = JsObject("objects" -> JsArray(objs.map{ x => JsString(x.id) }.toVector),
-                               "force" -> JsFalse)
-        val response = id match {
-            case _ if (id.startsWith("container-")) =>
-                DXAPI.containerRemoveObjects(id,
-                                             DxUtils.jsonNodeOfJsValue(request),
-                                             classOf[JsonNode],
-                                             DxUtils.dxEnv)
-            case _  if (id.startsWith("project-")) =>
-                DXAPI.projectRemoveObjects(id,
-                                           DxUtils.jsonNodeOfJsValue(request),
-                                           classOf[JsonNode],
-                                           DxUtils.dxEnv)
-            case _ =>
-                throw new Exception(s"invalid project id ${id}" )
-        }
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        Utils.ignore(repJs)
+    FolderContents(objs, subdirs)
+  }
+
+  def newFolder(folderPath: String, parents: Boolean): Unit = {
+    val request = JsObject(
+      "project" -> JsString(id),
+      "folder"  -> JsString(folderPath),
+      "parents" -> (if (parents) JsTrue else JsFalse)
+    )
+    val response = id match {
+      case _ if (id.startsWith("container-")) =>
+        DXAPI.containerNewFolder(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ if (id.startsWith("project-")) =>
+        DXAPI.projectNewFolder(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ =>
+        throw new Exception(s"invalid project id ${id}")
     }
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    Utils.ignore(repJs)
+  }
+
+  def moveObjects(objs: Vector[DxDataObject], destinationFolder: String): Unit = {
+    val request = JsObject(
+      "objects" -> JsArray(objs.map { x =>
+        JsString(x.id)
+      }.toVector),
+      "folders"     -> JsArray(Vector.empty[JsString]),
+      "destination" -> JsString(destinationFolder)
+    )
+    val response = id match {
+      case _ if (id.startsWith("container-")) =>
+        DXAPI.containerMove(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ if (id.startsWith("project-")) =>
+        DXAPI.projectMove(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+      case _ =>
+        throw new Exception(s"invalid project id ${id}")
+    }
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    Utils.ignore(repJs)
+  }
+
+  def removeObjects(objs: Vector[DxDataObject]): Unit = {
+    val request = JsObject("objects" -> JsArray(objs.map { x =>
+      JsString(x.id)
+    }.toVector), "force" -> JsFalse)
+    val response = id match {
+      case _ if (id.startsWith("container-")) =>
+        DXAPI.containerRemoveObjects(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ if (id.startsWith("project-")) =>
+        DXAPI.projectRemoveObjects(
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
+        )
+      case _ =>
+        throw new Exception(s"invalid project id ${id}")
+    }
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    Utils.ignore(repJs)
+  }
 }
 
 object DxProject {
-    def getInstance(id : String) : DxProject = {
-        DxObject.getInstance(id) match {
-             case p : DxProject => p
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a project")
-        }
+  def getInstance(id: String): DxProject = {
+    DxObject.getInstance(id) match {
+      case p: DxProject => p
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a project")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxProject.scala
+++ b/src/main/scala/dxWDL/dx/DxProject.scala
@@ -21,7 +21,7 @@ case class FolderContents(dataObjects: Vector[DxDataObject], subFolders: Vector[
 case class DxProject(id: String) extends DxDataObject {
   def describe(fields: Set[Field.Value] = Set.empty): DxProjectDescribe = {
     val defaultFields = Set(Field.Id, Field.Name, Field.Created, Field.Modified)
-    val request       = JsObject("fields" -> DxObject.requestFields(defaultFields))
+    val request = JsObject("fields" -> DxObject.requestFields(defaultFields))
     val response =
       if (id.startsWith("project-"))
         DXAPI.projectDescribe(
@@ -45,7 +45,7 @@ case class DxProject(id: String) extends DxDataObject {
         throw new Exception(s"malformed JSON ${descJs}")
     }
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 
@@ -106,7 +106,7 @@ case class DxProject(id: String) extends DxDataObject {
   def newFolder(folderPath: String, parents: Boolean): Unit = {
     val request = JsObject(
       "project" -> JsString(id),
-      "folder"  -> JsString(folderPath),
+      "folder" -> JsString(folderPath),
       "parents" -> (if (parents) JsTrue else JsFalse)
     )
     val response = id match {
@@ -136,7 +136,7 @@ case class DxProject(id: String) extends DxDataObject {
       "objects" -> JsArray(objs.map { x =>
         JsString(x.id)
       }.toVector),
-      "folders"     -> JsArray(Vector.empty[JsString]),
+      "folders" -> JsArray(Vector.empty[JsString]),
       "destination" -> JsString(destinationFolder)
     )
     val response = id match {

--- a/src/main/scala/dxWDL/dx/DxRecord.scala
+++ b/src/main/scala/dxWDL/dx/DxRecord.scala
@@ -4,67 +4,60 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxRecordDescribe(project : String,
-                            id  : String,
-                            name : String,
-                            folder: String,
-                            created : Long,
-                            modified : Long,
-                            properties: Option[Map[String, String]],
-                            details : Option[JsValue]) extends DxObjectDescribe
+case class DxRecordDescribe(
+    project: String,
+    id: String,
+    name: String,
+    folder: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue]
+) extends DxObjectDescribe
 
-case class DxRecord(id : String,
-                    project : Option[DxProject]) extends DxDataObject {
-    def describe(fields : Set[Field.Value] = Set.empty) : DxRecordDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Folder,
-                                Field.Created,
-                                Field.Modified)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.recordDescribe(id,
-                                            DxUtils.jsonNodeOfJsValue(request),
-                                            classOf[JsonNode],
-                                            DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id", "name", "folder",
-                                               "created", "modified") match {
-            case Seq(JsString(projectId), JsString(id),
-                     JsString(name), JsString(folder),
-                     JsNumber(created), JsNumber(modified)) =>
-                DxRecordDescribe(projectId,
-                                 id,
-                                 name,
-                                 folder,
-                                 created.toLong,
-                                 modified.toLong,
-                                 None,
-                                 None)
-        }
+case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject {
+  def describe(fields: Set[Field.Value] = Set.empty): DxRecordDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields =
+      Set(Field.Project, Field.Id, Field.Name, Field.Folder, Field.Created, Field.Modified)
+    val allFields = fields ++ defaultFields
+    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val response =
+      DXAPI.recordDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc =
+      descJs.asJsObject.getFields("project", "id", "name", "folder", "created", "modified") match {
+        case Seq(
+            JsString(projectId),
+            JsString(id),
+            JsString(name),
+            JsString(folder),
+            JsNumber(created),
+            JsNumber(modified)
+            ) =>
+          DxRecordDescribe(projectId, id, name, folder, created.toLong, modified.toLong, None, None)
+      }
 
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        desc.copy(details = details, properties = props)
-    }
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    desc.copy(details = details, properties = props)
+  }
 }
 
 object DxRecord {
-    def getInstance(id : String) : DxRecord = {
-         DxObject.getInstance(id) match {
-             case r : DxRecord => r
-             case _ =>
-                 throw new IllegalArgumentException(s"${id} isn't a record")
-         }
+  def getInstance(id: String): DxRecord = {
+    DxObject.getInstance(id) match {
+      case r: DxRecord => r
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a record")
     }
+  }
 
-    def getInstance(id : String, project : DxProject) : DxRecord = {
-        DxObject.getInstance(id, Some(project)) match {
-             case f : DxRecord => f
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a record")
-        }
+  def getInstance(id: String, project: DxProject): DxRecord = {
+    DxObject.getInstance(id, Some(project)) match {
+      case f: DxRecord => f
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a record")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxRecord.scala
+++ b/src/main/scala/dxWDL/dx/DxRecord.scala
@@ -19,14 +19,35 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
   def describe(fields: Set[Field.Value] = Set.empty): DxRecordDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields =
-      Set(Field.Project, Field.Id, Field.Name, Field.Folder, Field.Created, Field.Modified)
+      Set(
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Folder,
+        Field.Created,
+        Field.Modified
+      )
     val allFields = fields ++ defaultFields
-    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(
+      projSpec + ("fields" -> DxObject.requestFields(allFields))
+    )
     val response =
-      DXAPI.recordDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+      DXAPI.recordDescribe(
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
+      )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
-      descJs.asJsObject.getFields("project", "id", "name", "folder", "created", "modified") match {
+      descJs.asJsObject.getFields(
+        "project",
+        "id",
+        "name",
+        "folder",
+        "created",
+        "modified"
+      ) match {
         case Seq(
             JsString(projectId),
             JsString(id),
@@ -35,11 +56,22 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
             JsNumber(created),
             JsNumber(modified)
             ) =>
-          DxRecordDescribe(projectId, id, name, folder, created.toLong, modified.toLong, None, None)
+          DxRecordDescribe(
+            projectId,
+            id,
+            name,
+            folder,
+            created.toLong,
+            modified.toLong,
+            None,
+            None
+          )
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxRecord.scala
+++ b/src/main/scala/dxWDL/dx/DxRecord.scala
@@ -21,7 +21,7 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
     val defaultFields =
       Set(Field.Project, Field.Id, Field.Name, Field.Folder, Field.Created, Field.Modified)
     val allFields = fields ++ defaultFields
-    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
     val response =
       DXAPI.recordDescribe(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
@@ -39,7 +39,7 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
       }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
     desc.copy(details = details, properties = props)
   }
 }

--- a/src/main/scala/dxWDL/dx/DxRecord.scala
+++ b/src/main/scala/dxWDL/dx/DxRecord.scala
@@ -20,33 +20,33 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields =
       Set(
-        Field.Project,
-        Field.Id,
-        Field.Name,
-        Field.Folder,
-        Field.Created,
-        Field.Modified
+          Field.Project,
+          Field.Id,
+          Field.Name,
+          Field.Folder,
+          Field.Created,
+          Field.Modified
       )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec + ("fields" -> DxObject.requestFields(allFields))
+        projSpec + ("fields" -> DxObject.requestFields(allFields))
     )
     val response =
       DXAPI.recordDescribe(
-        id,
-        DxUtils.jsonNodeOfJsValue(request),
-        classOf[JsonNode],
-        DxUtils.dxEnv
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
       )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc =
       descJs.asJsObject.getFields(
-        "project",
-        "id",
-        "name",
-        "folder",
-        "created",
-        "modified"
+          "project",
+          "id",
+          "name",
+          "folder",
+          "created",
+          "modified"
       ) match {
         case Seq(
             JsString(projectId),
@@ -57,14 +57,14 @@ case class DxRecord(id: String, project: Option[DxProject]) extends DxDataObject
             JsNumber(modified)
             ) =>
           DxRecordDescribe(
-            projectId,
-            id,
-            name,
-            folder,
-            created.toLong,
-            modified.toLong,
-            None,
-            None
+              projectId,
+              id,
+              name,
+              folder,
+              created.toLong,
+              modified.toLong,
+              None,
+              None
           )
       }
 

--- a/src/main/scala/dxWDL/dx/DxUtils.scala
+++ b/src/main/scala/dxWDL/dx/DxUtils.scala
@@ -10,367 +10,373 @@ import wom.types._
 import dxWDL.base.{AppInternalException, Utils, Verbose}
 
 object DxUtils {
-    private val DOWNLOAD_RETRY_LIMIT = 3
-    private val UPLOAD_RETRY_LIMIT = 3
+  private val DOWNLOAD_RETRY_LIMIT = 3
+  private val UPLOAD_RETRY_LIMIT   = 3
 
-    lazy val dxEnv = DXEnvironment.create()
-    lazy val dxCrntProject = DxProject(dxEnv.getProjectContext())
+  lazy val dxEnv         = DXEnvironment.create()
+  lazy val dxCrntProject = DxProject(dxEnv.getProjectContext())
 
-    def isDxId(objName : String) : Boolean = {
-        objName match {
-            case _ if objName.startsWith("applet-") => true
-            case _ if objName.startsWith("file-") => true
-            case _  if objName.startsWith("record-") => true
-            case _ if objName.startsWith("workflow-") => true
-            case _ => false
+  def isDxId(objName: String): Boolean = {
+    objName match {
+      case _ if objName.startsWith("applet-")   => true
+      case _ if objName.startsWith("file-")     => true
+      case _ if objName.startsWith("record-")   => true
+      case _ if objName.startsWith("workflow-") => true
+      case _                                    => false
+    }
+  }
+
+  def dxDataObjectToURL(dxObj: DxDataObject): String = {
+    s"${Utils.DX_URL_PREFIX}${dxObj.id}"
+  }
+
+  // Is this a WDL type that maps to a native DX type?
+  def isNativeDxType(wdlType: WomType): Boolean = {
+    wdlType match {
+      // optional dx:native types
+      case WomOptionalType(WomBooleanType)           => true
+      case WomOptionalType(WomIntegerType)           => true
+      case WomOptionalType(WomFloatType)             => true
+      case WomOptionalType(WomStringType)            => true
+      case WomOptionalType(WomSingleFileType)        => true
+      case WomMaybeEmptyArrayType(WomBooleanType)    => true
+      case WomMaybeEmptyArrayType(WomIntegerType)    => true
+      case WomMaybeEmptyArrayType(WomFloatType)      => true
+      case WomMaybeEmptyArrayType(WomStringType)     => true
+      case WomMaybeEmptyArrayType(WomSingleFileType) => true
+
+      // compulsory dx:native types
+      case WomBooleanType                          => true
+      case WomIntegerType                          => true
+      case WomFloatType                            => true
+      case WomStringType                           => true
+      case WomSingleFileType                       => true
+      case WomNonEmptyArrayType(WomBooleanType)    => true
+      case WomNonEmptyArrayType(WomIntegerType)    => true
+      case WomNonEmptyArrayType(WomFloatType)      => true
+      case WomNonEmptyArrayType(WomStringType)     => true
+      case WomNonEmptyArrayType(WomSingleFileType) => true
+
+      // A tricky, but important case, is `Array[File]+?`. This
+      // cannot be converted into a dx file array, unfortunately.
+      case _ => false
+    }
+  }
+
+  private def isDxFile(jsValue: JsValue): Boolean = {
+    jsValue match {
+      case JsObject(fields) =>
+        fields.get("$dnanexus_link") match {
+          case Some(JsString(s)) if s.startsWith("file-") => true
+          case Some(JsObject(linkFields)) =>
+            linkFields.get("id") match {
+              case Some(JsString(s)) if s.startsWith("file-") => true
+              case _                                          => false
+            }
+          case _ => false
         }
+      case _ => false
     }
+  }
 
-    def dxDataObjectToURL(dxObj: DxDataObject) : String = {
-        s"${Utils.DX_URL_PREFIX}${dxObj.id}"
+  // Search through a JSON value for all the dx:file links inside it. Returns
+  // those as a vector.
+  def findDxFiles(jsValue: JsValue): Vector[DxFile] = {
+    jsValue match {
+      case JsBoolean(_) | JsNumber(_) | JsString(_) | JsNull =>
+        Vector.empty[DxFile]
+      case JsObject(_) if isDxFile(jsValue) =>
+        Vector(dxFileFromJsValue(jsValue))
+      case JsObject(fields) =>
+        fields.map { case (_, v) => findDxFiles(v) }.toVector.flatten
+      case JsArray(elems) =>
+        elems.map(e => findDxFiles(e)).flatten
     }
+  }
 
-    // Is this a WDL type that maps to a native DX type?
-    def isNativeDxType(wdlType: WomType) : Boolean = {
-        wdlType match {
-            // optional dx:native types
-            case WomOptionalType(WomBooleanType) => true
-            case WomOptionalType(WomIntegerType) => true
-            case WomOptionalType(WomFloatType) => true
-            case WomOptionalType(WomStringType) => true
-            case WomOptionalType(WomSingleFileType) => true
-            case WomMaybeEmptyArrayType(WomBooleanType) => true
-            case WomMaybeEmptyArrayType(WomIntegerType) => true
-            case WomMaybeEmptyArrayType(WomFloatType) => true
-            case WomMaybeEmptyArrayType(WomStringType) => true
-            case WomMaybeEmptyArrayType(WomSingleFileType) => true
+  // Convert from spray-json to jackson JsonNode
+  // Used to convert into the JSON datatype used by dxjava
+  private val objMapper: ObjectMapper = new ObjectMapper()
 
-                // compulsory dx:native types
-            case WomBooleanType => true
-            case WomIntegerType => true
-            case WomFloatType => true
-            case WomStringType => true
-            case WomSingleFileType => true
-            case WomNonEmptyArrayType(WomBooleanType) => true
-            case WomNonEmptyArrayType(WomIntegerType) => true
-            case WomNonEmptyArrayType(WomFloatType) => true
-            case WomNonEmptyArrayType(WomStringType) => true
-            case WomNonEmptyArrayType(WomSingleFileType) => true
+  def jsonNodeOfJsValue(jsValue: JsValue): JsonNode = {
+    val s: String = jsValue.prettyPrint
+    objMapper.readTree(s)
+  }
 
-            // A tricky, but important case, is `Array[File]+?`. This
-            // cannot be converted into a dx file array, unfortunately.
-            case _ => false
-        }
-    }
+  // Convert from jackson JsonNode to spray-json
+  def jsValueOfJsonNode(jsNode: JsonNode): JsValue = {
+    jsNode.toString().parseJson
+  }
 
-    private def isDxFile(jsValue: JsValue): Boolean = {
-        jsValue match {
-            case JsObject(fields) =>
-                fields.get("$dnanexus_link") match {
-                    case Some(JsString(s)) if s.startsWith("file-") => true
-                    case Some(JsObject(linkFields)) =>
-                        linkFields.get("id") match {
-                            case Some(JsString(s)) if s.startsWith("file-") => true
-                            case _ => false
-                        }
-                    case _ => false
-                }
-            case  _ => false
-        }
-    }
-
-    // Search through a JSON value for all the dx:file links inside it. Returns
-    // those as a vector.
-    def findDxFiles(jsValue: JsValue) : Vector[DxFile] = {
-        jsValue match {
-            case JsBoolean(_) | JsNumber(_) | JsString(_) | JsNull =>
-                Vector.empty[DxFile]
-            case JsObject(_) if isDxFile(jsValue) =>
-                Vector(dxFileFromJsValue(jsValue))
-            case JsObject(fields) =>
-                fields.map{ case(_,v) => findDxFiles(v) }.toVector.flatten
-            case JsArray(elems) =>
-                elems.map(e => findDxFiles(e)).flatten
-        }
-    }
-
-    // Convert from spray-json to jackson JsonNode
-    // Used to convert into the JSON datatype used by dxjava
-    private val objMapper : ObjectMapper = new ObjectMapper()
-
-    def jsonNodeOfJsValue(jsValue : JsValue) : JsonNode = {
-        val s : String = jsValue.prettyPrint
-        objMapper.readTree(s)
-    }
-
-    // Convert from jackson JsonNode to spray-json
-    def jsValueOfJsonNode(jsNode : JsonNode) : JsValue = {
-        jsNode.toString().parseJson
-    }
-
-
-    // Create a dx link to a field in an execution. The execution could
-    // be a job or an analysis.
-    def makeEBOR(dxExec: DxExecution, fieldName: String) : JsValue = {
-        if (dxExec.isInstanceOf[DxJob]) {
-            JsObject("$dnanexus_link" -> JsObject(
-                         "field" -> JsString(fieldName),
-                         "job" -> JsString(dxExec.id)))
-        } else if (dxExec.isInstanceOf[DxAnalysis]) {
-            JsObject("$dnanexus_link" -> JsObject(
-                         "field" -> JsString(fieldName),
-                         "analysis" -> JsString(dxExec.id)))
-        } else {
-            throw new Exception(s"makeEBOR can't work with ${dxExec.id}")
-        }
-    }
-
-    def runSubJob(entryPoint:String,
-                  instanceType:Option[String],
-                  inputs:JsValue,
-                  dependsOn: Vector[DxExecution],
-                  verbose: Boolean) : DxJob = {
-        val fields = Map(
-            "function" -> JsString(entryPoint),
-            "input" -> inputs
+  // Create a dx link to a field in an execution. The execution could
+  // be a job or an analysis.
+  def makeEBOR(dxExec: DxExecution, fieldName: String): JsValue = {
+    if (dxExec.isInstanceOf[DxJob]) {
+      JsObject(
+        "$dnanexus_link" -> JsObject("field" -> JsString(fieldName), "job" -> JsString(dxExec.id))
+      )
+    } else if (dxExec.isInstanceOf[DxAnalysis]) {
+      JsObject(
+        "$dnanexus_link" -> JsObject(
+          "field"    -> JsString(fieldName),
+          "analysis" -> JsString(dxExec.id)
         )
-        val instanceFields = instanceType match {
-            case None => Map.empty
-            case Some(iType) =>
-                Map("systemRequirements" -> JsObject(
-                        entryPoint -> JsObject("instanceType" -> JsString(iType))
-                    ))
-        }
-        val dependsFields =
-            if (dependsOn.isEmpty) {
-                Map.empty
-            } else {
-                val execIds = dependsOn.map{ dxExec => JsString(dxExec.id) }.toVector
-                Map("dependsOn" -> JsArray(execIds))
-            }
-        val req = JsObject(fields ++ instanceFields ++ dependsFields)
-        Utils.appletLog(verbose, s"subjob request=${req.prettyPrint}")
+      )
+    } else {
+      throw new Exception(s"makeEBOR can't work with ${dxExec.id}")
+    }
+  }
 
-        val retval: JsonNode = DXAPI.jobNew(jsonNodeOfJsValue(req), classOf[JsonNode])
-        val info: JsValue =  jsValueOfJsonNode(retval)
-        val id:String = info.asJsObject.fields.get("id") match {
-            case Some(JsString(x)) => x
-            case _ => throw new AppInternalException(
-                s"Bad format returned from jobNew ${info.prettyPrint}")
+  def runSubJob(
+      entryPoint: String,
+      instanceType: Option[String],
+      inputs: JsValue,
+      dependsOn: Vector[DxExecution],
+      verbose: Boolean
+  ): DxJob = {
+    val fields = Map(
+      "function" -> JsString(entryPoint),
+      "input"    -> inputs
+    )
+    val instanceFields = instanceType match {
+      case None => Map.empty
+      case Some(iType) =>
+        Map(
+          "systemRequirements" -> JsObject(
+            entryPoint -> JsObject("instanceType" -> JsString(iType))
+          )
+        )
+    }
+    val dependsFields =
+      if (dependsOn.isEmpty) {
+        Map.empty
+      } else {
+        val execIds = dependsOn.map { dxExec =>
+          JsString(dxExec.id)
+        }.toVector
+        Map("dependsOn" -> JsArray(execIds))
+      }
+    val req = JsObject(fields ++ instanceFields ++ dependsFields)
+    Utils.appletLog(verbose, s"subjob request=${req.prettyPrint}")
+
+    val retval: JsonNode = DXAPI.jobNew(jsonNodeOfJsValue(req), classOf[JsonNode])
+    val info: JsValue    = jsValueOfJsonNode(retval)
+    val id: String = info.asJsObject.fields.get("id") match {
+      case Some(JsString(x)) => x
+      case _ =>
+        throw new AppInternalException(s"Bad format returned from jobNew ${info.prettyPrint}")
+    }
+    DxJob(id)
+  }
+
+  // describe a project, and extract fields that not currently available
+  // through dxjava.
+  def projectDescribeExtraInfo(dxProject: DxProject): (String, String) = {
+    val rep           = DXAPI.projectDescribe(dxProject.id, classOf[JsonNode])
+    val jso: JsObject = jsValueOfJsonNode(rep).asJsObject
+
+    val billTo = jso.fields.get("billTo") match {
+      case Some(JsString(x)) => x
+      case _                 => throw new Exception(s"Failed to get billTo from project ${dxProject.id}")
+    }
+    val region = jso.fields.get("region") match {
+      case Some(JsString(x)) => x
+      case _                 => throw new Exception(s"Failed to get region from project ${dxProject.id}")
+    }
+    (billTo, region)
+  }
+
+  // Parse a dnanexus file descriptor. Examples:
+  //
+  // "$dnanexus_link": {
+  //    "project": "project-BKJfY1j0b06Z4y8PX8bQ094f",
+  //    "id": "file-BKQGkgQ0b06xG5560GGQ001B"
+  //   }
+  //
+  //  {"$dnanexus_link": "file-F0J6JbQ0ZvgVz1J9q5qKfkqP"}
+  //
+  def dxFileFromJsValue(jsValue: JsValue): DxFile = {
+    val innerObj = jsValue match {
+      case JsObject(fields) =>
+        fields.get("$dnanexus_link") match {
+          case None    => throw new AppInternalException(s"Non-dxfile json $jsValue")
+          case Some(x) => x
         }
-        DxJob(id)
+      case _ =>
+        throw new AppInternalException(s"Non-dxfile json $jsValue")
     }
 
-    // describe a project, and extract fields that not currently available
-    // through dxjava.
-    def projectDescribeExtraInfo(dxProject: DxProject) : (String,String) = {
-        val rep = DXAPI.projectDescribe(dxProject.id, classOf[JsonNode])
-        val jso:JsObject = jsValueOfJsonNode(rep).asJsObject
-
-        val billTo = jso.fields.get("billTo") match {
-            case Some(JsString(x)) => x
-            case _ => throw new Exception(
-                s"Failed to get billTo from project ${dxProject.id}")
+    val (fid, projId): (String, Option[String]) = innerObj match {
+      case JsString(fid) =>
+        // We just have a file-id
+        (fid, None)
+      case JsObject(linkFields) =>
+        // file-id and project-id
+        val fid =
+          linkFields.get("id") match {
+            case Some(JsString(s)) => s
+            case _                 => throw new AppInternalException(s"No file ID found in $jsValue")
+          }
+        linkFields.get("project") match {
+          case Some(JsString(pid: String)) => (fid, Some(pid))
+          case _                           => (fid, None)
         }
-        val region = jso.fields.get("region") match {
-            case Some(JsString(x)) => x
-            case _ => throw new Exception(
-                s"Failed to get region from project ${dxProject.id}")
-        }
-        (billTo,region)
+      case _ =>
+        throw new AppInternalException(s"Could not parse a dxlink from $innerObj")
     }
 
+    projId match {
+      case None      => DxFile(fid, None)
+      case Some(pid) => DxFile(fid, Some(DxProject(pid)))
+    }
+  }
 
-    // Parse a dnanexus file descriptor. Examples:
-    //
-    // "$dnanexus_link": {
-    //    "project": "project-BKJfY1j0b06Z4y8PX8bQ094f",
-    //    "id": "file-BKQGkgQ0b06xG5560GGQ001B"
-    //   }
-    //
-    //  {"$dnanexus_link": "file-F0J6JbQ0ZvgVz1J9q5qKfkqP"}
-    //
-    def dxFileFromJsValue(jsValue : JsValue) : DxFile = {
-        val innerObj = jsValue match {
-            case JsObject(fields) =>
-                fields.get("$dnanexus_link") match {
-                    case None => throw new AppInternalException(s"Non-dxfile json $jsValue")
-                    case Some(x) => x
-                }
-            case  _ =>
-                throw new AppInternalException(s"Non-dxfile json $jsValue")
-        }
+  def dxFileToJsValue(dxFile: DxFile): JsValue = {
+    dxFile.getLinkAsJson
+  }
 
-        val (fid, projId) : (String, Option[String]) = innerObj match {
-            case JsString(fid) =>
-                // We just have a file-id
-                (fid, None)
-            case JsObject(linkFields) =>
-                // file-id and project-id
-                val fid =
-                    linkFields.get("id") match {
-                        case Some(JsString(s)) => s
-                        case _ => throw new AppInternalException(s"No file ID found in $jsValue")
-                    }
-                linkFields.get("project") match {
-                    case Some(JsString(pid : String)) => (fid, Some(pid))
-                    case _ => (fid, None)
-                }
-            case _ =>
-                throw new AppInternalException(s"Could not parse a dxlink from $innerObj")
-        }
+  // copy asset to local project, if it isn't already here.
+  def cloneAsset(
+      assetRecord: DxRecord,
+      dxProject: DxProject,
+      pkgName: String,
+      rmtProject: DxProject,
+      verbose: Verbose
+  ): Unit = {
+    if (dxProject == rmtProject) {
+      Utils.trace(
+        verbose.on,
+        s"The asset ${pkgName} is from this project ${rmtProject.id}, no need to clone"
+      )
+      return
+    }
+    Utils.trace(verbose.on, s"The asset ${pkgName} is from a different project ${rmtProject.id}")
 
-        projId match {
-            case None => DxFile(fid, None)
-            case Some(pid) => DxFile(fid, Some(DxProject(pid)))
-        }
+    // clone
+    val req = JsObject(
+      "objects"     -> JsArray(JsString(assetRecord.id)),
+      "project"     -> JsString(dxProject.id),
+      "destination" -> JsString("/")
+    )
+    val rep            = DXAPI.projectClone(rmtProject.id, jsonNodeOfJsValue(req), classOf[JsonNode])
+    val repJs: JsValue = jsValueOfJsonNode(rep)
+
+    val exists = repJs.asJsObject.fields.get("exists") match {
+      case None => throw new Exception("API call did not returnd an exists field")
+      case Some(JsArray(x)) =>
+        x.map {
+          case JsString(id) => id
+          case _            => throw new Exception("bad type, not a string")
+        }.toVector
+      case other => throw new Exception(s"API call returned invalid exists field")
+    }
+    val existingRecords = exists.filter(_.startsWith("record-"))
+    existingRecords.size match {
+      case 0 =>
+        val localAssetRecord = DxRecord(assetRecord.id, None)
+        Utils.trace(verbose.on, s"Created ${localAssetRecord.id} pointing to asset ${pkgName}")
+      case 1 =>
+        Utils.trace(verbose.on, s"The project already has a record pointing to asset ${pkgName}")
+      case _ =>
+        throw new Exception(s"clone returned too many existing records ${exists}")
+    }
+  }
+
+  // download a file from the platform to a path on the local disk. Use
+  // 'dx download' as a separate process.
+  //
+  // Note: this function assumes that the target path does not exist yet
+  def downloadFile(path: Path, dxfile: DxFile, verbose: Boolean): Unit = {
+    def downloadOneFile(path: Path, dxfile: DxFile, counter: Int): Boolean = {
+      val fid = dxfile.id
+      try {
+        // Use dx download. Quote the path, because it may contains spaces.
+        val dxDownloadCmd    = s"""dx download ${fid} -o "${path.toString()}" """
+        val (outmsg, errmsg) = Utils.execCommand(dxDownloadCmd, None)
+        true
+      } catch {
+        case e: Throwable =>
+          if (counter < DOWNLOAD_RETRY_LIMIT)
+            false
+          else throw e
+      }
+    }
+    val dir = path.getParent()
+    if (dir != null) {
+      if (!Files.exists(dir))
+        Files.createDirectories(dir)
+    }
+    var rc      = false
+    var counter = 0
+    while (!rc && counter < DOWNLOAD_RETRY_LIMIT) {
+      Utils.appletLog(verbose, s"downloading file ${path.toString} (try=${counter})")
+      rc = downloadOneFile(path, dxfile, counter)
+      counter = counter + 1
+    }
+    if (!rc)
+      throw new Exception(s"Failure to download file ${path}")
+  }
+
+  // Upload a local file to the platform, and return a json link.
+  // Use 'dx upload' as a separate process.
+  def uploadFile(path: Path, verbose: Boolean): DxFile = {
+    if (!Files.exists(path))
+      throw new AppInternalException(s"Output file ${path.toString} is missing")
+    def uploadOneFile(path: Path, counter: Int): Option[String] = {
+      try {
+        // shell out to dx upload. We need to quote the path, because it may contain
+        // spaces
+        val dxUploadCmd = s"""dx upload "${path.toString}" --brief"""
+        Utils.appletLog(verbose, s"--  ${dxUploadCmd}")
+        val (outmsg, errmsg) = Utils.execCommand(dxUploadCmd, None)
+        if (!outmsg.startsWith("file-"))
+          return None
+        Some(outmsg.trim())
+      } catch {
+        case e: Throwable =>
+          if (counter < UPLOAD_RETRY_LIMIT)
+            None
+          else throw e
+      }
     }
 
-    def dxFileToJsValue(dxFile: DxFile) : JsValue = {
-        dxFile.getLinkAsJson
+    var counter = 0
+    while (counter < UPLOAD_RETRY_LIMIT) {
+      Utils.appletLog(verbose, s"upload file ${path.toString} (try=${counter})")
+      uploadOneFile(path, counter) match {
+        case Some(fid) =>
+          return DxFile(fid, None)
+        case None => ()
+      }
+      counter = counter + 1
     }
+    throw new Exception(s"Failure to upload file ${path}")
+  }
 
-    // copy asset to local project, if it isn't already here.
-    def cloneAsset(assetRecord: DxRecord,
-                   dxProject: DxProject,
-                   pkgName: String,
-                   rmtProject: DxProject,
-                   verbose: Verbose) : Unit = {
-        if (dxProject == rmtProject) {
-            Utils.trace(verbose.on, s"The asset ${pkgName} is from this project ${rmtProject.id}, no need to clone")
-            return
-        }
-        Utils.trace(verbose.on, s"The asset ${pkgName} is from a different project ${rmtProject.id}")
-
-        // clone
-        val req = JsObject( "objects" -> JsArray(JsString(assetRecord.id)),
-                            "project" -> JsString(dxProject.id),
-                            "destination" -> JsString("/"))
-        val rep = DXAPI.projectClone(rmtProject.id,
-                                     jsonNodeOfJsValue(req),
-                                     classOf[JsonNode])
-        val repJs:JsValue = jsValueOfJsonNode(rep)
-
-        val exists = repJs.asJsObject.fields.get("exists") match {
-            case None => throw new Exception("API call did not returnd an exists field")
-            case Some(JsArray(x)) => x.map {
-                case JsString(id) => id
-                case _ => throw new Exception("bad type, not a string")
-            }.toVector
-            case other => throw new Exception(s"API call returned invalid exists field")
-        }
-        val existingRecords = exists.filter(_.startsWith("record-"))
-        existingRecords.size match {
-            case 0 =>
-                val localAssetRecord = DxRecord(assetRecord.id, None)
-                Utils.trace(verbose.on, s"Created ${localAssetRecord.id} pointing to asset ${pkgName}")
-            case 1 =>
-                Utils.trace(verbose.on, s"The project already has a record pointing to asset ${pkgName}")
-            case _ =>
-                throw new Exception(s"clone returned too many existing records ${exists}")
-        }
+  private def silentFileDelete(p: Path): Unit = {
+    try {
+      Files.delete(p)
+    } catch {
+      case e: Throwable => ()
     }
+  }
 
+  // Read the contents of a platform file into a string
+  def downloadString(dxFile: DxFile, verbose: Boolean): String = {
+    // We don't want to use the dxjava implementation
+    //val bytes = dxFile.downloadBytes()
+    //new String(bytes, StandardCharsets.UTF_8)
 
-    // download a file from the platform to a path on the local disk. Use
-    // 'dx download' as a separate process.
-    //
-    // Note: this function assumes that the target path does not exist yet
-    def downloadFile(path: Path,
-                     dxfile: DxFile,
-                     verbose: Boolean) : Unit = {
-        def downloadOneFile(path: Path, dxfile: DxFile, counter: Int) : Boolean = {
-            val fid = dxfile.id
-            try {
-                // Use dx download. Quote the path, because it may contains spaces.
-                val dxDownloadCmd = s"""dx download ${fid} -o "${path.toString()}" """
-                val (outmsg, errmsg) = Utils.execCommand(dxDownloadCmd, None)
-                true
-            } catch {
-                case e: Throwable =>
-                    if (counter < DOWNLOAD_RETRY_LIMIT)
-                        false
-                    else throw e
-            }
-        }
-        val dir = path.getParent()
-        if (dir != null) {
-            if (!Files.exists(dir))
-                Files.createDirectories(dir)
-        }
-        var rc = false
-        var counter = 0
-        while (!rc && counter < DOWNLOAD_RETRY_LIMIT) {
-            Utils.appletLog(verbose, s"downloading file ${path.toString} (try=${counter})")
-            rc = downloadOneFile(path, dxfile, counter)
-            counter = counter + 1
-        }
-        if (!rc)
-            throw new Exception(s"Failure to download file ${path}")
-    }
+    // We don't want to use "dx cat" because it doesn't validate the checksum.
+    //val (outmsg, errmsg) = Utils.execCommand(s"dx cat ${dxFile.id}")
+    //outmsg
 
-    // Upload a local file to the platform, and return a json link.
-    // Use 'dx upload' as a separate process.
-    def uploadFile(path: Path,
-                   verbose: Boolean) : DxFile = {
-        if (!Files.exists(path))
-            throw new AppInternalException(s"Output file ${path.toString} is missing")
-        def uploadOneFile(path: Path, counter: Int) : Option[String] = {
-            try {
-                // shell out to dx upload. We need to quote the path, because it may contain
-                // spaces
-                val dxUploadCmd = s"""dx upload "${path.toString}" --brief"""
-                Utils.appletLog(verbose, s"--  ${dxUploadCmd}")
-                val (outmsg, errmsg) = Utils.execCommand(dxUploadCmd, None)
-                if (!outmsg.startsWith("file-"))
-                    return None
-                Some(outmsg.trim())
-            } catch {
-                case e: Throwable =>
-                    if (counter < UPLOAD_RETRY_LIMIT)
-                        None
-                    else throw e
-            }
-        }
-
-        var counter = 0
-        while (counter < UPLOAD_RETRY_LIMIT) {
-            Utils.appletLog(verbose, s"upload file ${path.toString} (try=${counter})")
-            uploadOneFile(path, counter) match {
-                case Some(fid) =>
-                    return DxFile(fid, None)
-                case None => ()
-            }
-            counter = counter + 1
-        }
-        throw new Exception(s"Failure to upload file ${path}")
-    }
-
-    private def silentFileDelete(p : Path) : Unit = {
-        try {
-            Files.delete(p)
-        } catch {
-            case e : Throwable => ()
-        }
-    }
-
-    // Read the contents of a platform file into a string
-    def downloadString(dxFile: DxFile,
-                       verbose: Boolean) : String = {
-        // We don't want to use the dxjava implementation
-        //val bytes = dxFile.downloadBytes()
-        //new String(bytes, StandardCharsets.UTF_8)
-
-        // We don't want to use "dx cat" because it doesn't validate the checksum.
-        //val (outmsg, errmsg) = Utils.execCommand(s"dx cat ${dxFile.id}")
-        //outmsg
-
-        // create a temporary file, and write the contents into it.
-        val tempFi : Path = Files.createTempFile(s"${dxFile.id}", ".tmp")
-        silentFileDelete(tempFi)
-        downloadFile(tempFi, dxFile, verbose)
-        val content = Utils.readFileContent(tempFi)
-        silentFileDelete(tempFi)
-        content
-    }
+    // create a temporary file, and write the contents into it.
+    val tempFi: Path = Files.createTempFile(s"${dxFile.id}", ".tmp")
+    silentFileDelete(tempFi)
+    downloadFile(tempFi, dxFile, verbose)
+    val content = Utils.readFileContent(tempFi)
+    silentFileDelete(tempFi)
+    content
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxUtils.scala
+++ b/src/main/scala/dxWDL/dx/DxUtils.scala
@@ -113,17 +113,17 @@ object DxUtils {
   def makeEBOR(dxExec: DxExecution, fieldName: String): JsValue = {
     if (dxExec.isInstanceOf[DxJob]) {
       JsObject(
-        "$dnanexus_link" -> JsObject(
-          "field" -> JsString(fieldName),
-          "job" -> JsString(dxExec.id)
-        )
+          "$dnanexus_link" -> JsObject(
+              "field" -> JsString(fieldName),
+              "job" -> JsString(dxExec.id)
+          )
       )
     } else if (dxExec.isInstanceOf[DxAnalysis]) {
       JsObject(
-        "$dnanexus_link" -> JsObject(
-          "field" -> JsString(fieldName),
-          "analysis" -> JsString(dxExec.id)
-        )
+          "$dnanexus_link" -> JsObject(
+              "field" -> JsString(fieldName),
+              "analysis" -> JsString(dxExec.id)
+          )
       )
     } else {
       throw new Exception(s"makeEBOR can't work with ${dxExec.id}")
@@ -138,16 +138,16 @@ object DxUtils {
       verbose: Boolean
   ): DxJob = {
     val fields = Map(
-      "function" -> JsString(entryPoint),
-      "input" -> inputs
+        "function" -> JsString(entryPoint),
+        "input" -> inputs
     )
     val instanceFields = instanceType match {
       case None => Map.empty
       case Some(iType) =>
         Map(
-          "systemRequirements" -> JsObject(
-            entryPoint -> JsObject("instanceType" -> JsString(iType))
-          )
+            "systemRequirements" -> JsObject(
+                entryPoint -> JsObject("instanceType" -> JsString(iType))
+            )
         )
     }
     val dependsFields =
@@ -169,7 +169,7 @@ object DxUtils {
       case Some(JsString(x)) => x
       case _ =>
         throw new AppInternalException(
-          s"Bad format returned from jobNew ${info.prettyPrint}"
+            s"Bad format returned from jobNew ${info.prettyPrint}"
         )
     }
     DxJob(id)
@@ -185,14 +185,14 @@ object DxUtils {
       case Some(JsString(x)) => x
       case _ =>
         throw new Exception(
-          s"Failed to get billTo from project ${dxProject.id}"
+            s"Failed to get billTo from project ${dxProject.id}"
         )
     }
     val region = jso.fields.get("region") match {
       case Some(JsString(x)) => x
       case _ =>
         throw new Exception(
-          s"Failed to get region from project ${dxProject.id}"
+            s"Failed to get region from project ${dxProject.id}"
         )
     }
     (billTo, region)
@@ -237,7 +237,7 @@ object DxUtils {
         }
       case _ =>
         throw new AppInternalException(
-          s"Could not parse a dxlink from $innerObj"
+            s"Could not parse a dxlink from $innerObj"
         )
     }
 
@@ -261,26 +261,26 @@ object DxUtils {
   ): Unit = {
     if (dxProject == rmtProject) {
       Utils.trace(
-        verbose.on,
-        s"The asset ${pkgName} is from this project ${rmtProject.id}, no need to clone"
+          verbose.on,
+          s"The asset ${pkgName} is from this project ${rmtProject.id}, no need to clone"
       )
       return
     }
     Utils.trace(
-      verbose.on,
-      s"The asset ${pkgName} is from a different project ${rmtProject.id}"
+        verbose.on,
+        s"The asset ${pkgName} is from a different project ${rmtProject.id}"
     )
 
     // clone
     val req = JsObject(
-      "objects" -> JsArray(JsString(assetRecord.id)),
-      "project" -> JsString(dxProject.id),
-      "destination" -> JsString("/")
+        "objects" -> JsArray(JsString(assetRecord.id)),
+        "project" -> JsString(dxProject.id),
+        "destination" -> JsString("/")
     )
     val rep = DXAPI.projectClone(
-      rmtProject.id,
-      jsonNodeOfJsValue(req),
-      classOf[JsonNode]
+        rmtProject.id,
+        jsonNodeOfJsValue(req),
+        classOf[JsonNode]
     )
     val repJs: JsValue = jsValueOfJsonNode(rep)
 
@@ -300,17 +300,17 @@ object DxUtils {
       case 0 =>
         val localAssetRecord = DxRecord(assetRecord.id, None)
         Utils.trace(
-          verbose.on,
-          s"Created ${localAssetRecord.id} pointing to asset ${pkgName}"
+            verbose.on,
+            s"Created ${localAssetRecord.id} pointing to asset ${pkgName}"
         )
       case 1 =>
         Utils.trace(
-          verbose.on,
-          s"The project already has a record pointing to asset ${pkgName}"
+            verbose.on,
+            s"The project already has a record pointing to asset ${pkgName}"
         )
       case _ =>
         throw new Exception(
-          s"clone returned too many existing records ${exists}"
+            s"clone returned too many existing records ${exists}"
         )
     }
   }
@@ -343,8 +343,8 @@ object DxUtils {
     var counter = 0
     while (!rc && counter < DOWNLOAD_RETRY_LIMIT) {
       Utils.appletLog(
-        verbose,
-        s"downloading file ${path.toString} (try=${counter})"
+          verbose,
+          s"downloading file ${path.toString} (try=${counter})"
       )
       rc = downloadOneFile(path, dxfile, counter)
       counter = counter + 1

--- a/src/main/scala/dxWDL/dx/DxUtils.scala
+++ b/src/main/scala/dxWDL/dx/DxUtils.scala
@@ -11,9 +11,9 @@ import dxWDL.base.{AppInternalException, Utils, Verbose}
 
 object DxUtils {
   private val DOWNLOAD_RETRY_LIMIT = 3
-  private val UPLOAD_RETRY_LIMIT   = 3
+  private val UPLOAD_RETRY_LIMIT = 3
 
-  lazy val dxEnv         = DXEnvironment.create()
+  lazy val dxEnv = DXEnvironment.create()
   lazy val dxCrntProject = DxProject(dxEnv.getProjectContext())
 
   def isDxId(objName: String): Boolean = {
@@ -118,7 +118,7 @@ object DxUtils {
     } else if (dxExec.isInstanceOf[DxAnalysis]) {
       JsObject(
         "$dnanexus_link" -> JsObject(
-          "field"    -> JsString(fieldName),
+          "field" -> JsString(fieldName),
           "analysis" -> JsString(dxExec.id)
         )
       )
@@ -136,7 +136,7 @@ object DxUtils {
   ): DxJob = {
     val fields = Map(
       "function" -> JsString(entryPoint),
-      "input"    -> inputs
+      "input" -> inputs
     )
     val instanceFields = instanceType match {
       case None => Map.empty
@@ -160,7 +160,7 @@ object DxUtils {
     Utils.appletLog(verbose, s"subjob request=${req.prettyPrint}")
 
     val retval: JsonNode = DXAPI.jobNew(jsonNodeOfJsValue(req), classOf[JsonNode])
-    val info: JsValue    = jsValueOfJsonNode(retval)
+    val info: JsValue = jsValueOfJsonNode(retval)
     val id: String = info.asJsObject.fields.get("id") match {
       case Some(JsString(x)) => x
       case _ =>
@@ -172,7 +172,7 @@ object DxUtils {
   // describe a project, and extract fields that not currently available
   // through dxjava.
   def projectDescribeExtraInfo(dxProject: DxProject): (String, String) = {
-    val rep           = DXAPI.projectDescribe(dxProject.id, classOf[JsonNode])
+    val rep = DXAPI.projectDescribe(dxProject.id, classOf[JsonNode])
     val jso: JsObject = jsValueOfJsonNode(rep).asJsObject
 
     val billTo = jso.fields.get("billTo") match {
@@ -254,11 +254,11 @@ object DxUtils {
 
     // clone
     val req = JsObject(
-      "objects"     -> JsArray(JsString(assetRecord.id)),
-      "project"     -> JsString(dxProject.id),
+      "objects" -> JsArray(JsString(assetRecord.id)),
+      "project" -> JsString(dxProject.id),
       "destination" -> JsString("/")
     )
-    val rep            = DXAPI.projectClone(rmtProject.id, jsonNodeOfJsValue(req), classOf[JsonNode])
+    val rep = DXAPI.projectClone(rmtProject.id, jsonNodeOfJsValue(req), classOf[JsonNode])
     val repJs: JsValue = jsValueOfJsonNode(rep)
 
     val exists = repJs.asJsObject.fields.get("exists") match {
@@ -291,7 +291,7 @@ object DxUtils {
       val fid = dxfile.id
       try {
         // Use dx download. Quote the path, because it may contains spaces.
-        val dxDownloadCmd    = s"""dx download ${fid} -o "${path.toString()}" """
+        val dxDownloadCmd = s"""dx download ${fid} -o "${path.toString()}" """
         val (outmsg, errmsg) = Utils.execCommand(dxDownloadCmd, None)
         true
       } catch {
@@ -306,7 +306,7 @@ object DxUtils {
       if (!Files.exists(dir))
         Files.createDirectories(dir)
     }
-    var rc      = false
+    var rc = false
     var counter = 0
     while (!rc && counter < DOWNLOAD_RETRY_LIMIT) {
       Utils.appletLog(verbose, s"downloading file ${path.toString} (try=${counter})")

--- a/src/main/scala/dxWDL/dx/DxWorkflow.scala
+++ b/src/main/scala/dxWDL/dx/DxWorkflow.scala
@@ -51,7 +51,7 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
       Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
-    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
     val response = DXAPI.workflowDescribe(
       id,
       DxUtils.jsonNodeOfJsValue(request),
@@ -97,8 +97,8 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-    val stages  = descJs.asJsObject.fields.get("stages").map(parseStages)
+    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val stages = descJs.asJsObject.fields.get("stages").map(parseStages)
     desc.copy(details = details, properties = props, stages = stages)
   }
 

--- a/src/main/scala/dxWDL/dx/DxWorkflow.scala
+++ b/src/main/scala/dxWDL/dx/DxWorkflow.scala
@@ -4,7 +4,12 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxWorkflowStageDesc(id: String, executable: String, name: String, input: JsValue)
+case class DxWorkflowStageDesc(
+    id: String,
+    executable: String,
+    name: String,
+    input: JsValue
+)
 
 case class DxWorkflowDescribe(
     project: String,
@@ -28,12 +33,13 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
     }
     jsVec.map {
       case jsv2 =>
-        val stage = jsv2.asJsObject.getFields("id", "executable", "name", "input") match {
-          case Seq(JsString(id), JsString(exec), JsString(name), input) =>
-            DxWorkflowStageDesc(id, exec, name, input)
-          case other =>
-            throw new Exception(s"Malfored JSON ${other}")
-        }
+        val stage =
+          jsv2.asJsObject.getFields("id", "executable", "name", "input") match {
+            case Seq(JsString(id), JsString(exec), JsString(name), input) =>
+              DxWorkflowStageDesc(id, exec, name, input)
+            case other =>
+              throw new Exception(s"Malfored JSON ${other}")
+          }
         stage
     }.toVector
   }
@@ -51,7 +57,9 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
       Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
-    val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val request = JsObject(
+      projSpec + ("fields" -> DxObject.requestFields(allFields))
+    )
     val response = DXAPI.workflowDescribe(
       id,
       DxUtils.jsonNodeOfJsValue(request),
@@ -97,7 +105,9 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
     }
 
     val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val props = descJs.asJsObject.fields
+      .get("properties")
+      .map(DxObject.parseJsonProperties)
     val stages = descJs.asJsObject.fields.get("stages").map(parseStages)
     desc.copy(details = details, properties = props, stages = stages)
   }
@@ -107,9 +117,15 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
   }
 
   def newRun(input: JsValue, name: String): DxAnalysis = {
-    val request = JsObject("name" -> JsString(name), "input" -> input.asJsObject)
+    val request =
+      JsObject("name" -> JsString(name), "input" -> input.asJsObject)
     val response =
-      DXAPI.workflowRun(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+      DXAPI.workflowRun(
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
+      )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     repJs.asJsObject.fields.get("id") match {
       case None =>

--- a/src/main/scala/dxWDL/dx/DxWorkflow.scala
+++ b/src/main/scala/dxWDL/dx/DxWorkflow.scala
@@ -47,35 +47,35 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
   def describe(fields: Set[Field.Value] = Set.empty): DxWorkflowDescribe = {
     val projSpec = DxObject.maybeSpecifyProject(project)
     val defaultFields = Set(
-      Field.Project,
-      Field.Id,
-      Field.Name,
-      Field.Folder,
-      Field.Created,
-      Field.Modified,
-      Field.InputSpec,
-      Field.OutputSpec
+        Field.Project,
+        Field.Id,
+        Field.Name,
+        Field.Folder,
+        Field.Created,
+        Field.Modified,
+        Field.InputSpec,
+        Field.OutputSpec
     )
     val allFields = fields ++ defaultFields
     val request = JsObject(
-      projSpec + ("fields" -> DxObject.requestFields(allFields))
+        projSpec + ("fields" -> DxObject.requestFields(allFields))
     )
     val response = DXAPI.workflowDescribe(
-      id,
-      DxUtils.jsonNodeOfJsValue(request),
-      classOf[JsonNode],
-      DxUtils.dxEnv
+        id,
+        DxUtils.jsonNodeOfJsValue(request),
+        classOf[JsonNode],
+        DxUtils.dxEnv
     )
     val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     val desc = descJs.asJsObject.getFields(
-      "project",
-      "id",
-      "name",
-      "folder",
-      "created",
-      "modified",
-      "inputSpec",
-      "outputSpec"
+        "project",
+        "id",
+        "name",
+        "folder",
+        "created",
+        "modified",
+        "inputSpec",
+        "outputSpec"
     ) match {
       case Seq(
           JsString(projectId),
@@ -88,17 +88,17 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
           JsArray(outputSpec)
           ) =>
         DxWorkflowDescribe(
-          projectId,
-          id,
-          name,
-          folder,
-          created.toLong,
-          modified.toLong,
-          None,
-          None,
-          Some(DxObject.parseIOSpec(inputSpec.toVector)),
-          Some(DxObject.parseIOSpec(outputSpec.toVector)),
-          None
+            projectId,
+            id,
+            name,
+            folder,
+            created.toLong,
+            modified.toLong,
+            None,
+            None,
+            Some(DxObject.parseIOSpec(inputSpec.toVector)),
+            Some(DxObject.parseIOSpec(outputSpec.toVector)),
+            None
         )
       case _ =>
         throw new Exception(s"Malformed JSON ${descJs}")
@@ -121,10 +121,10 @@ case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutab
       JsObject("name" -> JsString(name), "input" -> input.asJsObject)
     val response =
       DXAPI.workflowRun(
-        id,
-        DxUtils.jsonNodeOfJsValue(request),
-        classOf[JsonNode],
-        DxUtils.dxEnv
+          id,
+          DxUtils.jsonNodeOfJsValue(request),
+          classOf[JsonNode],
+          DxUtils.dxEnv
       )
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
     repJs.asJsObject.fields.get("id") match {

--- a/src/main/scala/dxWDL/dx/DxWorkflow.scala
+++ b/src/main/scala/dxWDL/dx/DxWorkflow.scala
@@ -4,127 +4,138 @@ import com.dnanexus.DXAPI
 import com.fasterxml.jackson.databind.JsonNode
 import spray.json._
 
-case class DxWorkflowStageDesc(id: String,
-                               executable : String,
-                               name : String,
-                               input : JsValue)
+case class DxWorkflowStageDesc(id: String, executable: String, name: String, input: JsValue)
 
-case class DxWorkflowDescribe(project : String,
-                              id  : String,
-                              name : String,
-                              folder : String,
-                              created : Long,
-                              modified : Long,
-                              properties: Option[Map[String, String]],
-                              details : Option[JsValue],
-                              inputSpec : Option[Vector[IOParameter]],
-                              outputSpec : Option[Vector[IOParameter]],
-                              stages : Option[Vector[DxWorkflowStageDesc]]) extends DxObjectDescribe
+case class DxWorkflowDescribe(
+    project: String,
+    id: String,
+    name: String,
+    folder: String,
+    created: Long,
+    modified: Long,
+    properties: Option[Map[String, String]],
+    details: Option[JsValue],
+    inputSpec: Option[Vector[IOParameter]],
+    outputSpec: Option[Vector[IOParameter]],
+    stages: Option[Vector[DxWorkflowStageDesc]]
+) extends DxObjectDescribe
 
-case class DxWorkflow(id : String,
-                      project : Option[DxProject]) extends DxExecutable {
-    private def parseStages(jsv : JsValue) : Vector[DxWorkflowStageDesc] = {
-        val jsVec = jsv match {
-            case JsArray(a) => a
-            case other => throw new Exception(s"Malfored JSON ${other}")
+case class DxWorkflow(id: String, project: Option[DxProject]) extends DxExecutable {
+  private def parseStages(jsv: JsValue): Vector[DxWorkflowStageDesc] = {
+    val jsVec = jsv match {
+      case JsArray(a) => a
+      case other      => throw new Exception(s"Malfored JSON ${other}")
+    }
+    jsVec.map {
+      case jsv2 =>
+        val stage = jsv2.asJsObject.getFields("id", "executable", "name", "input") match {
+          case Seq(JsString(id), JsString(exec), JsString(name), input) =>
+            DxWorkflowStageDesc(id, exec, name, input)
+          case other =>
+            throw new Exception(s"Malfored JSON ${other}")
         }
-        jsVec.map{
-            case jsv2 =>
-                val stage = jsv2.asJsObject.getFields("id", "executable", "name", "input") match {
-                    case Seq(JsString(id), JsString(exec), JsString(name), input) =>
-                        DxWorkflowStageDesc(id, exec, name, input)
-                    case other =>
-                        throw new Exception(s"Malfored JSON ${other}")
-                }
-                stage
-        }.toVector
+        stage
+    }.toVector
+  }
+
+  def describe(fields: Set[Field.Value] = Set.empty): DxWorkflowDescribe = {
+    val projSpec = DxObject.maybeSpecifyProject(project)
+    val defaultFields = Set(
+      Field.Project,
+      Field.Id,
+      Field.Name,
+      Field.Folder,
+      Field.Created,
+      Field.Modified,
+      Field.InputSpec,
+      Field.OutputSpec
+    )
+    val allFields = fields ++ defaultFields
+    val request   = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
+    val response = DXAPI.workflowDescribe(
+      id,
+      DxUtils.jsonNodeOfJsValue(request),
+      classOf[JsonNode],
+      DxUtils.dxEnv
+    )
+    val descJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    val desc = descJs.asJsObject.getFields(
+      "project",
+      "id",
+      "name",
+      "folder",
+      "created",
+      "modified",
+      "inputSpec",
+      "outputSpec"
+    ) match {
+      case Seq(
+          JsString(projectId),
+          JsString(id),
+          JsString(name),
+          JsString(folder),
+          JsNumber(created),
+          JsNumber(modified),
+          JsArray(inputSpec),
+          JsArray(outputSpec)
+          ) =>
+        DxWorkflowDescribe(
+          projectId,
+          id,
+          name,
+          folder,
+          created.toLong,
+          modified.toLong,
+          None,
+          None,
+          Some(DxObject.parseIOSpec(inputSpec.toVector)),
+          Some(DxObject.parseIOSpec(outputSpec.toVector)),
+          None
+        )
+      case _ =>
+        throw new Exception(s"Malformed JSON ${descJs}")
     }
 
-    def describe(fields : Set[Field.Value] = Set.empty) : DxWorkflowDescribe = {
-        val projSpec = DxObject.maybeSpecifyProject(project)
-        val defaultFields = Set(Field.Project,
-                                Field.Id,
-                                Field.Name,
-                                Field.Folder,
-                                Field.Created,
-                                Field.Modified,
-                                Field.InputSpec,
-                                Field.OutputSpec)
-        val allFields = fields ++ defaultFields
-        val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
-        val response = DXAPI.workflowDescribe(id,
-                                              DxUtils.jsonNodeOfJsValue(request),
-                                              classOf[JsonNode],
-                                              DxUtils.dxEnv)
-        val descJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-        val desc = descJs.asJsObject.getFields("project", "id", "name", "folder",
-                                               "created", "modified",
-                                               "inputSpec", "outputSpec") match {
-            case Seq(JsString(projectId), JsString(id),
-                     JsString(name), JsString(folder),
-                     JsNumber(created), JsNumber(modified),
-                     JsArray(inputSpec), JsArray(outputSpec)) =>
-                DxWorkflowDescribe(projectId,
-                                   id,
-                                   name,
-                                   folder,
-                                   created.toLong,
-                                   modified.toLong,
-                                   None,
-                                   None,
-                                   Some(DxObject.parseIOSpec(inputSpec.toVector)),
-                                   Some(DxObject.parseIOSpec(outputSpec.toVector)),
-                                   None)
-            case _ =>
-                throw new Exception(s"Malformed JSON ${descJs}")
-        }
+    val details = descJs.asJsObject.fields.get("details")
+    val props   = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
+    val stages  = descJs.asJsObject.fields.get("stages").map(parseStages)
+    desc.copy(details = details, properties = props, stages = stages)
+  }
 
-        val details = descJs.asJsObject.fields.get("details")
-        val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-        val stages = descJs.asJsObject.fields.get("stages").map(parseStages)
-        desc.copy(details = details, properties = props, stages = stages)
-    }
+  def close(): Unit = {
+    DXAPI.workflowClose(id, classOf[JsonNode], DxUtils.dxEnv)
+  }
 
-    def close() : Unit = {
-        DXAPI.workflowClose(id,
-                            classOf[JsonNode],
-                            DxUtils.dxEnv)
+  def newRun(input: JsValue, name: String): DxAnalysis = {
+    val request = JsObject("name" -> JsString(name), "input" -> input.asJsObject)
+    val response =
+      DXAPI.workflowRun(id, DxUtils.jsonNodeOfJsValue(request), classOf[JsonNode], DxUtils.dxEnv)
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(response)
+    repJs.asJsObject.fields.get("id") match {
+      case None =>
+        throw new Exception("id not returned in response")
+      case Some(JsString(x)) =>
+        DxAnalysis.getInstance(x)
+      case Some(other) =>
+        throw new Exception(s"malformed json response ${other}")
     }
-
-    def newRun(input : JsValue, name : String) : DxAnalysis = {
-        val request = JsObject(
-            "name" -> JsString(name),
-            "input" -> input.asJsObject)
-        val response = DXAPI.workflowRun(id,
-                                         DxUtils.jsonNodeOfJsValue(request),
-                                         classOf[JsonNode],
-                                         DxUtils.dxEnv)
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(response)
-	repJs.asJsObject.fields.get("id") match {
-            case None =>
-                throw new Exception("id not returned in response")
-            case Some(JsString(x)) =>
-                DxAnalysis.getInstance(x)
-            case Some(other) =>
-                throw new Exception(s"malformed json response ${other}")
-        }
-    }
+  }
 }
 
 object DxWorkflow {
-    def getInstance(id : String) : DxWorkflow = {
-        DxObject.getInstance(id) match {
-             case wf : DxWorkflow => wf
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a workflow")
-        }
+  def getInstance(id: String): DxWorkflow = {
+    DxObject.getInstance(id) match {
+      case wf: DxWorkflow => wf
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a workflow")
     }
+  }
 
-    def getInstance(id : String, project : DxProject ) : DxWorkflow = {
-        DxObject.getInstance(id, Some(project)) match {
-             case wf : DxWorkflow => wf
-             case _ =>
-                throw new IllegalArgumentException(s"${id} isn't a workflow")
-        }
+  def getInstance(id: String, project: DxProject): DxWorkflow = {
+    DxObject.getInstance(id, Some(project)) match {
+      case wf: DxWorkflow => wf
+      case _ =>
+        throw new IllegalArgumentException(s"${id} isn't a workflow")
     }
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxdaManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxdaManifest.scala
@@ -44,13 +44,13 @@ object DxdaManifest {
         i.toString -> JsObject("size" -> JsNumber(part.size), "md5" -> JsString(part.md5))
     }
     val destinationFile: java.io.File = destination.toFile()
-    val name                          = destinationFile.getName()
-    val folder                        = destinationFile.getParent().toString
+    val name = destinationFile.getName()
+    val folder = destinationFile.getParent().toString
     JsObject(
-      "id"     -> JsString(desc.id),
-      "name"   -> JsString(name),
+      "id" -> JsString(desc.id),
+      "name" -> JsString(name),
       "folder" -> JsString(folder),
-      "parts"  -> JsObject(parts)
+      "parts" -> JsObject(parts)
     )
   }
 

--- a/src/main/scala/dxWDL/dx/DxdaManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxdaManifest.scala
@@ -42,18 +42,18 @@ object DxdaManifest {
     val parts: Map[String, JsValue] = partsRaw.map {
       case (i, part) =>
         i.toString -> JsObject(
-          "size" -> JsNumber(part.size),
-          "md5" -> JsString(part.md5)
+            "size" -> JsNumber(part.size),
+            "md5" -> JsString(part.md5)
         )
     }
     val destinationFile: java.io.File = destination.toFile()
     val name = destinationFile.getName()
     val folder = destinationFile.getParent().toString
     JsObject(
-      "id" -> JsString(desc.id),
-      "name" -> JsString(name),
-      "folder" -> JsString(folder),
-      "parts" -> JsObject(parts)
+        "id" -> JsString(desc.id),
+        "name" -> JsString(name),
+        "folder" -> JsString(folder),
+        "parts" -> JsObject(parts)
     )
   }
 
@@ -72,7 +72,7 @@ object DxdaManifest {
     // create a sub-map per container
     val fileDescsByContainer: Map[DxProject, Map[String, (DxFile, DxFileDescribe)]] =
       fileDescs.foldLeft(
-        Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]
+          Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]
       ) {
         case (accu, (fid, (dxFile, dxDesc))) =>
           val container = DxProject.getInstance(dxDesc.project)

--- a/src/main/scala/dxWDL/dx/DxdaManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxdaManifest.scala
@@ -41,7 +41,10 @@ object DxdaManifest {
     }
     val parts: Map[String, JsValue] = partsRaw.map {
       case (i, part) =>
-        i.toString -> JsObject("size" -> JsNumber(part.size), "md5" -> JsString(part.md5))
+        i.toString -> JsObject(
+          "size" -> JsNumber(part.size),
+          "md5" -> JsString(part.md5)
+        )
     }
     val destinationFile: java.io.File = destination.toFile()
     val name = destinationFile.getName()
@@ -68,7 +71,9 @@ object DxdaManifest {
 
     // create a sub-map per container
     val fileDescsByContainer: Map[DxProject, Map[String, (DxFile, DxFileDescribe)]] =
-      fileDescs.foldLeft(Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]) {
+      fileDescs.foldLeft(
+        Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]
+      ) {
         case (accu, (fid, (dxFile, dxDesc))) =>
           val container = DxProject.getInstance(dxDesc.project)
           accu.get(container) match {

--- a/src/main/scala/dxWDL/dx/DxdaManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxdaManifest.scala
@@ -6,10 +6,10 @@ package dxWDL.dx
 import java.nio.file.Path
 import spray.json._
 
-case class DxdaManifest(value : JsValue)
+case class DxdaManifest(value: JsValue)
 
 object DxdaManifest {
-/*
+  /*
   Start with paths like this:
     "dx://dxWDL_playground:/test_data/fileB",
     "dx://dxWDL_playground:/test_data/fileC",
@@ -30,63 +30,65 @@ object DxdaManifest {
       projId2 -> JsArray(...)
   )
 
- */
+   */
 
-    // create a manifest for a single file
-    private def processFile(desc : DxFileDescribe,
-                            destination : Path) : JsValue = {
-        val partsRaw : Map[Int, DxFilePart] = desc.parts match {
-            case None => throw new Exception(
-                s"""|No options for file ${desc.id},
+  // create a manifest for a single file
+  private def processFile(desc: DxFileDescribe, destination: Path): JsValue = {
+    val partsRaw: Map[Int, DxFilePart] = desc.parts match {
+      case None    => throw new Exception(s"""|No options for file ${desc.id},
                     |name=${desc.name} folder=${desc.folder}""".stripMargin)
-            case Some(x) => x
-        }
-        val parts: Map[String, JsValue] = partsRaw.map{ case (i, part) =>
-            i.toString -> JsObject(
-                "size" -> JsNumber(part.size),
-                "md5" -> JsString(part.md5))
-        }
-        val destinationFile : java.io.File = destination.toFile()
-        val name = destinationFile.getName()
-        val folder = destinationFile.getParent().toString
-        JsObject("id" -> JsString(desc.id),
-                 "name" -> JsString(name),
-                 "folder" -> JsString(folder),
-                 "parts" -> JsObject(parts))
+      case Some(x) => x
     }
-
-    // The project is just a hint. The files don't have to actually reside in it.
-    def apply(file2LocalMapping: Map[String, (DxFile, Path)]) : DxdaManifest = {
-        // collect all the information per file
-        val files : Vector[DxFile] = file2LocalMapping.values.map(_._1).toVector
-        val fileDescs : Map[String, (DxFile, DxFileDescribe)] =
-            DxFile.bulkDescribe(files, Set(Field.Parts)).map {
-                case (dxFile, desc) => dxFile.id -> (dxFile, desc)
-            }.toMap
-
-        // create a sub-map per container
-        val fileDescsByContainer : Map[DxProject, Map[String, (DxFile, DxFileDescribe)]] =
-            fileDescs.foldLeft(Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]) {
-                case (accu, (fid, (dxFile, dxDesc))) =>
-                    val container = DxProject.getInstance(dxDesc.project)
-                    accu.get(container) match {
-                        case None =>
-                            accu + (container -> Map(dxFile.id -> (dxFile, dxDesc)))
-                        case Some(m) =>
-                            accu + (container -> (m + (dxFile.id -> (dxFile, dxDesc))))
-                    }
-            }
-
-        val m : Map[String, JsValue] = fileDescsByContainer.map{
-            case (dxContainer, fileDescs) =>
-                val projectFilesToLocalPath : Vector[JsValue] =
-                    fileDescs.map{
-                        case (fid, (dxFile, dxDesc)) =>
-                            val (_, local: Path) = file2LocalMapping(fid)
-                            processFile(dxDesc, local)
-                    }.toVector
-                dxContainer.getId -> JsArray(projectFilesToLocalPath)
-        }.toMap
-        new DxdaManifest(JsObject(m))
+    val parts: Map[String, JsValue] = partsRaw.map {
+      case (i, part) =>
+        i.toString -> JsObject("size" -> JsNumber(part.size), "md5" -> JsString(part.md5))
     }
+    val destinationFile: java.io.File = destination.toFile()
+    val name                          = destinationFile.getName()
+    val folder                        = destinationFile.getParent().toString
+    JsObject(
+      "id"     -> JsString(desc.id),
+      "name"   -> JsString(name),
+      "folder" -> JsString(folder),
+      "parts"  -> JsObject(parts)
+    )
+  }
+
+  // The project is just a hint. The files don't have to actually reside in it.
+  def apply(file2LocalMapping: Map[String, (DxFile, Path)]): DxdaManifest = {
+    // collect all the information per file
+    val files: Vector[DxFile] = file2LocalMapping.values.map(_._1).toVector
+    val fileDescs: Map[String, (DxFile, DxFileDescribe)] =
+      DxFile
+        .bulkDescribe(files, Set(Field.Parts))
+        .map {
+          case (dxFile, desc) => dxFile.id -> (dxFile, desc)
+        }
+        .toMap
+
+    // create a sub-map per container
+    val fileDescsByContainer: Map[DxProject, Map[String, (DxFile, DxFileDescribe)]] =
+      fileDescs.foldLeft(Map.empty[DxProject, Map[String, (DxFile, DxFileDescribe)]]) {
+        case (accu, (fid, (dxFile, dxDesc))) =>
+          val container = DxProject.getInstance(dxDesc.project)
+          accu.get(container) match {
+            case None =>
+              accu + (container -> Map(dxFile.id -> (dxFile, dxDesc)))
+            case Some(m) =>
+              accu + (container -> (m + (dxFile.id -> (dxFile, dxDesc))))
+          }
+      }
+
+    val m: Map[String, JsValue] = fileDescsByContainer.map {
+      case (dxContainer, fileDescs) =>
+        val projectFilesToLocalPath: Vector[JsValue] =
+          fileDescs.map {
+            case (fid, (dxFile, dxDesc)) =>
+              val (_, local: Path) = file2LocalMapping(fid)
+              processFile(dxDesc, local)
+          }.toVector
+        dxContainer.getId -> JsArray(projectFilesToLocalPath)
+    }.toMap
+    new DxdaManifest(JsObject(m))
+  }
 }

--- a/src/main/scala/dxWDL/dx/DxfuseManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxfuseManifest.scala
@@ -30,21 +30,21 @@ object DxfuseManifest {
 
         val (_, fDesc) = dxIoFunctions.fileInfoDir(dxFile.id)
         JsObject(
-          "proj_id" -> JsString(fDesc.project),
-          "file_id" -> JsString(dxFile.id),
-          "parent" -> JsString(relParentDir),
-          "fname" -> JsString(fDesc.name),
-          "size" -> JsNumber(fDesc.size),
-          "ctime" -> JsNumber(fDesc.created),
-          "mtime" -> JsNumber(fDesc.modified)
+            "proj_id" -> JsString(fDesc.project),
+            "file_id" -> JsString(dxFile.id),
+            "parent" -> JsString(relParentDir),
+            "fname" -> JsString(fDesc.name),
+            "size" -> JsNumber(fDesc.size),
+            "ctime" -> JsNumber(fDesc.created),
+            "mtime" -> JsNumber(fDesc.modified)
         )
     }.toVector
 
     DxfuseManifest(
-      JsObject(
-        "files" -> JsArray(files),
-        "directories" -> JsArray(Vector.empty)
-      )
+        JsObject(
+            "files" -> JsArray(files),
+            "directories" -> JsArray(Vector.empty)
+        )
     )
   }
 }

--- a/src/main/scala/dxWDL/dx/DxfuseManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxfuseManifest.scala
@@ -11,7 +11,10 @@ import dxWDL.util.DxIoFunctions
 case class DxfuseManifest(value: JsValue)
 
 object DxfuseManifest {
-  def apply(file2LocalMapping: Map[DxFile, Path], dxIoFunctions: DxIoFunctions): DxfuseManifest = {
+  def apply(
+      file2LocalMapping: Map[DxFile, Path],
+      dxIoFunctions: DxIoFunctions
+  ): DxfuseManifest = {
     if (file2LocalMapping.isEmpty)
       return DxfuseManifest(JsNull)
 
@@ -38,7 +41,10 @@ object DxfuseManifest {
     }.toVector
 
     DxfuseManifest(
-      JsObject("files" -> JsArray(files), "directories" -> JsArray(Vector.empty))
+      JsObject(
+        "files" -> JsArray(files),
+        "directories" -> JsArray(Vector.empty)
+      )
     )
   }
 }

--- a/src/main/scala/dxWDL/dx/DxfuseManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxfuseManifest.scala
@@ -29,11 +29,11 @@ object DxfuseManifest {
         JsObject(
           "proj_id" -> JsString(fDesc.project),
           "file_id" -> JsString(dxFile.id),
-          "parent"  -> JsString(relParentDir),
-          "fname"   -> JsString(fDesc.name),
-          "size"    -> JsNumber(fDesc.size),
-          "ctime"   -> JsNumber(fDesc.created),
-          "mtime"   -> JsNumber(fDesc.modified)
+          "parent" -> JsString(relParentDir),
+          "fname" -> JsString(fDesc.name),
+          "size" -> JsNumber(fDesc.size),
+          "ctime" -> JsNumber(fDesc.created),
+          "mtime" -> JsNumber(fDesc.modified)
         )
     }.toVector
 

--- a/src/main/scala/dxWDL/dx/DxfuseManifest.scala
+++ b/src/main/scala/dxWDL/dx/DxfuseManifest.scala
@@ -8,38 +8,37 @@ import spray.json._
 
 import dxWDL.util.DxIoFunctions
 
-case class DxfuseManifest(value : JsValue)
+case class DxfuseManifest(value: JsValue)
 
 object DxfuseManifest {
-    def apply(file2LocalMapping: Map[DxFile, Path],
-              dxIoFunctions : DxIoFunctions) : DxfuseManifest = {
-        if (file2LocalMapping.isEmpty)
-            return DxfuseManifest(JsNull)
+  def apply(file2LocalMapping: Map[DxFile, Path], dxIoFunctions: DxIoFunctions): DxfuseManifest = {
+    if (file2LocalMapping.isEmpty)
+      return DxfuseManifest(JsNull)
 
-        val files = file2LocalMapping.map{
-            case (dxFile, path) =>
-                val parentDir = path.getParent().toString
+    val files = file2LocalMapping.map {
+      case (dxFile, path) =>
+        val parentDir = path.getParent().toString
 
-                // remove the mountpoint from the directory. We need
-                // paths that are relative to the mount point.
-                val mountDir = dxIoFunctions.config.dxfuseMountpoint.toString
-                assert(parentDir.startsWith(mountDir))
-                val relParentDir = "/" + parentDir.stripPrefix(mountDir)
+        // remove the mountpoint from the directory. We need
+        // paths that are relative to the mount point.
+        val mountDir = dxIoFunctions.config.dxfuseMountpoint.toString
+        assert(parentDir.startsWith(mountDir))
+        val relParentDir = "/" + parentDir.stripPrefix(mountDir)
 
-                val (_,fDesc) = dxIoFunctions.fileInfoDir(dxFile.id)
-                JsObject(
-                    "proj_id" -> JsString(fDesc.project),
-                    "file_id" -> JsString(dxFile.id),
-                    "parent" -> JsString(relParentDir),
-                    "fname" -> JsString(fDesc.name),
-                    "size" -> JsNumber(fDesc.size),
-                    "ctime" -> JsNumber(fDesc.created),
-                    "mtime" -> JsNumber(fDesc.modified))
-        }.toVector
-
-        DxfuseManifest(
-            JsObject("files" -> JsArray(files),
-                     "directories" -> JsArray(Vector.empty))
+        val (_, fDesc) = dxIoFunctions.fileInfoDir(dxFile.id)
+        JsObject(
+          "proj_id" -> JsString(fDesc.project),
+          "file_id" -> JsString(dxFile.id),
+          "parent"  -> JsString(relParentDir),
+          "fname"   -> JsString(fDesc.name),
+          "size"    -> JsNumber(fDesc.size),
+          "ctime"   -> JsNumber(fDesc.created),
+          "mtime"   -> JsNumber(fDesc.modified)
         )
-    }
+    }.toVector
+
+    DxfuseManifest(
+      JsObject("files" -> JsArray(files), "directories" -> JsArray(Vector.empty))
+    )
+  }
 }

--- a/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
+++ b/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
@@ -27,10 +27,10 @@ object ExecLinkInfo {
       case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
     }.toMap
     JsObject(
-      "name"    -> JsString(ali.name),
-      "inputs"  -> JsObject(TreeMap(appInputDefs.toArray: _*)),
+      "name" -> JsString(ali.name),
+      "inputs" -> JsObject(TreeMap(appInputDefs.toArray: _*)),
       "outputs" -> JsObject(TreeMap(appOutputDefs.toArray: _*)),
-      "id"      -> JsString(ali.dxExec.getId)
+      "id" -> JsString(ali.dxExec.getId)
     )
   }
 

--- a/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
+++ b/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
@@ -7,55 +7,65 @@ import dxWDL.base._
 
 // Information used to link applets that call other applets. For example, a scatter
 // applet calls applets that implement tasks.
-case class ExecLinkInfo(name: String,
-                        inputs: Map[String, WomType],
-                        outputs: Map[String, WomType],
-                        dxExec: DxExecutable)
+case class ExecLinkInfo(
+    name: String,
+    inputs: Map[String, WomType],
+    outputs: Map[String, WomType],
+    dxExec: DxExecutable
+)
 
 object ExecLinkInfo {
-    // Serialize applet input definitions, so they could be used
-    // at runtime.
-    def writeJson(ali: ExecLinkInfo,
-                  typeAliases: Map[String, WomType]) : JsValue = {
-        val womTypeConverter = WomTypeSerialization(typeAliases)
+  // Serialize applet input definitions, so they could be used
+  // at runtime.
+  def writeJson(ali: ExecLinkInfo, typeAliases: Map[String, WomType]): JsValue = {
+    val womTypeConverter = WomTypeSerialization(typeAliases)
 
-        val appInputDefs: Map[String, JsString] = ali.inputs.map{
-            case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
-        }.toMap
-        val appOutputDefs: Map[String, JsString] = ali.outputs.map{
-            case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
-        }.toMap
-        JsObject(
-            "name" -> JsString(ali.name),
-            "inputs" -> JsObject(TreeMap(appInputDefs.toArray:_*)),
-            "outputs" -> JsObject(TreeMap(appOutputDefs.toArray:_*)),
-            "id" -> JsString(ali.dxExec.getId)
-        )
+    val appInputDefs: Map[String, JsString] = ali.inputs.map {
+      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
+    }.toMap
+    val appOutputDefs: Map[String, JsString] = ali.outputs.map {
+      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
+    }.toMap
+    JsObject(
+      "name"    -> JsString(ali.name),
+      "inputs"  -> JsObject(TreeMap(appInputDefs.toArray: _*)),
+      "outputs" -> JsObject(TreeMap(appOutputDefs.toArray: _*)),
+      "id"      -> JsString(ali.dxExec.getId)
+    )
+  }
+
+  def readJson(aplInfo: JsValue, typeAliases: Map[String, WomType]): ExecLinkInfo = {
+    val womTypeConverter = WomTypeSerialization(typeAliases)
+
+    val name = aplInfo.asJsObject.fields("name") match {
+      case JsString(x) => x
+      case _           => throw new Exception("Bad JSON")
     }
-
-    def readJson(aplInfo: JsValue,
-                 typeAliases: Map[String, WomType]) : ExecLinkInfo = {
-        val womTypeConverter = WomTypeSerialization(typeAliases)
-
-        val name = aplInfo.asJsObject.fields("name") match {
-            case JsString(x) => x
-            case _ => throw new Exception("Bad JSON")
-        }
-        val inputDefs = aplInfo.asJsObject.fields("inputs").asJsObject.fields.map{
-            case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
-            case _ => throw new Exception("Bad JSON")
-        }.toMap
-        val outputDefs = aplInfo.asJsObject.fields("outputs").asJsObject.fields.map{
-            case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
-            case _ => throw new Exception("Bad JSON")
-        }.toMap
-        val dxExec = aplInfo.asJsObject.fields("id") match {
-            case JsString(id) if id.startsWith("app-") => DxApp(id)
-            case JsString(id) if id.startsWith("applet-") => DxApplet(id, None)
-            case JsString(id) if id.startsWith("workflow-") => DxWorkflow(id, None)
-            case JsString(id) => throw new Exception(s"${id} is not an app/applet/workflow")
-            case _ => throw new Exception("Bad JSON")
-        }
-        ExecLinkInfo(name, inputDefs, outputDefs, dxExec)
+    val inputDefs = aplInfo.asJsObject
+      .fields("inputs")
+      .asJsObject
+      .fields
+      .map {
+        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
+        case _                           => throw new Exception("Bad JSON")
+      }
+      .toMap
+    val outputDefs = aplInfo.asJsObject
+      .fields("outputs")
+      .asJsObject
+      .fields
+      .map {
+        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
+        case _                           => throw new Exception("Bad JSON")
+      }
+      .toMap
+    val dxExec = aplInfo.asJsObject.fields("id") match {
+      case JsString(id) if id.startsWith("app-")      => DxApp(id)
+      case JsString(id) if id.startsWith("applet-")   => DxApplet(id, None)
+      case JsString(id) if id.startsWith("workflow-") => DxWorkflow(id, None)
+      case JsString(id)                               => throw new Exception(s"${id} is not an app/applet/workflow")
+      case _                                          => throw new Exception("Bad JSON")
     }
+    ExecLinkInfo(name, inputDefs, outputDefs, dxExec)
+  }
 }

--- a/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
+++ b/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
@@ -17,14 +17,19 @@ case class ExecLinkInfo(
 object ExecLinkInfo {
   // Serialize applet input definitions, so they could be used
   // at runtime.
-  def writeJson(ali: ExecLinkInfo, typeAliases: Map[String, WomType]): JsValue = {
+  def writeJson(
+      ali: ExecLinkInfo,
+      typeAliases: Map[String, WomType]
+  ): JsValue = {
     val womTypeConverter = WomTypeSerialization(typeAliases)
 
     val appInputDefs: Map[String, JsString] = ali.inputs.map {
-      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
+      case (name, womType) =>
+        name -> JsString(womTypeConverter.toString(womType))
     }.toMap
     val appOutputDefs: Map[String, JsString] = ali.outputs.map {
-      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
+      case (name, womType) =>
+        name -> JsString(womTypeConverter.toString(womType))
     }.toMap
     JsObject(
       "name" -> JsString(ali.name),
@@ -34,7 +39,10 @@ object ExecLinkInfo {
     )
   }
 
-  def readJson(aplInfo: JsValue, typeAliases: Map[String, WomType]): ExecLinkInfo = {
+  def readJson(
+      aplInfo: JsValue,
+      typeAliases: Map[String, WomType]
+  ): ExecLinkInfo = {
     val womTypeConverter = WomTypeSerialization(typeAliases)
 
     val name = aplInfo.asJsObject.fields("name") match {
@@ -46,8 +54,9 @@ object ExecLinkInfo {
       .asJsObject
       .fields
       .map {
-        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
-        case _                           => throw new Exception("Bad JSON")
+        case (key, JsString(womTypeStr)) =>
+          key -> womTypeConverter.fromString(womTypeStr)
+        case _ => throw new Exception("Bad JSON")
       }
       .toMap
     val outputDefs = aplInfo.asJsObject
@@ -55,16 +64,18 @@ object ExecLinkInfo {
       .asJsObject
       .fields
       .map {
-        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
-        case _                           => throw new Exception("Bad JSON")
+        case (key, JsString(womTypeStr)) =>
+          key -> womTypeConverter.fromString(womTypeStr)
+        case _ => throw new Exception("Bad JSON")
       }
       .toMap
     val dxExec = aplInfo.asJsObject.fields("id") match {
       case JsString(id) if id.startsWith("app-")      => DxApp(id)
       case JsString(id) if id.startsWith("applet-")   => DxApplet(id, None)
       case JsString(id) if id.startsWith("workflow-") => DxWorkflow(id, None)
-      case JsString(id)                               => throw new Exception(s"${id} is not an app/applet/workflow")
-      case _                                          => throw new Exception("Bad JSON")
+      case JsString(id) =>
+        throw new Exception(s"${id} is not an app/applet/workflow")
+      case _ => throw new Exception("Bad JSON")
     }
     ExecLinkInfo(name, inputDefs, outputDefs, dxExec)
   }

--- a/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
+++ b/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
@@ -32,10 +32,10 @@ object ExecLinkInfo {
         name -> JsString(womTypeConverter.toString(womType))
     }.toMap
     JsObject(
-      "name" -> JsString(ali.name),
-      "inputs" -> JsObject(TreeMap(appInputDefs.toArray: _*)),
-      "outputs" -> JsObject(TreeMap(appOutputDefs.toArray: _*)),
-      "id" -> JsString(ali.dxExec.getId)
+        "name" -> JsString(ali.name),
+        "inputs" -> JsObject(TreeMap(appInputDefs.toArray: _*)),
+        "outputs" -> JsObject(TreeMap(appOutputDefs.toArray: _*)),
+        "id" -> JsString(ali.dxExec.getId)
     )
   }
 

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -31,7 +31,11 @@ object DxIOClass extends Enumeration {
   }
 }
 
-case class IOParameter(name: String, ioClass: DxIOClass.Value, optional: Boolean)
+case class IOParameter(
+    name: String,
+    ioClass: DxIOClass.Value,
+    optional: Boolean
+)
 
 // Extra fields for describe
 object Field extends Enumeration {
@@ -128,11 +132,15 @@ object DxObject {
   def getInstance(id: String, container: Option[DxProject] = None): DxObject = {
     val parts = id.split("-")
     if (parts.length != 2)
-      throw new IllegalArgumentException(s"${id} is not of the form class-alphnumeric{24}")
+      throw new IllegalArgumentException(
+        s"${id} is not of the form class-alphnumeric{24}"
+      )
     val klass = parts(0)
     val numLetters = parts(1)
     if (!numLetters.matches("[A-Za-z0-9]{24}"))
-      throw new IllegalArgumentException(s"${numLetters} does not match [A-Za-z0-9]{24}")
+      throw new IllegalArgumentException(
+        s"${numLetters} does not match [A-Za-z0-9]{24}"
+      )
 
     klass match {
       case "project"   => DxProject(id)
@@ -145,7 +153,9 @@ object DxObject {
       case "job"       => DxJob(id, container)
       case "analysis"  => DxAnalysis(id, container)
       case _ =>
-        throw new IllegalArgumentException(s"${id} does not belong to a know class")
+        throw new IllegalArgumentException(
+          s"${id} does not belong to a know class"
+        )
     }
   }
 
@@ -179,12 +189,18 @@ case class DxWorkflowStage(id: String) {
 
   def getInputReference(inputName: String): JsValue = {
     JsObject(
-      "$dnanexus_link" -> JsObject("stage" -> JsString(id), "inputField" -> JsString(inputName))
+      "$dnanexus_link" -> JsObject(
+        "stage" -> JsString(id),
+        "inputField" -> JsString(inputName)
+      )
     )
   }
   def getOutputReference(outputName: String): JsValue = {
     JsObject(
-      "$dnanexus_link" -> JsObject("stage" -> JsString(id), "outputField" -> JsString(outputName))
+      "$dnanexus_link" -> JsObject(
+        "stage" -> JsString(id),
+        "outputField" -> JsString(outputName)
+      )
     )
   }
 }

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -129,7 +129,7 @@ object DxObject {
     val parts = id.split("-")
     if (parts.length != 2)
       throw new IllegalArgumentException(s"${id} is not of the form class-alphnumeric{24}")
-    val klass      = parts(0)
+    val klass = parts(0)
     val numLetters = parts(1)
     if (!numLetters.matches("[A-Za-z0-9]{24}"))
       throw new IllegalArgumentException(s"${numLetters} does not match [A-Za-z0-9]{24}")

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -133,13 +133,13 @@ object DxObject {
     val parts = id.split("-")
     if (parts.length != 2)
       throw new IllegalArgumentException(
-        s"${id} is not of the form class-alphnumeric{24}"
+          s"${id} is not of the form class-alphnumeric{24}"
       )
     val klass = parts(0)
     val numLetters = parts(1)
     if (!numLetters.matches("[A-Za-z0-9]{24}"))
       throw new IllegalArgumentException(
-        s"${numLetters} does not match [A-Za-z0-9]{24}"
+          s"${numLetters} does not match [A-Za-z0-9]{24}"
       )
 
     klass match {
@@ -154,7 +154,7 @@ object DxObject {
       case "analysis"  => DxAnalysis(id, container)
       case _ =>
         throw new IllegalArgumentException(
-          s"${id} does not belong to a know class"
+            s"${id} does not belong to a know class"
         )
     }
   }
@@ -189,18 +189,18 @@ case class DxWorkflowStage(id: String) {
 
   def getInputReference(inputName: String): JsValue = {
     JsObject(
-      "$dnanexus_link" -> JsObject(
-        "stage" -> JsString(id),
-        "inputField" -> JsString(inputName)
-      )
+        "$dnanexus_link" -> JsObject(
+            "stage" -> JsString(id),
+            "inputField" -> JsString(inputName)
+        )
     )
   }
   def getOutputReference(outputName: String): JsValue = {
     JsObject(
-      "$dnanexus_link" -> JsObject(
-        "stage" -> JsString(id),
-        "outputField" -> JsString(outputName)
-      )
+        "$dnanexus_link" -> JsObject(
+            "stage" -> JsString(id),
+            "outputField" -> JsString(outputName)
+        )
     )
   }
 }

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -3,184 +3,166 @@ package dxWDL.dx
 import spray.json._
 
 object DxIOClass extends Enumeration {
-    val INT, FLOAT, STRING, BOOLEAN, FILE,
-        ARRAY_OF_INTS, ARRAY_OF_FLOATS, ARRAY_OF_STRINGS, ARRAY_OF_BOOLEANS, ARRAY_OF_FILES,
-        HASH, OTHER = Value
+  val INT, FLOAT, STRING, BOOLEAN, FILE, ARRAY_OF_INTS, ARRAY_OF_FLOATS, ARRAY_OF_STRINGS,
+      ARRAY_OF_BOOLEANS, ARRAY_OF_FILES, HASH, OTHER = Value
 
-    def fromString(s : String) : DxIOClass.Value = {
-        s match {
-            // primitives
-            case "int" => INT
-            case "float" => FLOAT
-            case "string" => STRING
-            case "boolean" => BOOLEAN
-            case "file" => FILE
+  def fromString(s: String): DxIOClass.Value = {
+    s match {
+      // primitives
+      case "int"     => INT
+      case "float"   => FLOAT
+      case "string"  => STRING
+      case "boolean" => BOOLEAN
+      case "file"    => FILE
 
-            // arrays of primitives
-            case "array:int" => ARRAY_OF_INTS
-            case "array:float" => ARRAY_OF_FLOATS
-            case "array:string" => ARRAY_OF_STRINGS
-            case "array:boolean"=> ARRAY_OF_BOOLEANS
-            case "array:file" => ARRAY_OF_FILES
+      // arrays of primitives
+      case "array:int"     => ARRAY_OF_INTS
+      case "array:float"   => ARRAY_OF_FLOATS
+      case "array:string"  => ARRAY_OF_STRINGS
+      case "array:boolean" => ARRAY_OF_BOOLEANS
+      case "array:file"    => ARRAY_OF_FILES
 
-            // hash
-            case "hash" => HASH
+      // hash
+      case "hash" => HASH
 
-            // we don't deal with anything else
-            case other => OTHER
-        }
+      // we don't deal with anything else
+      case other => OTHER
     }
+  }
 }
 
-case class IOParameter(name: String,
-                       ioClass: DxIOClass.Value,
-                       optional : Boolean)
+case class IOParameter(name: String, ioClass: DxIOClass.Value, optional: Boolean)
 
 // Extra fields for describe
 object Field extends Enumeration {
-    val Analysis,
-        Applet,
-        Created,
-        Details,
-        Folder,
-        Id,
-        InputSpec,
-        Modified,
-        Name,
-        OutputSpec,
-        ParentJob,
-        Parts,
-        Project,
-        Properties,
-        Size,
-        Stages = Value
+  val Analysis, Applet, Created, Details, Folder, Id, InputSpec, Modified, Name, OutputSpec,
+      ParentJob, Parts, Project, Properties, Size, Stages = Value
 }
 
 trait DxObjectDescribe {
-    val id  : String
-    val name : String
-    val created : Long
-    val modified : Long
-    val properties: Option[Map[String, String]]
-    val details : Option[JsValue]
+  val id: String
+  val name: String
+  val created: Long
+  val modified: Long
+  val properties: Option[Map[String, String]]
+  val details: Option[JsValue]
 
-    def getCreationDate() : java.util.Date = new java.util.Date(created)
+  def getCreationDate(): java.util.Date = new java.util.Date(created)
 }
 
 trait DxObject {
-    val id : String
-    def getId : String = id
-    def describe(fields : Set[Field.Value]) : DxObjectDescribe
+  val id: String
+  def getId: String = id
+  def describe(fields: Set[Field.Value]): DxObjectDescribe
 }
 
 object DxObject {
-    def parseJsonProperties(props : JsValue) : Map[String, String] = {
-        props.asJsObject.fields.map{
-            case (k,JsString(v)) => k -> v
-            case (_,_) =>
-                throw new Exception(s"malform JSON properties ${props}")
-        }.toMap
+  def parseJsonProperties(props: JsValue): Map[String, String] = {
+    props.asJsObject.fields.map {
+      case (k, JsString(v)) => k -> v
+      case (_, _) =>
+        throw new Exception(s"malform JSON properties ${props}")
+    }.toMap
+  }
+
+  def parseIoParam(jsv: JsValue): IOParameter = {
+    val ioParam = jsv.asJsObject.getFields("name", "class") match {
+      case Seq(JsString(name), JsString(klass)) =>
+        val ioClass = DxIOClass.fromString(klass)
+        IOParameter(name, ioClass, false)
+      case other =>
+        throw new Exception(s"Malformed io spec ${other}")
     }
 
-
-    def parseIoParam(jsv: JsValue) : IOParameter = {
-        val ioParam = jsv.asJsObject.getFields("name", "class") match {
-            case Seq(JsString(name), JsString(klass)) =>
-                val ioClass = DxIOClass.fromString(klass)
-                IOParameter(name, ioClass, false)
-            case other =>
-                throw new Exception(s"Malformed io spec ${other}")
-        }
-
-        val optFlag = jsv.asJsObject.fields.get("optional") match {
-            case Some(JsBoolean(b)) => b
-            case None => false
-        }
-        ioParam.copy(optional = optFlag)
+    val optFlag = jsv.asJsObject.fields.get("optional") match {
+      case Some(JsBoolean(b)) => b
+      case None               => false
     }
+    ioParam.copy(optional = optFlag)
+  }
 
-    def parseIOSpec(specs : Vector[JsValue]) : Vector[IOParameter] = {
-        specs.map(ioSpec => parseIoParam(ioSpec)).toVector
+  def parseIOSpec(specs: Vector[JsValue]): Vector[IOParameter] = {
+    specs.map(ioSpec => parseIoParam(ioSpec)).toVector
+  }
+
+  def maybeSpecifyProject(project: Option[DxProject]): Map[String, JsValue] = {
+    project match {
+      case None =>
+        // we don't know the project.
+        Map.empty
+      case Some(p) =>
+        // We know the project, this makes the search more efficient.
+        Map("project" -> JsString(p.id))
     }
+  }
 
-    def maybeSpecifyProject(project : Option[DxProject]) : Map[String, JsValue] = {
-        project match {
-            case None =>
-                // we don't know the project.
-                Map.empty
-            case Some(p) =>
-                // We know the project, this makes the search more efficient.
-                Map("project" -> JsString(p.id))
-        }
+  def requestFields(fields: Set[Field.Value]): JsValue = {
+    val fieldStrings = fields.map {
+      case Field.Analysis   => "analysis"
+      case Field.Applet     => "applet"
+      case Field.Created    => "created"
+      case Field.Details    => "details"
+      case Field.Folder     => "folder"
+      case Field.Id         => "id"
+      case Field.InputSpec  => "inputSpec"
+      case Field.Modified   => "modified"
+      case Field.Name       => "name"
+      case Field.OutputSpec => "outputSpec"
+      case Field.ParentJob  => "parentJob"
+      case Field.Parts      => "parts"
+      case Field.Project    => "project"
+      case Field.Properties => "properties"
+      case Field.Size       => "size"
+      case Field.Stages     => "stages"
+    }.toVector
+    val m: Map[String, JsValue] = fieldStrings.map { x =>
+      x -> JsTrue
+    }.toMap
+    JsObject(m)
+  }
+
+  // We are expecting string like:
+  //    record-FgG51b00xF63k86F13pqFv57
+  //    file-FV5fqXj0ffPB9bKP986j5kVQ
+  //
+  def getInstance(id: String, container: Option[DxProject] = None): DxObject = {
+    val parts = id.split("-")
+    if (parts.length != 2)
+      throw new IllegalArgumentException(s"${id} is not of the form class-alphnumeric{24}")
+    val klass      = parts(0)
+    val numLetters = parts(1)
+    if (!numLetters.matches("[A-Za-z0-9]{24}"))
+      throw new IllegalArgumentException(s"${numLetters} does not match [A-Za-z0-9]{24}")
+
+    klass match {
+      case "project"   => DxProject(id)
+      case "container" => DxProject(id)
+      case "file"      => DxFile(id, container)
+      case "record"    => DxRecord(id, container)
+      case "app"       => DxApp(id)
+      case "applet"    => DxApplet(id, container)
+      case "workflow"  => DxWorkflow(id, container)
+      case "job"       => DxJob(id, container)
+      case "analysis"  => DxAnalysis(id, container)
+      case _ =>
+        throw new IllegalArgumentException(s"${id} does not belong to a know class")
     }
+  }
 
-    def requestFields(fields : Set[Field.Value]) : JsValue = {
-        val fieldStrings = fields.map{
-            case Field.Analysis => "analysis"
-            case Field.Applet => "applet"
-            case Field.Created => "created"
-            case Field.Details => "details"
-            case Field.Folder => "folder"
-            case Field.Id => "id"
-            case Field.InputSpec => "inputSpec"
-            case Field.Modified => "modified"
-            case Field.Name => "name"
-            case Field.OutputSpec => "outputSpec"
-            case Field.ParentJob => "parentJob"
-            case Field.Parts => "parts"
-            case Field.Project => "project"
-            case Field.Properties => "properties"
-            case Field.Size => "size"
-            case Field.Stages => "stages"
-        }.toVector
-        val m : Map[String, JsValue] = fieldStrings.map{ x => x -> JsTrue }.toMap
-        JsObject(m)
+  // convenience methods
+  def getInstance(id: String, container: DxProject): DxObject = {
+    getInstance(id, Some(container))
+  }
+
+  def isDataObject(id: String): Boolean = {
+    try {
+      val o = getInstance(id, None)
+      o.isInstanceOf[DxDataObject]
+    } catch {
+      case e: IllegalArgumentException =>
+        false
     }
-
-    // We are expecting string like:
-    //    record-FgG51b00xF63k86F13pqFv57
-    //    file-FV5fqXj0ffPB9bKP986j5kVQ
-    //
-    def getInstance(id : String,
-                    container: Option[DxProject] = None) : DxObject = {
-        val parts = id.split("-")
-        if (parts.length != 2)
-            throw new IllegalArgumentException(s"${id} is not of the form class-alphnumeric{24}")
-        val klass = parts(0)
-        val numLetters = parts(1)
-        if (!numLetters.matches("[A-Za-z0-9]{24}"))
-            throw new IllegalArgumentException(s"${numLetters} does not match [A-Za-z0-9]{24}")
-
-        klass match {
-            case "project" => DxProject(id)
-            case "container" => DxProject(id)
-            case "file" => DxFile(id, container)
-            case "record" => DxRecord(id, container)
-            case "app" => DxApp(id)
-            case "applet" => DxApplet(id, container)
-            case "workflow" => DxWorkflow(id, container)
-            case "job" => DxJob(id, container)
-            case "analysis" => DxAnalysis(id, container)
-            case _ =>
-                throw new IllegalArgumentException(s"${id} does not belong to a know class")
-        }
-    }
-
-    // convenience methods
-    def getInstance(id : String,
-                    container: DxProject) : DxObject = {
-        getInstance(id, Some(container))
-    }
-
-    def isDataObject(id : String) : Boolean = {
-        try {
-            val o = getInstance(id, None)
-            o.isInstanceOf[DxDataObject]
-        } catch {
-            case e : IllegalArgumentException =>
-                false
-        }
-    }
+  }
 }
 
 trait DxDataObject extends DxObject
@@ -193,16 +175,16 @@ trait DxExecution extends DxObject
 
 // A stand in for the DxWorkflow.Stage inner class (we don't have a constructor for it)
 case class DxWorkflowStage(id: String) {
-    def getId() = id
+  def getId() = id
 
-    def getInputReference(inputName:String) : JsValue = {
-        JsObject("$dnanexus_link" -> JsObject(
-                     "stage" -> JsString(id),
-                     "inputField" -> JsString(inputName)))
-    }
-    def getOutputReference(outputName:String) : JsValue = {
-        JsObject("$dnanexus_link" -> JsObject(
-                     "stage" -> JsString(id),
-                     "outputField" -> JsString(outputName)))
-    }
+  def getInputReference(inputName: String): JsValue = {
+    JsObject(
+      "$dnanexus_link" -> JsObject("stage" -> JsString(id), "inputField" -> JsString(inputName))
+    )
+  }
+  def getOutputReference(outputName: String): JsValue = {
+    JsObject(
+      "$dnanexus_link" -> JsObject("stage" -> JsString(id), "outputField" -> JsString(outputName))
+    )
+  }
 }

--- a/src/main/scala/dxWDL/exec/CollectSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/CollectSubJobs.scala
@@ -85,8 +85,8 @@ case class CollectSubJobs(
     typeAliases: Map[String, WomType]
 ) {
   //private val verbose = runtimeDebugLevel >= 1
-  private val maxVerboseLevel      = (runtimeDebugLevel == 2)
-  private val verbose              = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val maxVerboseLevel = (runtimeDebugLevel == 2)
+  private val verbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
   private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, Map.empty, typeAliases)
 
   // Launch a subjob to collect the outputs
@@ -116,7 +116,7 @@ case class CollectSubJobs(
 
   private def findChildExecs(): Vector[DxExecution] = {
     // get the parent job
-    val dxJob            = DxJob(DxUtils.dxEnv.getJob())
+    val dxJob = DxJob(DxUtils.dxEnv.getJob())
     val parentJob: DxJob = dxJob.describe().parentJob.get
 
     val childExecs: Vector[DxExecution] = DxFindExecutions.apply(Some(parentJob))
@@ -135,9 +135,9 @@ case class CollectSubJobs(
       JsObject(
         "id" -> JsString(job.getId),
         "describe" -> JsObject(
-          "outputs"        -> JsBoolean(true),
+          "outputs" -> JsBoolean(true),
           "executableName" -> JsBoolean(true),
-          "properties"     -> JsBoolean(true)
+          "properties" -> JsBoolean(true)
         )
       )
     }
@@ -205,7 +205,7 @@ case class CollectSubJobs(
     val vec: Vector[WomValue] =
       childJobsComplete.flatMap {
         case childExec =>
-          val dxName     = Utils.transformVarName(name)
+          val dxName = Utils.transformVarName(name)
           val fieldValue = childExec.outputs.get(dxName)
           (womType, fieldValue) match {
             case (WomOptionalType(_), None) =>
@@ -229,10 +229,10 @@ case class CollectSubJobs(
       childJobsComplete: Vector[ChildExecDesc]
   ): Map[String, WdlVarLinks] = {
     call.callable.outputs.map { cot: OutputDefinition =>
-      val fullName        = s"${call.identifier.workflowLocalName}.${cot.name}"
-      val womType         = cot.womType
+      val fullName = s"${call.identifier.workflowLocalName}.${cot.name}"
+      val womType = cot.womType
       val value: WomValue = collectCallField(cot.name, womType, childJobsComplete)
-      val wvl             = wdlVarLinksConverter.importFromWDL(value.womType, value)
+      val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
       fullName -> wvl
     }.toMap
   }
@@ -246,7 +246,7 @@ case class CollectSubJobs(
     execLinkInfo.outputs.map {
       case (name, womType) =>
         val value: WomValue = collectCallField(name, womType, childJobsComplete)
-        val wvl             = wdlVarLinksConverter.importFromWDL(value.womType, value)
+        val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
         name -> wvl
     }.toMap
   }

--- a/src/main/scala/dxWDL/exec/CollectSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/CollectSubJobs.scala
@@ -100,11 +100,11 @@ case class CollectSubJobs(
     // Run a sub-job with the "collect" entry point.
     // We need to provide the exact same inputs.
     val dxSubJob: DxJob = DxUtils.runSubJob(
-      "collect",
-      Some(instanceTypeDB.defaultInstanceType),
-      inputsRaw,
-      childJobs,
-      maxVerboseLevel
+        "collect",
+        Some(instanceTypeDB.defaultInstanceType),
+        inputsRaw,
+        childJobs,
+        maxVerboseLevel
     )
 
     // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
@@ -137,22 +137,22 @@ case class CollectSubJobs(
   ): Vector[ChildExecDesc] = {
     val jobInfoReq: Vector[JsValue] = execs.map { job =>
       JsObject(
-        "id" -> JsString(job.getId),
-        "describe" -> JsObject(
-          "outputs" -> JsBoolean(true),
-          "executableName" -> JsBoolean(true),
-          "properties" -> JsBoolean(true)
-        )
+          "id" -> JsString(job.getId),
+          "describe" -> JsObject(
+              "outputs" -> JsBoolean(true),
+              "executableName" -> JsBoolean(true),
+              "properties" -> JsBoolean(true)
+          )
       )
     }
     val req = JsObject("executions" -> JsArray(jobInfoReq))
     System.err.println(s"bulk-describe request=${req}")
     val retval: JsValue =
       DxUtils.jsValueOfJsonNode(
-        DXAPI.systemDescribeExecutions(
-          DxUtils.jsonNodeOfJsValue(req),
-          classOf[JsonNode]
-        )
+          DXAPI.systemDescribeExecutions(
+              DxUtils.jsonNodeOfJsValue(req),
+              classOf[JsonNode]
+          )
       )
     val results: Vector[JsValue] =
       retval.asJsObject.fields.get("results") match {
@@ -166,7 +166,7 @@ case class CollectSubJobs(
           case Some(JsObject(fields)) => fields
           case _ =>
             throw new Exception(
-              s"result does not contains a describe field ${desc}"
+                s"result does not contains a describe field ${desc}"
             )
         }
         val execName = fields.get("executableName") match {
@@ -180,7 +180,7 @@ case class CollectSubJobs(
               case Seq(JsString(seqNum)) => seqNum.toInt
               case _ =>
                 throw new Exception(
-                  s"wrong value for properties ${desc}, ${obj}"
+                    s"wrong value for properties ${desc}, ${obj}"
                 )
             }
           case _ => throw new Exception(s"wrong type for properties ${desc}")
@@ -233,7 +233,7 @@ case class CollectSubJobs(
             case (_, None) =>
               // Required output that is missing
               throw new Exception(
-                s"Could not find compulsory field <${name}> in results"
+                  s"Could not find compulsory field <${name}> in results"
               )
             case (_, Some(jsv)) =>
               Some(jobInputOutput.unpackJobInput(name, womType, jsv))

--- a/src/main/scala/dxWDL/exec/CollectSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/CollectSubJobs.scala
@@ -70,171 +70,184 @@ import dxWDL.base._
 import dxWDL.dx._
 import dxWDL.util._
 
-case class ChildExecDesc(execName: String,
-                         seqNum: Int,
-                         outputs: Map[String, JsValue],
-                         exec: DxExecution)
+case class ChildExecDesc(
+    execName: String,
+    seqNum: Int,
+    outputs: Map[String, JsValue],
+    exec: DxExecution
+)
 
-case class CollectSubJobs(jobInputOutput : JobInputOutput,
-                          inputsRaw : JsValue,
-                          instanceTypeDB : InstanceTypeDB,
-                          runtimeDebugLevel: Int,
-                          typeAliases: Map[String, WomType]) {
-    //private val verbose = runtimeDebugLevel >= 1
-    private val maxVerboseLevel = (runtimeDebugLevel == 2)
-    private val verbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, Map.empty, typeAliases)
+case class CollectSubJobs(
+    jobInputOutput: JobInputOutput,
+    inputsRaw: JsValue,
+    instanceTypeDB: InstanceTypeDB,
+    runtimeDebugLevel: Int,
+    typeAliases: Map[String, WomType]
+) {
+  //private val verbose = runtimeDebugLevel >= 1
+  private val maxVerboseLevel      = (runtimeDebugLevel == 2)
+  private val verbose              = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, Map.empty, typeAliases)
 
-    // Launch a subjob to collect the outputs
-    def launch(childJobs: Vector[DxExecution],
-               exportTypes: Map[String, WomType]) : Map[String, WdlVarLinks] = {
-        assert(!childJobs.isEmpty)
+  // Launch a subjob to collect the outputs
+  def launch(
+      childJobs: Vector[DxExecution],
+      exportTypes: Map[String, WomType]
+  ): Map[String, WdlVarLinks] = {
+    assert(!childJobs.isEmpty)
 
-        // Run a sub-job with the "collect" entry point.
-        // We need to provide the exact same inputs.
-        val dxSubJob : DxJob = DxUtils.runSubJob("collect",
-                                                 Some(instanceTypeDB.defaultInstanceType),
-                                                 inputsRaw,
-                                                 childJobs,
-                                                 maxVerboseLevel)
+    // Run a sub-job with the "collect" entry point.
+    // We need to provide the exact same inputs.
+    val dxSubJob: DxJob = DxUtils.runSubJob(
+      "collect",
+      Some(instanceTypeDB.defaultInstanceType),
+      inputsRaw,
+      childJobs,
+      maxVerboseLevel
+    )
 
-        // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
-        // is exactly the same as the parent, we can immediately exit the parent job.
-        exportTypes.map{
-            case (eVarName, womType) =>
-                eVarName -> WdlVarLinks(womType, DxlExec(dxSubJob, eVarName))
-        }.toMap
+    // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
+    // is exactly the same as the parent, we can immediately exit the parent job.
+    exportTypes.map {
+      case (eVarName, womType) =>
+        eVarName -> WdlVarLinks(womType, DxlExec(dxSubJob, eVarName))
+    }.toMap
+  }
+
+  private def findChildExecs(): Vector[DxExecution] = {
+    // get the parent job
+    val dxJob            = DxJob(DxUtils.dxEnv.getJob())
+    val parentJob: DxJob = dxJob.describe().parentJob.get
+
+    val childExecs: Vector[DxExecution] = DxFindExecutions.apply(Some(parentJob))
+
+    // make sure the collect subjob is not included. Theoretically,
+    // it should not be returned as a search result, becase we did
+    // not explicitly ask for subjobs. However, let's make
+    // sure.
+    childExecs.filter(_ != dxJob)
+  }
+
+  // Describe all the scatter child jobs. Use a bulk-describe
+  // for efficiency.
+  private def describeChildExecs(execs: Vector[DxExecution]): Vector[ChildExecDesc] = {
+    val jobInfoReq: Vector[JsValue] = execs.map { job =>
+      JsObject(
+        "id" -> JsString(job.getId),
+        "describe" -> JsObject(
+          "outputs"        -> JsBoolean(true),
+          "executableName" -> JsBoolean(true),
+          "properties"     -> JsBoolean(true)
+        )
+      )
     }
-
-    private def findChildExecs() : Vector[DxExecution] = {
-         // get the parent job
-        val dxJob = DxJob(DxUtils.dxEnv.getJob())
-        val parentJob: DxJob = dxJob.describe().parentJob.get
-
-        val childExecs : Vector[DxExecution] = DxFindExecutions.apply(Some(parentJob))
-
-        // make sure the collect subjob is not included. Theoretically,
-        // it should not be returned as a search result, becase we did
-        // not explicitly ask for subjobs. However, let's make
-        // sure.
-        childExecs.filter(_ != dxJob)
+    val req = JsObject("executions" -> JsArray(jobInfoReq))
+    System.err.println(s"bulk-describe request=${req}")
+    val retval: JsValue =
+      DxUtils.jsValueOfJsonNode(
+        DXAPI.systemDescribeExecutions(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+      )
+    val results: Vector[JsValue] = retval.asJsObject.fields.get("results") match {
+      case Some(JsArray(x)) => x.toVector
+      case _                => throw new Exception(s"wrong type for executableName ${retval}")
     }
-
-    // Describe all the scatter child jobs. Use a bulk-describe
-    // for efficiency.
-    private def describeChildExecs(execs: Vector[DxExecution]) : Vector[ChildExecDesc] = {
-        val jobInfoReq:Vector[JsValue] = execs.map{ job =>
-            JsObject(
-                "id" -> JsString(job.getId),
-                "describe" -> JsObject("outputs" -> JsBoolean(true),
-                                       "executableName" -> JsBoolean(true),
-                                       "properties" -> JsBoolean(true))
-            )
+    (execs zip results).map {
+      case (dxExec, desc) =>
+        val fields = desc.asJsObject.fields.get("describe") match {
+          case Some(JsObject(fields)) => fields
+          case _                      => throw new Exception(s"result does not contains a describe field ${desc}")
         }
-        val req = JsObject("executions" -> JsArray(jobInfoReq))
-        System.err.println(s"bulk-describe request=${req}")
-        val retval: JsValue =
-            DxUtils.jsValueOfJsonNode(
-                DXAPI.systemDescribeExecutions(DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode]))
-        val results:Vector[JsValue] = retval.asJsObject.fields.get("results") match {
-            case Some(JsArray(x)) => x.toVector
-            case _ => throw new Exception(s"wrong type for executableName ${retval}")
+        val execName = fields.get("executableName") match {
+          case Some(JsString(name)) => name
+          case _                    => throw new Exception(s"wrong type for executableName ${desc}")
         }
-        (execs zip results).map { case (dxExec, desc) =>
-            val fields = desc.asJsObject.fields.get("describe") match {
-                case Some(JsObject(fields)) => fields
-                case _ => throw new Exception(s"result does not contains a describe field ${desc}")
+        val seqNum = fields.get("properties") match {
+          case Some(obj) =>
+            obj.asJsObject.getFields("seq_number") match {
+              case Seq(JsString(seqNum)) => seqNum.toInt
+              case _                     => throw new Exception(s"wrong value for properties ${desc}, ${obj}")
             }
-            val execName = fields.get("executableName") match {
-                case Some(JsString(name)) => name
-                case _ => throw new Exception(s"wrong type for executableName ${desc}")
-            }
-            val seqNum = fields.get("properties") match {
-                case Some(obj) =>
-                    obj.asJsObject.getFields("seq_number") match {
-                        case Seq(JsString(seqNum)) => seqNum.toInt
-                        case _ => throw new Exception(s"wrong value for properties ${desc}, ${obj}")
-                    }
-                case _ => throw new Exception(s"wrong type for properties ${desc}")
-            }
-            val outputs = fields.get("output") match {
-                case None => throw new Exception(s"No output field for a child job ${desc}")
-                case Some(o) => o
-            }
-            ChildExecDesc(execName, seqNum, outputs.asJsObject.fields, dxExec)
-        }.toVector
-    }
+          case _ => throw new Exception(s"wrong type for properties ${desc}")
+        }
+        val outputs = fields.get("output") match {
+          case None    => throw new Exception(s"No output field for a child job ${desc}")
+          case Some(o) => o
+        }
+        ChildExecDesc(execName, seqNum, outputs.asJsObject.fields, dxExec)
+    }.toVector
+  }
 
-    def executableFromSeqNum() : Vector[ChildExecDesc] = {
-        // We cannot change the input fields, because this is a sub-job with the same
-        // input/output spec as the parent scatter. Therefore, we need to computationally
-        // figure out:
-        //   1) child job-ids
-        //   2) field names
-        //   3) WDL types
-        val childExecs:Vector[DxExecution] = findChildExecs()
-        System.err.println(s"childExecs=${childExecs}")
+  def executableFromSeqNum(): Vector[ChildExecDesc] = {
+    // We cannot change the input fields, because this is a sub-job with the same
+    // input/output spec as the parent scatter. Therefore, we need to computationally
+    // figure out:
+    //   1) child job-ids
+    //   2) field names
+    //   3) WDL types
+    val childExecs: Vector[DxExecution] = findChildExecs()
+    System.err.println(s"childExecs=${childExecs}")
 
-        // describe all the job outputs and which applet they were running
-        val execDescs:Vector[ChildExecDesc] = describeChildExecs(childExecs)
-        System.err.println(s"execDescs=${execDescs}")
+    // describe all the job outputs and which applet they were running
+    val execDescs: Vector[ChildExecDesc] = describeChildExecs(childExecs)
+    System.err.println(s"execDescs=${execDescs}")
 
-        // sort from low to high sequence number
-        execDescs.sortWith(_.seqNum < _.seqNum)
-    }
+    // sort from low to high sequence number
+    execDescs.sortWith(_.seqNum < _.seqNum)
+  }
 
-    // collect field [name] from all child jobs, by looking at their
-    // outputs. Coerce to the correct [womType].
-    private def collectCallField(name: String,
-                                 womType: WomType,
-                                 childJobsComplete: Vector[ChildExecDesc]) : WomValue = {
-        val vec : Vector[WomValue] =
-            childJobsComplete.flatMap{
-                case childExec =>
-                    val dxName = Utils.transformVarName(name)
-                    val fieldValue = childExec.outputs.get(dxName)
-                    (womType, fieldValue) match {
-                        case (WomOptionalType(_), None) =>
-                            // Optional field that has not been returned
-                            None
-                        case (WomOptionalType(_), Some(jsv)) =>
-                            Some(jobInputOutput.unpackJobInput(name, womType, jsv))
-                        case (_, None) =>
-                            // Required output that is missing
-                            throw new Exception(s"Could not find compulsory field <${name}> in results")
-                        case (_, Some(jsv)) =>
-                            Some(jobInputOutput.unpackJobInput(name, womType, jsv))
-                    }
-            }.toVector
-        WomArray(WomArrayType(womType), vec)
-    }
+  // collect field [name] from all child jobs, by looking at their
+  // outputs. Coerce to the correct [womType].
+  private def collectCallField(
+      name: String,
+      womType: WomType,
+      childJobsComplete: Vector[ChildExecDesc]
+  ): WomValue = {
+    val vec: Vector[WomValue] =
+      childJobsComplete.flatMap {
+        case childExec =>
+          val dxName     = Utils.transformVarName(name)
+          val fieldValue = childExec.outputs.get(dxName)
+          (womType, fieldValue) match {
+            case (WomOptionalType(_), None) =>
+              // Optional field that has not been returned
+              None
+            case (WomOptionalType(_), Some(jsv)) =>
+              Some(jobInputOutput.unpackJobInput(name, womType, jsv))
+            case (_, None) =>
+              // Required output that is missing
+              throw new Exception(s"Could not find compulsory field <${name}> in results")
+            case (_, Some(jsv)) =>
+              Some(jobInputOutput.unpackJobInput(name, womType, jsv))
+          }
+      }.toVector
+    WomArray(WomArrayType(womType), vec)
+  }
 
-    // aggregate call results
-    def aggregateResults(call: CallNode,
-                         childJobsComplete: Vector[ChildExecDesc]) : Map[String, WdlVarLinks] = {
-        call.callable.outputs.map{ cot : OutputDefinition =>
-            val fullName = s"${call.identifier.workflowLocalName}.${cot.name}"
-            val womType = cot.womType
-            val value : WomValue = collectCallField(cot.name,
-                                                    womType,
-                                                    childJobsComplete)
-            val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
-            fullName -> wvl
-        }.toMap
-    }
+  // aggregate call results
+  def aggregateResults(
+      call: CallNode,
+      childJobsComplete: Vector[ChildExecDesc]
+  ): Map[String, WdlVarLinks] = {
+    call.callable.outputs.map { cot: OutputDefinition =>
+      val fullName        = s"${call.identifier.workflowLocalName}.${cot.name}"
+      val womType         = cot.womType
+      val value: WomValue = collectCallField(cot.name, womType, childJobsComplete)
+      val wvl             = wdlVarLinksConverter.importFromWDL(value.womType, value)
+      fullName -> wvl
+    }.toMap
+  }
 
-    // collect results from a sub-workflow generated for the sole purpose of calculating
-    // a sub-block.
-    def aggregateResultsFromGeneratedSubWorkflow(execLinkInfo: ExecLinkInfo,
-                                                 childJobsComplete: Vector[ChildExecDesc])
-            : Map[String, WdlVarLinks] = {
-        execLinkInfo.outputs.map{
-            case (name, womType) =>
-                val value : WomValue = collectCallField(name,
-                                                        womType,
-                                                        childJobsComplete)
-                val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
-                name -> wvl
-        }.toMap
-    }
+  // collect results from a sub-workflow generated for the sole purpose of calculating
+  // a sub-block.
+  def aggregateResultsFromGeneratedSubWorkflow(
+      execLinkInfo: ExecLinkInfo,
+      childJobsComplete: Vector[ChildExecDesc]
+  ): Map[String, WdlVarLinks] = {
+    execLinkInfo.outputs.map {
+      case (name, womType) =>
+        val value: WomValue = collectCallField(name, womType, childJobsComplete)
+        val wvl             = wdlVarLinksConverter.importFromWDL(value.womType, value)
+        name -> wvl
+    }.toMap
+  }
 }

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -20,7 +20,7 @@ case class JobInputOutput(
     runtimeDebugLevel: Int,
     typeAliases: Map[String, WomType]
 ) {
-  private val verbose    = (runtimeDebugLevel >= 1)
+  private val verbose = (runtimeDebugLevel >= 1)
   private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
   private val wdlVarLinksConverter =
     WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
@@ -182,7 +182,7 @@ case class JobInputOutput(
 
     for (dirNum <- 1 to DISAMBIGUATION_DIRS_MAX_NUM) {
       val dir: Path = inputsDir.resolve(dirNum.toString)
-      val longPath  = dir.resolve(basename)
+      val longPath = dir.resolve(basename)
       if (!(existingFiles contains longPath))
         return longPath
     }
@@ -220,7 +220,7 @@ case class JobInputOutput(
         WomMap(t, m1)
 
       case (WomPair(l, r)) =>
-        val left  = translateFiles(l, translation)
+        val left = translateFiles(l, translation)
         val right = translateFiles(r, translation)
         WomPair(left, right)
 
@@ -266,7 +266,7 @@ case class JobInputOutput(
   ): WomValue = {
     val translation: Map[String, String] = localizationPlan.map {
       case (FurlDx(value, _, _), path) => value -> path.toString
-      case (FurlLocal(p1), p2)         => p1    -> p2.toString
+      case (FurlLocal(p1), p2)         => p1 -> p2.toString
     }.toMap
     translateFiles(womValue, translation)
   }
@@ -336,7 +336,7 @@ case class JobInputOutput(
       inputs: Map[InputDefinition, WomValue],
       inputsDir: Path
   ): (Map[InputDefinition, WomValue], Map[Furl, Path], DxdaManifest, DxfuseManifest) = {
-    val fileURLs: Vector[Furl]    = inputs.values.map(findFiles).flatten.toVector
+    val fileURLs: Vector[Furl] = inputs.values.map(findFiles).flatten.toVector
     val streamingFiles: Set[Furl] = areStreaming(parameterMeta, inputs)
     Utils.appletLog(verbose, s"streaming files = ${streamingFiles}")
 
@@ -359,7 +359,7 @@ case class JobInputOutput(
             case dxUrl: FurlDx if streamingFiles contains dxUrl =>
               // file should be streamed
               val existingFiles = accu.values.toSet
-              val (_, desc)     = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
+              val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
               val path = createUniqueDownloadPath(
                 desc.name,
                 dxUrl.dxFile,
@@ -371,8 +371,8 @@ case class JobInputOutput(
             case dxUrl: FurlDx =>
               // The file needs to be localized
               val existingFiles = accu.values.toSet
-              val (_, desc)     = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
-              val path          = createUniqueDownloadPath(desc.name, dxUrl.dxFile, existingFiles, inputsDir)
+              val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
+              val path = createUniqueDownloadPath(desc.name, dxUrl.dxFile, existingFiles, inputsDir)
               accu + (dxUrl -> path)
           }
       }

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -50,7 +50,7 @@ case class JobInputOutput(
     val value = result match {
       case Invalid(errors) =>
         throw new Exception(
-          s"Failed to evaluate expression ${expr} with ${errors}"
+            s"Failed to evaluate expression ${expr} with ${errors}"
         )
       case Valid(x: WomValue) => x
     }
@@ -86,7 +86,7 @@ case class JobInputOutput(
             fields.get(iName.value) match {
               case None =>
                 throw new Exception(
-                  s"Input ${iName} is required but not provided"
+                    s"Input ${iName} is required but not provided"
                 )
               case Some(x: JsValue) =>
                 // Conversion from JSON to WomValue
@@ -206,9 +206,9 @@ case class JobInputOutput(
         return longPath
     }
     throw new Exception(
-      s"""|Tried to download ${dxFile.getId} ${basename} to local filesystem
+        s"""|Tried to download ${dxFile.getId} ${basename} to local filesystem
                                 |at ${inputsDir}/*/${basename}, all are taken""".stripMargin
-        .replaceAll("\n", " ")
+          .replaceAll("\n", " ")
     )
   }
 
@@ -394,10 +394,10 @@ case class JobInputOutput(
               val existingFiles = accu.values.toSet
               val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
               val path = createUniqueDownloadPath(
-                desc.name,
-                dxUrl.dxFile,
-                existingFiles,
-                dxIoFunctions.config.dxfuseMountpoint
+                  desc.name,
+                  dxUrl.dxFile,
+                  existingFiles,
+                  dxIoFunctions.config.dxfuseMountpoint
               )
               accu + (dxUrl -> path)
 
@@ -406,10 +406,10 @@ case class JobInputOutput(
               val existingFiles = accu.values.toSet
               val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
               val path = createUniqueDownloadPath(
-                desc.name,
-                dxUrl.dxFile,
-                existingFiles,
-                inputsDir
+                  desc.name,
+                  dxUrl.dxFile,
+                  existingFiles,
+                  inputsDir
               )
               accu + (dxUrl -> path)
           }
@@ -465,7 +465,7 @@ case class JobInputOutput(
         case FurlLocal(p) => Paths.get(p)
         case dxUrl: FurlDx =>
           throw new Exception(
-            s"Should not find cloud file on local machine (${dxUrl})"
+              s"Should not find cloud file on local machine (${dxUrl})"
           )
       }
       .toVector

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -15,425 +15,459 @@ import dxWDL.base.Utils.{FLAT_FILES_SUFFIX}
 import dxWDL.dx.{DxFile, DxUtils, DxdaManifest, DxfuseManifest}
 import dxWDL.util._
 
-case class JobInputOutput(dxIoFunctions : DxIoFunctions,
-                          runtimeDebugLevel: Int,
-                          typeAliases: Map[String, WomType]) {
-    private val verbose = (runtimeDebugLevel >= 1)
-    private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
+case class JobInputOutput(
+    dxIoFunctions: DxIoFunctions,
+    runtimeDebugLevel: Int,
+    typeAliases: Map[String, WomType]
+) {
+  private val verbose    = (runtimeDebugLevel >= 1)
+  private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
 
-    private val DISAMBIGUATION_DIRS_MAX_NUM = 200
+  private val DISAMBIGUATION_DIRS_MAX_NUM = 200
 
-    def unpackJobInput(name: String, womType: WomType, jsv: JsValue) : WomValue = {
-        val (womValue, _) = wdlVarLinksConverter.unpackJobInput(name, womType, jsv)
-        womValue
+  def unpackJobInput(name: String, womType: WomType, jsv: JsValue): WomValue = {
+    val (womValue, _) = wdlVarLinksConverter.unpackJobInput(name, womType, jsv)
+    womValue
+  }
+
+  def unpackJobInputFindRefFiles(womType: WomType, jsv: JsValue): Vector[DxFile] = {
+    val (_, dxFiles) = wdlVarLinksConverter.unpackJobInput("", womType, jsv)
+    dxFiles
+  }
+
+  private def evaluateWomExpression(
+      expr: WomExpression,
+      womType: WomType,
+      env: Map[String, WomValue]
+  ): WomValue = {
+    val result: ErrorOr[WomValue] =
+      expr.evaluateValue(env, dxIoFunctions)
+    val value = result match {
+      case Invalid(errors) =>
+        throw new Exception(s"Failed to evaluate expression ${expr} with ${errors}")
+      case Valid(x: WomValue) => x
     }
 
-    def unpackJobInputFindRefFiles(womType: WomType, jsv: JsValue) : Vector[DxFile] = {
-        val (_, dxFiles) = wdlVarLinksConverter.unpackJobInput("", womType, jsv)
-        dxFiles
-    }
+    // cast the result value to the correct type
+    // For example, an expression like:
+    //   Float x = "3.2"
+    // requires casting from string to float
+    womType.coerceRawValue(value).get
+  }
 
-    private def evaluateWomExpression(expr: WomExpression,
-                                      womType: WomType,
-                                      env: Map[String, WomValue]) : WomValue = {
-        val result: ErrorOr[WomValue] =
-            expr.evaluateValue(env, dxIoFunctions)
-        val value = result match {
-            case Invalid(errors) => throw new Exception(
-                s"Failed to evaluate expression ${expr} with ${errors}")
-            case Valid(x: WomValue) => x
-        }
+  // Read the job-inputs JSON file, and convert the variables
+  // from JSON to WOM values. Delay downloading the files.
+  def loadInputs(
+      inputs: JsValue,
+      callable: wom.callable.Callable
+  ): Map[InputDefinition, WomValue] = {
+    // Discard auxiliary fields
+    val fields: Map[String, JsValue] = inputs.asJsObject.fields
+      .filter { case (fieldName, _) => !fieldName.endsWith(FLAT_FILES_SUFFIX) }
 
-        // cast the result value to the correct type
-        // For example, an expression like:
-        //   Float x = "3.2"
-        // requires casting from string to float
-        womType.coerceRawValue(value).get
-    }
-
-    // Read the job-inputs JSON file, and convert the variables
-    // from JSON to WOM values. Delay downloading the files.
-    def loadInputs(inputs: JsValue,
-                   callable: wom.callable.Callable): Map[InputDefinition, WomValue] = {
-        // Discard auxiliary fields
-        val fields : Map[String, JsValue] = inputs
-            .asJsObject.fields
-            .filter{ case (fieldName,_) => !fieldName.endsWith(FLAT_FILES_SUFFIX) }
-
-        // Get the declarations matching the input fields.
-        // Create a mapping from each key to its WDL value
-        callable.inputs.foldLeft(Map.empty[InputDefinition, WomValue]) {
-            case (accu, inpDfn) =>
-                val accuValues = accu.map{ case (inpDfn, value) =>
-                    inpDfn.name -> value
-                }.toMap
-                val value: WomValue = inpDfn match {
-                    // A required input, no default.
-                    case RequiredInputDefinition(iName, womType, _, _) =>
-                        fields.get(iName.value) match {
-                            case None =>
-                                throw new Exception(s"Input ${iName} is required but not provided")
-                            case Some(x : JsValue) =>
-                                // Conversion from JSON to WomValue
-                                unpackJobInput(iName.value, womType, x)
-                        }
-
-                    // An input definition that has a default value supplied.
-                    // Typical WDL example would be a declaration like: "Int x = 5"
-                    case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                        fields.get(iName.value) match {
-                            case None =>
-                                // use the default expression
-                                evaluateWomExpression(defaultExpr, womType, accuValues)
-                            case Some(x : JsValue) =>
-                                unpackJobInput(iName.value, womType, x)
-                        }
-
-                    // An input whose value should always be calculated from the default, and is
-                    // not allowed to be overridden.
-                    case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                        fields.get(iName.value) match {
-                            case None => ()
-                            case Some(_) =>
-                                throw new Exception(s"Input ${iName} should not be provided")
-                        }
-                        evaluateWomExpression(defaultExpr, womType, accuValues)
-
-                    // There are several distinct cases
-                    //
-                    //   default   input           result   comments
-                    //   -------   -----           ------   --------
-                    //   d         not-specified   d
-                    //   _         null            None     override
-                    //   _         Some(v)         Some(v)
-                    //
-                    case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
-                        fields.get(iName.value) match {
-                            case None =>
-                                // this key is not specified in the input
-                                WomOptionalValue(womType, None)
-                            case Some(JsNull) =>
-                                // the input is null
-                                WomOptionalValue(womType, None)
-                            case Some(x) =>
-                                val value : WomValue = unpackJobInput(iName.value, womType, x)
-                                WomOptionalValue(womType, Some(value))
-                        }
-                }
-                accu + (inpDfn -> value)
-        }
-    }
-
-    // find all file URLs in a Wom value
-    private def findFiles(v : WomValue) : Vector[Furl] = {
-        v match {
-            case (WomSingleFile(s)) => Vector(Furl.parse(s))
-            case (WomMap(_, m: Map[WomValue, WomValue])) =>
-                m.foldLeft(Vector.empty[Furl]) {
-                    case (accu, (k,v)) =>
-                        findFiles(k) ++ findFiles(v) ++ accu
-                }
-            case WomPair(lf, rt) =>
-                findFiles(lf) ++ findFiles(rt)
-
-            // empty array
-            case (WomArray(_, value: Seq[WomValue])) =>
-                value.map(findFiles).flatten.toVector
-
-            case (WomOptionalValue(_, Some(value))) =>
-                findFiles(value)
-
-            // structs
-            case WomObject(m, t) =>
-                m.map{
-                    case (k, v) => findFiles(v)
-                }.flatten.toVector
-
-            case _ => Vector.empty
-        }
-    }
-
-    // Create a local path for a DNAx file. The normal location, is to download
-    // to the $HOME/inputs directory. However, since downloaded files may have the same
-    // name, we may need to disambiguate them.
-    private def createUniqueDownloadPath(basename: String,
-                                         dxFile: DxFile,
-                                         existingFiles: Set[Path],
-                                         inputsDir: Path) : Path = {
-        val shortPath = inputsDir.resolve(basename)
-        if (!(existingFiles contains shortPath))
-            return shortPath
-
-        // The path is already used for a file with this name. Try to place it
-        // in directories: [inputs/1, inputs/2, ... ]
-        System.err.println(s"Disambiguating file ${basename}")
-
-        for (dirNum <- 1 to DISAMBIGUATION_DIRS_MAX_NUM) {
-            val dir:Path = inputsDir.resolve(dirNum.toString)
-            val longPath = dir.resolve(basename)
-            if (!(existingFiles contains longPath))
-                return longPath
-        }
-        throw new Exception(s"""|Tried to download ${dxFile.getId} ${basename} to local filesystem
-                                |at ${inputsDir}/*/${basename}, all are taken"""
-                                .stripMargin.replaceAll("\n", " "))
-    }
-
-
-    // Recursively go into a womValue, and replace file string with
-    // an equivalent. Use the [translation] map to translate.
-    private def translateFiles(womValue: WomValue,
-                               translation: Map[String, String]) : WomValue = {
-        womValue match {
-            // primitive types, pass through
-            case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) => womValue
-
-            // single file
-            case WomSingleFile(s) =>
-                translation.get(s) match {
-                    case None =>
-                        throw new Exception(s"Did not localize file ${s}")
-                    case Some(s2) =>
-                        WomSingleFile(s2)
-                }
-
-            // Maps
-            case (WomMap(t: WomMapType, m: Map[WomValue, WomValue])) =>
-                val m1 = m.map{ case (k, v) =>
-                    val k1 = translateFiles(k, translation)
-                    val v1 = translateFiles(v, translation)
-                    k1 -> v1
-                }
-                WomMap(t, m1)
-
-            case (WomPair(l, r)) =>
-                val left = translateFiles(l, translation)
-                val right = translateFiles(r, translation)
-                WomPair(left, right)
-
-            case WomArray(t: WomArrayType, a: Seq[WomValue]) =>
-                val a1 = a.map{ v => translateFiles(v, translation) }
-                WomArray(t, a1)
-
-            case WomOptionalValue(t,  None) =>
-                WomOptionalValue(t, None)
-
-                // special case: an optional file. If it doesn't exist,
-                // return None
-            case WomOptionalValue(WomSingleFileType, Some(WomSingleFile(localPath))) =>
-                translation.get(localPath) match {
-                    case None =>
-                        WomOptionalValue(WomSingleFileType, None)
-                    case Some(url) =>
-                        WomOptionalValue(WomSingleFileType, Some(WomSingleFile(url)))
-                }
-
-
-            case WomOptionalValue(t, Some(v)) =>
-                val v1 = translateFiles(v, translation)
-                WomOptionalValue(t, Some(v1))
-
-            case WomObject(m,t) =>
-                val m2 = m.map{
-                    case (k, v) => k -> translateFiles(v, translation)
-                }.toMap
-                WomObject(m2, t)
-
-            case _ =>
-                throw new AppInternalException(s"Unsupported wom value ${womValue}")
-        }
-    }
-
-    // Recursively go into a womValue, and replace cloud URLs with the
-    // equivalent local path.
-    private def replaceFURLsWithLocalPaths(womValue: WomValue,
-                                           localizationPlan: Map[Furl, Path]) : WomValue = {
-        val translation : Map[String, String] = localizationPlan.map{
-            case (FurlDx(value, _, _), path) =>  value -> path.toString
-            case (FurlLocal(p1), p2) => p1 -> p2.toString
+    // Get the declarations matching the input fields.
+    // Create a mapping from each key to its WDL value
+    callable.inputs.foldLeft(Map.empty[InputDefinition, WomValue]) {
+      case (accu, inpDfn) =>
+        val accuValues = accu.map {
+          case (inpDfn, value) =>
+            inpDfn.name -> value
         }.toMap
-        translateFiles(womValue, translation)
-    }
+        val value: WomValue = inpDfn match {
+          // A required input, no default.
+          case RequiredInputDefinition(iName, womType, _, _) =>
+            fields.get(iName.value) match {
+              case None =>
+                throw new Exception(s"Input ${iName} is required but not provided")
+              case Some(x: JsValue) =>
+                // Conversion from JSON to WomValue
+                unpackJobInput(iName.value, womType, x)
+            }
 
-    // Recursively go into a womValue, and replace cloud URLs with the
-    // equivalent local path.
-    private def replaceLocalPathsWithURLs(womValue: WomValue,
-                                          path2furl : Map[Path, Furl]) : WomValue = {
-        val translation : Map[String, String] = path2furl.map{
-            case (path, dxUrl:FurlDx) => path.toString -> dxUrl.value
-            case (path, local:FurlLocal) => path.toString -> local.path
+          // An input definition that has a default value supplied.
+          // Typical WDL example would be a declaration like: "Int x = 5"
+          case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+            fields.get(iName.value) match {
+              case None =>
+                // use the default expression
+                evaluateWomExpression(defaultExpr, womType, accuValues)
+              case Some(x: JsValue) =>
+                unpackJobInput(iName.value, womType, x)
+            }
+
+          // An input whose value should always be calculated from the default, and is
+          // not allowed to be overridden.
+          case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+            fields.get(iName.value) match {
+              case None => ()
+              case Some(_) =>
+                throw new Exception(s"Input ${iName} should not be provided")
+            }
+            evaluateWomExpression(defaultExpr, womType, accuValues)
+
+          // There are several distinct cases
+          //
+          //   default   input           result   comments
+          //   -------   -----           ------   --------
+          //   d         not-specified   d
+          //   _         null            None     override
+          //   _         Some(v)         Some(v)
+          //
+          case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
+            fields.get(iName.value) match {
+              case None =>
+                // this key is not specified in the input
+                WomOptionalValue(womType, None)
+              case Some(JsNull) =>
+                // the input is null
+                WomOptionalValue(womType, None)
+              case Some(x) =>
+                val value: WomValue = unpackJobInput(iName.value, womType, x)
+                WomOptionalValue(womType, Some(value))
+            }
+        }
+        accu + (inpDfn -> value)
+    }
+  }
+
+  // find all file URLs in a Wom value
+  private def findFiles(v: WomValue): Vector[Furl] = {
+    v match {
+      case (WomSingleFile(s)) => Vector(Furl.parse(s))
+      case (WomMap(_, m: Map[WomValue, WomValue])) =>
+        m.foldLeft(Vector.empty[Furl]) {
+          case (accu, (k, v)) =>
+            findFiles(k) ++ findFiles(v) ++ accu
+        }
+      case WomPair(lf, rt) =>
+        findFiles(lf) ++ findFiles(rt)
+
+      // empty array
+      case (WomArray(_, value: Seq[WomValue])) =>
+        value.map(findFiles).flatten.toVector
+
+      case (WomOptionalValue(_, Some(value))) =>
+        findFiles(value)
+
+      // structs
+      case WomObject(m, t) =>
+        m.map {
+            case (k, v) => findFiles(v)
+          }
+          .flatten
+          .toVector
+
+      case _ => Vector.empty
+    }
+  }
+
+  // Create a local path for a DNAx file. The normal location, is to download
+  // to the $HOME/inputs directory. However, since downloaded files may have the same
+  // name, we may need to disambiguate them.
+  private def createUniqueDownloadPath(
+      basename: String,
+      dxFile: DxFile,
+      existingFiles: Set[Path],
+      inputsDir: Path
+  ): Path = {
+    val shortPath = inputsDir.resolve(basename)
+    if (!(existingFiles contains shortPath))
+      return shortPath
+
+    // The path is already used for a file with this name. Try to place it
+    // in directories: [inputs/1, inputs/2, ... ]
+    System.err.println(s"Disambiguating file ${basename}")
+
+    for (dirNum <- 1 to DISAMBIGUATION_DIRS_MAX_NUM) {
+      val dir: Path = inputsDir.resolve(dirNum.toString)
+      val longPath  = dir.resolve(basename)
+      if (!(existingFiles contains longPath))
+        return longPath
+    }
+    throw new Exception(
+      s"""|Tried to download ${dxFile.getId} ${basename} to local filesystem
+                                |at ${inputsDir}/*/${basename}, all are taken""".stripMargin
+        .replaceAll("\n", " ")
+    )
+  }
+
+  // Recursively go into a womValue, and replace file string with
+  // an equivalent. Use the [translation] map to translate.
+  private def translateFiles(womValue: WomValue, translation: Map[String, String]): WomValue = {
+    womValue match {
+      // primitive types, pass through
+      case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) => womValue
+
+      // single file
+      case WomSingleFile(s) =>
+        translation.get(s) match {
+          case None =>
+            throw new Exception(s"Did not localize file ${s}")
+          case Some(s2) =>
+            WomSingleFile(s2)
+        }
+
+      // Maps
+      case (WomMap(t: WomMapType, m: Map[WomValue, WomValue])) =>
+        val m1 = m.map {
+          case (k, v) =>
+            val k1 = translateFiles(k, translation)
+            val v1 = translateFiles(v, translation)
+            k1 -> v1
+        }
+        WomMap(t, m1)
+
+      case (WomPair(l, r)) =>
+        val left  = translateFiles(l, translation)
+        val right = translateFiles(r, translation)
+        WomPair(left, right)
+
+      case WomArray(t: WomArrayType, a: Seq[WomValue]) =>
+        val a1 = a.map { v =>
+          translateFiles(v, translation)
+        }
+        WomArray(t, a1)
+
+      case WomOptionalValue(t, None) =>
+        WomOptionalValue(t, None)
+
+      // special case: an optional file. If it doesn't exist,
+      // return None
+      case WomOptionalValue(WomSingleFileType, Some(WomSingleFile(localPath))) =>
+        translation.get(localPath) match {
+          case None =>
+            WomOptionalValue(WomSingleFileType, None)
+          case Some(url) =>
+            WomOptionalValue(WomSingleFileType, Some(WomSingleFile(url)))
+        }
+
+      case WomOptionalValue(t, Some(v)) =>
+        val v1 = translateFiles(v, translation)
+        WomOptionalValue(t, Some(v1))
+
+      case WomObject(m, t) =>
+        val m2 = m.map {
+          case (k, v) => k -> translateFiles(v, translation)
         }.toMap
-        translateFiles(womValue, translation)
+        WomObject(m2, t)
+
+      case _ =>
+        throw new AppInternalException(s"Unsupported wom value ${womValue}")
     }
+  }
 
+  // Recursively go into a womValue, and replace cloud URLs with the
+  // equivalent local path.
+  private def replaceFURLsWithLocalPaths(
+      womValue: WomValue,
+      localizationPlan: Map[Furl, Path]
+  ): WomValue = {
+    val translation: Map[String, String] = localizationPlan.map {
+      case (FurlDx(value, _, _), path) => value -> path.toString
+      case (FurlLocal(p1), p2)         => p1    -> p2.toString
+    }.toMap
+    translateFiles(womValue, translation)
+  }
 
-    // Figure out which files need to be streamed
-    private def areStreaming(parameterMeta: Map[String, MetaValueElement],
-                             inputs: Map[InputDefinition, WomValue]) : Set[Furl] = {
-        inputs.map{
-            case (iDef, womValue) =>
-                if (dxIoFunctions.config.streamAllFiles) {
-                    findFiles(womValue)
+  // Recursively go into a womValue, and replace cloud URLs with the
+  // equivalent local path.
+  private def replaceLocalPathsWithURLs(
+      womValue: WomValue,
+      path2furl: Map[Path, Furl]
+  ): WomValue = {
+    val translation: Map[String, String] = path2furl.map {
+      case (path, dxUrl: FurlDx)    => path.toString -> dxUrl.value
+      case (path, local: FurlLocal) => path.toString -> local.path
+    }.toMap
+    translateFiles(womValue, translation)
+  }
+
+  // Figure out which files need to be streamed
+  private def areStreaming(
+      parameterMeta: Map[String, MetaValueElement],
+      inputs: Map[InputDefinition, WomValue]
+  ): Set[Furl] = {
+    inputs
+      .map {
+        case (iDef, womValue) =>
+          if (dxIoFunctions.config.streamAllFiles) {
+            findFiles(womValue)
+          } else {
+            // This is better than "iDef.parameterMeta", but it does not
+            // work on draft2.
+            parameterMeta.get(iDef.name) match {
+              case (Some(MetaValueElement.MetaValueElementString("stream"))) =>
+                findFiles(womValue)
+              case (Some(MetaValueElement.MetaValueElementObject(value))) =>
+                // This enables the stream annotation in the object form of metadata value, e.g.
+                // bam_file : {
+                //   stream : true
+                // }
+                if (value.contains("stream") &&
+                    value("stream").asInstanceOf[MetaValueElement.MetaValueElementBoolean].value) {
+                  findFiles(womValue)
                 } else {
-                    // This is better than "iDef.parameterMeta", but it does not
-                    // work on draft2.
-                    parameterMeta.get(iDef.name) match {
-                        case (Some(MetaValueElement.MetaValueElementString("stream"))) =>
-                            findFiles(womValue)
-                        case (Some(MetaValueElement.MetaValueElementObject(value))) =>
-                            // This enables the stream annotation in the object form of metadata value, e.g.
-                            // bam_file : {
-                            //   stream : true
-                            // }
-                            if (value.contains("stream") &&
-                                value("stream").asInstanceOf[MetaValueElement.MetaValueElementBoolean].value) {
-                                findFiles(womValue)
-                            } else {
-                                Vector.empty
-                            }
-                        case _ =>
-                            Vector.empty
-                    }
+                  Vector.empty
                 }
-        }.flatten.toSet
-    }
-
-    // After applying [loadInputs] above, we have the job inputs in the correct format,
-    // except for files. These are represented as dx URLs (dx://proj-xxxx:file-yyyy::/A/B/C.txt)
-    // instead of local files (/home/C.txt).
-    //
-    // 1. Figure out what files to download.
-    // 2. Return a new map with the localized files replacing the platform files.
-    //    Also return a mapping from the dxURL to the local path.
-    //
-    // Notes:
-    // A file may be referenced more than once, we want to download it
-    // just once.
-    def localizeFiles(parameterMeta: Map[String, MetaValueElement],
-                      inputs: Map[InputDefinition, WomValue],
-                      inputsDir: Path) : (Map[InputDefinition, WomValue],
-                                          Map[Furl, Path],
-                                          DxdaManifest,
-                                          DxfuseManifest) = {
-        val fileURLs : Vector[Furl] = inputs.values.map(findFiles).flatten.toVector
-        val streamingFiles : Set[Furl] = areStreaming(parameterMeta, inputs)
-        Utils.appletLog(verbose, s"streaming files = ${streamingFiles}")
-
-        // remove duplicates; we want to download each file just once
-        val filesToDownload: Set[Furl] = fileURLs.toSet
-
-        // Choose a local path for each cloud file
-        val furl2path: Map[Furl, Path] =
-            filesToDownload.foldLeft(Map.empty[Furl, Path]) { case (accu, furl) =>
-                furl match {
-                    case FurlLocal(p) =>
-                        // The file is already on the local disk, there
-                        // is no need to download it.
-                        //
-                        // TODO: make sure this file is NOT in the applet input/output
-                        // directories.
-                        accu + (FurlLocal(p) -> Paths.get(p))
-
-                    case dxUrl: FurlDx if streamingFiles contains dxUrl =>
-                        // file should be streamed
-                        val existingFiles = accu.values.toSet
-                        val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
-                        val path = createUniqueDownloadPath(desc.name, dxUrl.dxFile, existingFiles,
-                                                            dxIoFunctions.config.dxfuseMountpoint)
-                        accu + (dxUrl -> path)
-
-                    case dxUrl: FurlDx =>
-                        // The file needs to be localized
-                        val existingFiles = accu.values.toSet
-                        val (_, desc) = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
-                        val path = createUniqueDownloadPath(desc.name, dxUrl.dxFile, existingFiles,
-                                                            inputsDir)
-                        accu + (dxUrl -> path)
-                }
+              case _ =>
+                Vector.empty
             }
+          }
+      }
+      .flatten
+      .toSet
+  }
 
-        // Create a manifest for all the streaming files; we'll use dxfuse to handle them.
-        val filesToMount : Map[DxFile, Path] =
-            furl2path.collect{
-                case (dxUrl: FurlDx, localPath) if (streamingFiles contains dxUrl) =>
-                    dxUrl.dxFile -> localPath
-            }
-        val dxfuseManifest = DxfuseManifest.apply(filesToMount, dxIoFunctions)
+  // After applying [loadInputs] above, we have the job inputs in the correct format,
+  // except for files. These are represented as dx URLs (dx://proj-xxxx:file-yyyy::/A/B/C.txt)
+  // instead of local files (/home/C.txt).
+  //
+  // 1. Figure out what files to download.
+  // 2. Return a new map with the localized files replacing the platform files.
+  //    Also return a mapping from the dxURL to the local path.
+  //
+  // Notes:
+  // A file may be referenced more than once, we want to download it
+  // just once.
+  def localizeFiles(
+      parameterMeta: Map[String, MetaValueElement],
+      inputs: Map[InputDefinition, WomValue],
+      inputsDir: Path
+  ): (Map[InputDefinition, WomValue], Map[Furl, Path], DxdaManifest, DxfuseManifest) = {
+    val fileURLs: Vector[Furl]    = inputs.values.map(findFiles).flatten.toVector
+    val streamingFiles: Set[Furl] = areStreaming(parameterMeta, inputs)
+    Utils.appletLog(verbose, s"streaming files = ${streamingFiles}")
 
-        // Create a manifest for the download agent (dxda)
-        val filesToDownloadWithDxda : Map[String, (DxFile, Path)] =
-            furl2path.collect{
-                case (dxUrl: FurlDx, localPath) if !(streamingFiles contains dxUrl) =>
-                    dxUrl.dxFile.id -> (dxUrl.dxFile, localPath)
-            }
-        val dxdaManifest = DxdaManifest.apply(filesToDownloadWithDxda)
+    // remove duplicates; we want to download each file just once
+    val filesToDownload: Set[Furl] = fileURLs.toSet
 
-        // Replace the dxURLs with local file paths
-        val localizedInputs = inputs.map{ case (inpDef, womValue) =>
-            val v1 = replaceFURLsWithLocalPaths(womValue, furl2path)
-            inpDef -> v1
-        }
+    // Choose a local path for each cloud file
+    val furl2path: Map[Furl, Path] =
+      filesToDownload.foldLeft(Map.empty[Furl, Path]) {
+        case (accu, furl) =>
+          furl match {
+            case FurlLocal(p) =>
+              // The file is already on the local disk, there
+              // is no need to download it.
+              //
+              // TODO: make sure this file is NOT in the applet input/output
+              // directories.
+              accu + (FurlLocal(p) -> Paths.get(p))
 
-        (localizedInputs, furl2path, dxdaManifest, dxfuseManifest)
-    }
+            case dxUrl: FurlDx if streamingFiles contains dxUrl =>
+              // file should be streamed
+              val existingFiles = accu.values.toSet
+              val (_, desc)     = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
+              val path = createUniqueDownloadPath(
+                desc.name,
+                dxUrl.dxFile,
+                existingFiles,
+                dxIoFunctions.config.dxfuseMountpoint
+              )
+              accu + (dxUrl -> path)
 
-    // We have task outputs, where files are stored locally. Upload the files to
-    // the cloud, and replace the WomValues with dxURLs.
-    //
-    // Edge cases:
-    // 1) If a file is already on the cloud, do not re-upload it. The content has not
-    // changed because files are immutable.
-    // 2) A file that was initially local, does not need to be uploaded.
-    def delocalizeFiles(outputs: Map[String, WomValue],
-                        furl2path: Map[Furl, Path]) : Map[String, WomValue] = {
-        // Files that were local to begin with
-        val localInputFiles: Set[Path] = furl2path.collect{
-            case (FurlLocal(_),path) => path
-        }.toSet
-
-        val localOutputFilesAll : Vector[Path] = outputs.values.map(findFiles).flatten.toVector.map{
-            case FurlLocal(p) => Paths.get(p)
             case dxUrl: FurlDx =>
-                throw new Exception(s"Should not find cloud file on local machine (${dxUrl})")
-        }.toVector
+              // The file needs to be localized
+              val existingFiles = accu.values.toSet
+              val (_, desc)     = dxIoFunctions.fileInfoDir(dxUrl.dxFile.id)
+              val path          = createUniqueDownloadPath(desc.name, dxUrl.dxFile, existingFiles, inputsDir)
+              accu + (dxUrl -> path)
+          }
+      }
 
-        // Remove files that were local to begin with, and do not need to be uploaded to the cloud.
-        val localOutputFiles : Vector[Path] = localOutputFilesAll.filter{
-            path => !(localInputFiles contains path)
-        }.toVector
+    // Create a manifest for all the streaming files; we'll use dxfuse to handle them.
+    val filesToMount: Map[DxFile, Path] =
+      furl2path.collect {
+        case (dxUrl: FurlDx, localPath) if (streamingFiles contains dxUrl) =>
+          dxUrl.dxFile -> localPath
+      }
+    val dxfuseManifest = DxfuseManifest.apply(filesToMount, dxIoFunctions)
 
-        // 1) A path can appear multiple times, make paths unique
-        //    so we don't upload the same file twice.
-        // 2) Filter out files that are already on the cloud.
-        val filesOnCloud : Set[Path] =  furl2path.values.toSet
-        val pathsToUpload : Set[Path] = localOutputFiles.filter{ case path =>
-            !(filesOnCloud contains path)
-        }.toSet
+    // Create a manifest for the download agent (dxda)
+    val filesToDownloadWithDxda: Map[String, (DxFile, Path)] =
+      furl2path.collect {
+        case (dxUrl: FurlDx, localPath) if !(streamingFiles contains dxUrl) =>
+          dxUrl.dxFile.id -> (dxUrl.dxFile, localPath)
+      }
+    val dxdaManifest = DxdaManifest.apply(filesToDownloadWithDxda)
 
-        // upload the files; this could be in parallel in the future.
-        val uploaded_path2furl : Map[Path, Furl] = pathsToUpload.flatMap{ path =>
-            if (Files.exists(path)) {
-                val dxFile = DxUtils.uploadFile(path, verbose)
-                Some(path -> Furl.dxFileToFurl(dxFile, Map.empty))   // no cache
-            } else {
-                // The file does not exist on the local machine. This is
-                // legal if it is optional.
-                None
-            }
-        }.toMap
-
-        // invert the furl2path map
-        val alreadyOnCloud_path2furl : Map[Path, Furl] = furl2path.foldLeft(Map.empty[Path, Furl]) {
-            case (accu, (furl, path)) =>
-                accu + (path -> furl)
-        }
-        val path2furl = alreadyOnCloud_path2furl ++ uploaded_path2furl
-
-        // Replace the files that need to be uploaded, file paths with FURLs
-        outputs.map{ case (outputName, womValue) =>
-            val v1 = replaceLocalPathsWithURLs(womValue, path2furl)
-            outputName -> v1
-        }.toMap
+    // Replace the dxURLs with local file paths
+    val localizedInputs = inputs.map {
+      case (inpDef, womValue) =>
+        val v1 = replaceFURLsWithLocalPaths(womValue, furl2path)
+        inpDef -> v1
     }
+
+    (localizedInputs, furl2path, dxdaManifest, dxfuseManifest)
+  }
+
+  // We have task outputs, where files are stored locally. Upload the files to
+  // the cloud, and replace the WomValues with dxURLs.
+  //
+  // Edge cases:
+  // 1) If a file is already on the cloud, do not re-upload it. The content has not
+  // changed because files are immutable.
+  // 2) A file that was initially local, does not need to be uploaded.
+  def delocalizeFiles(
+      outputs: Map[String, WomValue],
+      furl2path: Map[Furl, Path]
+  ): Map[String, WomValue] = {
+    // Files that were local to begin with
+    val localInputFiles: Set[Path] = furl2path.collect {
+      case (FurlLocal(_), path) => path
+    }.toSet
+
+    val localOutputFilesAll: Vector[Path] = outputs.values
+      .map(findFiles)
+      .flatten
+      .toVector
+      .map {
+        case FurlLocal(p) => Paths.get(p)
+        case dxUrl: FurlDx =>
+          throw new Exception(s"Should not find cloud file on local machine (${dxUrl})")
+      }
+      .toVector
+
+    // Remove files that were local to begin with, and do not need to be uploaded to the cloud.
+    val localOutputFiles: Vector[Path] = localOutputFilesAll.filter { path =>
+      !(localInputFiles contains path)
+    }.toVector
+
+    // 1) A path can appear multiple times, make paths unique
+    //    so we don't upload the same file twice.
+    // 2) Filter out files that are already on the cloud.
+    val filesOnCloud: Set[Path] = furl2path.values.toSet
+    val pathsToUpload: Set[Path] = localOutputFiles.filter {
+      case path =>
+        !(filesOnCloud contains path)
+    }.toSet
+
+    // upload the files; this could be in parallel in the future.
+    val uploaded_path2furl: Map[Path, Furl] = pathsToUpload.flatMap { path =>
+      if (Files.exists(path)) {
+        val dxFile = DxUtils.uploadFile(path, verbose)
+        Some(path -> Furl.dxFileToFurl(dxFile, Map.empty)) // no cache
+      } else {
+        // The file does not exist on the local machine. This is
+        // legal if it is optional.
+        None
+      }
+    }.toMap
+
+    // invert the furl2path map
+    val alreadyOnCloud_path2furl: Map[Path, Furl] = furl2path.foldLeft(Map.empty[Path, Furl]) {
+      case (accu, (furl, path)) =>
+        accu + (path -> furl)
+    }
+    val path2furl = alreadyOnCloud_path2furl ++ uploaded_path2furl
+
+    // Replace the files that need to be uploaded, file paths with FURLs
+    outputs.map {
+      case (outputName, womValue) =>
+        val v1 = replaceLocalPathsWithURLs(womValue, path2furl)
+        outputName -> v1
+    }.toMap
+  }
 }

--- a/src/main/scala/dxWDL/exec/TaskRunner.scala
+++ b/src/main/scala/dxWDL/exec/TaskRunner.scala
@@ -88,9 +88,9 @@ case class TaskRunner(
     defaultRuntimeAttrs: Option[WdlRuntimeAttrs],
     runtimeDebugLevel: Int
 ) {
-  private val verbose         = (runtimeDebugLevel >= 1)
+  private val verbose = (runtimeDebugLevel >= 1)
   private val maxVerboseLevel = (runtimeDebugLevel == 2)
-  private val utlVerbose      = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
   private val wdlVarLinksConverter =
     WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
   private val DOCKER_TARBALLS_DIR = "/tmp/docker-tarballs"
@@ -132,7 +132,7 @@ case class TaskRunner(
   }
 
   def readEnvFromDisk(): (Map[String, WomValue], Map[Furl, Path]) = {
-    val buf           = Utils.readFileContent(dxPathConfig.runnerTaskEnv)
+    val buf = Utils.readFileContent(dxPathConfig.runnerTaskEnv)
     val json: JsValue = buf.parseJson
     val (locInputsM, dxUrlM) = json match {
       case JsObject(m) =>
@@ -223,8 +223,8 @@ case class TaskRunner(
         // 2. load into the local docker cache
         // 3. figure out the image name
         Utils.appletLog(verbose, s"looking up dx:url ${url}")
-        val dxFile     = DxPath.resolveDxURLFile(url)
-        val fileName   = dxFile.describe().name
+        val dxFile = DxPath.resolveDxURLFile(url)
+        val fileName = dxFile.describe().name
         val tarballDir = Paths.get(DOCKER_TARBALLS_DIR)
         Utils.safeMkdir(tarballDir)
         val localTar: Path = tarballDir.resolve(fileName)
@@ -276,7 +276,7 @@ case class TaskRunner(
 
   private def getRuntimeEnvironment(): RuntimeEnvironment = {
     val physicalMemorySize = availableMemory()
-    val numCores           = Runtime.getRuntime().availableProcessors()
+    val numCores = Runtime.getRuntime().availableProcessors()
 
     import eu.timepit.refined._
     import eu.timepit.refined.numeric._
@@ -536,7 +536,7 @@ case class TaskRunner(
         // requires casting from string to float
         val value = outDef.womType.coerceRawValue(valueRaw).get
         envFull += (outDef.name -> value)
-        outDef.name             -> value
+        outDef.name -> value
     }.toMap
 
     val outputs: Map[String, WomValue] =
@@ -589,12 +589,12 @@ case class TaskRunner(
     }
 
     val dxInstanceType = evalAttr("dx_instance_type")
-    val memory         = evalAttr("memory")
-    val diskSpace      = evalAttr("disks")
-    val cores          = evalAttr("cpu")
-    val gpu            = evalAttr("gpu")
-    val iTypeRaw       = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
-    val iType          = instanceTypeDB.apply(iTypeRaw)
+    val memory = evalAttr("memory")
+    val diskSpace = evalAttr("disks")
+    val cores = evalAttr("cpu")
+    val gpu = evalAttr("gpu")
+    val iTypeRaw = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
+    val iType = instanceTypeDB.apply(iTypeRaw)
     Utils.appletLog(
       verbose,
       s"""|calcInstanceType memory=${memory} disk=${diskSpace}

--- a/src/main/scala/dxWDL/exec/TaskRunner.scala
+++ b/src/main/scala/dxWDL/exec/TaskRunner.scala
@@ -15,7 +15,6 @@ task Add {
 }
 
   */
-
 package dxWDL.exec
 
 import cats.data.Validated.{Invalid, Valid}
@@ -38,282 +37,295 @@ import dxWDL.util._
 // This object is used to allow easy testing of complex
 // methods internal to the TaskRunner.
 object TaskRunnerUtils {
-    // Read the manifest file from a docker tarball, and get the repository name.
-    //
-    // A manifest could look like this:
-    // [
-    //    {"Config":"4b778ee055da936b387080ba034c05a8fad46d8e50ee24f27dcd0d5166c56819.json",
-    //     "RepoTags":["ubuntu_18_04_minimal:latest"],
-    //     "Layers":[
-    //          "1053541ae4c67d0daa87babb7fe26bf2f5a3b29d03f4af94e9c3cb96128116f5/layer.tar",
-    //          "fb1542f1963e61a22f9416077bf5f999753cbf363234bf8c9c5c1992d9a0b97d/layer.tar",
-    //          "2652f5844803bcf8615bec64abd20959c023d34644104245b905bb9b08667c8d/layer.tar",
-    //          ]}
-    // ]
-    def readManifestGetDockerImageName(buf: String) : String = {
-        val jso = buf.parseJson
-        val elem = jso match {
-            case JsArray(elements) if elements.size >= 1 => elements.head
-            case other => throw new Exception(s"bad value ${other} for manifest, expecting non empty array")
-        }
-        val repo: String = elem.asJsObject.fields.get("RepoTags") match {
-            case None =>
-                throw new Exception("The repository is not specified for the image")
-            case Some(JsString(repo)) =>
-                repo
-            case Some(JsArray(elements)) =>
-                if (elements.isEmpty)
-                    throw new Exception("RepoTags has an empty array")
-                elements.head match {
-                    case JsString(repo) => repo
-                    case other => throw new Exception(s"bad value ${other} in RepoTags manifest field")
-                }
-            case other =>
-                throw new Exception(s"bad value ${other} in RepoTags manifest field")
-        }
-        repo
+  // Read the manifest file from a docker tarball, and get the repository name.
+  //
+  // A manifest could look like this:
+  // [
+  //    {"Config":"4b778ee055da936b387080ba034c05a8fad46d8e50ee24f27dcd0d5166c56819.json",
+  //     "RepoTags":["ubuntu_18_04_minimal:latest"],
+  //     "Layers":[
+  //          "1053541ae4c67d0daa87babb7fe26bf2f5a3b29d03f4af94e9c3cb96128116f5/layer.tar",
+  //          "fb1542f1963e61a22f9416077bf5f999753cbf363234bf8c9c5c1992d9a0b97d/layer.tar",
+  //          "2652f5844803bcf8615bec64abd20959c023d34644104245b905bb9b08667c8d/layer.tar",
+  //          ]}
+  // ]
+  def readManifestGetDockerImageName(buf: String): String = {
+    val jso = buf.parseJson
+    val elem = jso match {
+      case JsArray(elements) if elements.size >= 1 => elements.head
+      case other =>
+        throw new Exception(s"bad value ${other} for manifest, expecting non empty array")
     }
+    val repo: String = elem.asJsObject.fields.get("RepoTags") match {
+      case None =>
+        throw new Exception("The repository is not specified for the image")
+      case Some(JsString(repo)) =>
+        repo
+      case Some(JsArray(elements)) =>
+        if (elements.isEmpty)
+          throw new Exception("RepoTags has an empty array")
+        elements.head match {
+          case JsString(repo) => repo
+          case other          => throw new Exception(s"bad value ${other} in RepoTags manifest field")
+        }
+      case other =>
+        throw new Exception(s"bad value ${other} in RepoTags manifest field")
+    }
+    repo
+  }
 }
 
 // We can't use the name Task, because that would confuse it with the
 // WDL language definition.
-case class TaskRunner(task: CallableTaskDefinition,
-                      taskSourceCode: WorkflowSource,  // for debugging/informational purposes only
-                      typeAliases: Map[String, WomType],
-                      instanceTypeDB : InstanceTypeDB,
-                      dxPathConfig : DxPathConfig,
-                      dxIoFunctions : DxIoFunctions,
-                      jobInputOutput : JobInputOutput,
-                      defaultRuntimeAttrs : Option[WdlRuntimeAttrs],
-                      runtimeDebugLevel: Int) {
-    private val verbose = (runtimeDebugLevel >= 1)
-    private val maxVerboseLevel = (runtimeDebugLevel == 2)
-    private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
-    private val DOCKER_TARBALLS_DIR = "/tmp/docker-tarballs"
+case class TaskRunner(
+    task: CallableTaskDefinition,
+    taskSourceCode: WorkflowSource, // for debugging/informational purposes only
+    typeAliases: Map[String, WomType],
+    instanceTypeDB: InstanceTypeDB,
+    dxPathConfig: DxPathConfig,
+    dxIoFunctions: DxIoFunctions,
+    jobInputOutput: JobInputOutput,
+    defaultRuntimeAttrs: Option[WdlRuntimeAttrs],
+    runtimeDebugLevel: Int
+) {
+  private val verbose         = (runtimeDebugLevel >= 1)
+  private val maxVerboseLevel = (runtimeDebugLevel == 2)
+  private val utlVerbose      = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
+  private val DOCKER_TARBALLS_DIR = "/tmp/docker-tarballs"
 
-    // check if the command section is empty
-    val commandSectionEmpty: Boolean = {
-        try {
-            val commandTemplate = task.commandTemplateString(Map.empty[InputDefinition, WomValue])
-            commandTemplate.trim.isEmpty
-        } catch {
-            case _: Throwable =>
-                false
-        }
+  // check if the command section is empty
+  val commandSectionEmpty: Boolean = {
+    try {
+      val commandTemplate = task.commandTemplateString(Map.empty[InputDefinition, WomValue])
+      commandTemplate.trim.isEmpty
+    } catch {
+      case _: Throwable =>
+        false
+    }
+  }
+
+  def getErrorOr[A](value: ErrorOr[A]): A = {
+    value match {
+      case Valid(x)   => x
+      case Invalid(s) => throw new AppInternalException(s"Invalid ${s}")
+    }
+  }
+
+  // serialize the task inputs to json, and then write to a file.
+  def writeEnvToDisk(localizedInputs: Map[String, WomValue], dxUrl2path: Map[Furl, Path]): Unit = {
+    val locInputsM: Map[String, JsValue] = localizedInputs.map {
+      case (name, v) =>
+        (name, WomValueSerialization(typeAliases).toJSON(v))
+    }.toMap
+    val dxUrlM: Map[String, JsValue] = dxUrl2path.map {
+      case (FurlLocal(url), path) =>
+        url -> JsString(path.toString)
+      case (FurlDx(value, _, _), path) =>
+        value -> JsString(path.toString)
     }
 
-    def getErrorOr[A](value: ErrorOr[A]) : A = {
-        value match {
-            case Valid(x) => x
-            case Invalid(s) => throw new AppInternalException(s"Invalid ${s}")
+    // marshal into json, and then to a string
+    val json = JsObject("localizedInputs" -> JsObject(locInputsM), "dxUrl2path" -> JsObject(dxUrlM))
+    Utils.writeFileContent(dxPathConfig.runnerTaskEnv, json.prettyPrint)
+  }
+
+  def readEnvFromDisk(): (Map[String, WomValue], Map[Furl, Path]) = {
+    val buf           = Utils.readFileContent(dxPathConfig.runnerTaskEnv)
+    val json: JsValue = buf.parseJson
+    val (locInputsM, dxUrlM) = json match {
+      case JsObject(m) =>
+        (m.get("localizedInputs"), m.get("dxUrl2path")) match {
+          case (Some(JsObject(env_m)), Some(JsObject(path_m))) =>
+            (env_m, path_m)
+          case (_, _) =>
+            throw new Exception("Malformed environment serialized to disk")
+        }
+      case _ => throw new Exception("Malformed environment serialized to disk")
+    }
+    val localizedInputs = locInputsM.map {
+      case (key, jsVal) =>
+        key -> WomValueSerialization(typeAliases).fromJSON(jsVal)
+    }.toMap
+    val dxUrl2path = dxUrlM.map {
+      case (key, JsString(path)) => Furl.parse(key) -> Paths.get(path)
+      case (_, _)                => throw new Exception("Sanity")
+    }.toMap
+    (localizedInputs, dxUrl2path)
+  }
+
+  private def printDirStruct(): Unit = {
+    Utils.appletLog(maxVerboseLevel, "Directory structure:")
+    val (stdout, stderr) = Utils.execCommand("ls -lR", None)
+    Utils.appletLog(maxVerboseLevel, stdout + "\n", 10000)
+  }
+
+  // Figure out if a docker image is specified. If so, return it as a string.
+  private def dockerImageEval(env: Map[String, WomValue]): Option[String] = {
+    val dImg: Option[WomValue] = task.runtimeAttributes.attributes.get("docker") match {
+      case None =>
+        defaultRuntimeAttrs match {
+          case None      => None
+          case Some(dra) => dra.m.get("docker")
+        }
+      case Some(expr) =>
+        val result: ErrorOr[WomValue] = expr.evaluateValue(env, dxIoFunctions)
+        result match {
+          case Valid(x) => Some(x)
+          case Invalid(_) =>
+            throw new AppInternalException(s"Invalid wom expression ${expr}")
         }
     }
-
-    // serialize the task inputs to json, and then write to a file.
-    def writeEnvToDisk(localizedInputs: Map[String, WomValue],
-                       dxUrl2path: Map[Furl, Path]) : Unit = {
-        val locInputsM : Map[String, JsValue] = localizedInputs.map{ case(name, v) =>
-            (name, WomValueSerialization(typeAliases).toJSON(v))
-        }.toMap
-        val dxUrlM : Map[String, JsValue] = dxUrl2path.map{
-            case (FurlLocal(url), path) =>
-                url -> JsString(path.toString)
-            case (FurlDx(value, _, _), path) =>
-                value -> JsString(path.toString)
-        }
-
-        // marshal into json, and then to a string
-        val json = JsObject("localizedInputs" -> JsObject(locInputsM),
-                            "dxUrl2path" -> JsObject(dxUrlM))
-        Utils.writeFileContent(dxPathConfig.runnerTaskEnv, json.prettyPrint)
+    dImg match {
+      case None               => None
+      case Some(WomString(s)) => Some(s)
+      case Some(other) =>
+        throw new AppInternalException(s"docker is not a string expression ${other}")
     }
+  }
 
-    def readEnvFromDisk() : (Map[String, WomValue], Map[Furl, Path]) = {
-        val buf = Utils.readFileContent(dxPathConfig.runnerTaskEnv)
-        val json : JsValue = buf.parseJson
-        val (locInputsM, dxUrlM) = json match {
-            case JsObject(m) =>
-                (m.get("localizedInputs"), m.get("dxUrl2path")) match {
-                    case (Some(JsObject(env_m)), Some(JsObject(path_m))) =>
-                        (env_m, path_m)
-                    case (_, _) =>
-                        throw new Exception("Malformed environment serialized to disk")
-                }
-            case _ => throw new Exception("Malformed environment serialized to disk")
-        }
-        val localizedInputs = locInputsM.map{ case (key, jsVal) =>
-            key -> WomValueSerialization(typeAliases).fromJSON(jsVal)
-        }.toMap
-        val dxUrl2path = dxUrlM.map{
-            case (key, JsString(path)) => Furl.parse(key) -> Paths.get(path)
-            case (_, _) => throw new Exception("Sanity")
-        }.toMap
-        (localizedInputs, dxUrl2path)
-    }
+  private def pullImage(dImg: String): Option[String] = {
 
-    private def printDirStruct() : Unit = {
-        Utils.appletLog(maxVerboseLevel, "Directory structure:")
-        val (stdout, stderr) = Utils.execCommand("ls -lR", None)
-        Utils.appletLog(maxVerboseLevel, stdout + "\n", 10000)
-    }
+    var retry_count = 5;
+    while (retry_count > 0) {
+      try {
+        val (outstr, errstr) = Utils.execCommand(s"docker pull ${dImg}")
 
-    // Figure out if a docker image is specified. If so, return it as a string.
-    private def dockerImageEval(env: Map[String, WomValue]) : Option[String] = {
-        val dImg : Option[WomValue] = task.runtimeAttributes.attributes.get("docker") match {
-            case None =>
-                defaultRuntimeAttrs match {
-                    case None => None
-                    case Some(dra) => dra.m.get("docker")
-                }
-            case Some(expr) =>
-                val result: ErrorOr[WomValue] = expr.evaluateValue(env, dxIoFunctions)
-                result match {
-                    case Valid(x) => Some(x)
-                    case Invalid(_) =>
-                        throw new AppInternalException(s"Invalid wom expression ${expr}")
-                }
-        }
-        dImg match {
-            case None => None
-            case Some(WomString(s)) => Some(s)
-            case Some(other) =>
-                throw new AppInternalException(s"docker is not a string expression ${other}")
-        }
-    }
-
-    private def pullImage(dImg: String): Option[String] = {
-
-        var retry_count = 5;
-        while (retry_count > 0){
-            try {
-                val (outstr, errstr) = Utils.execCommand(s"docker pull ${dImg}")
-
-                Utils.appletLog(verbose, s"""|output:
+        Utils.appletLog(
+          verbose,
+          s"""|output:
                                              |${outstr}
                                              |stderr:
-                                             |${errstr}""".stripMargin)
-                return Some(dImg)
-            } catch {
-                // ideally should catch specific exception.
-                case e: Throwable =>
-                    retry_count = retry_count - 1
-                    Utils.appletLog(verbose,
-                        s"""Failed to pull docker image:
+                                             |${errstr}""".stripMargin
+        )
+        return Some(dImg)
+      } catch {
+        // ideally should catch specific exception.
+        case e: Throwable =>
+          retry_count = retry_count - 1
+          Utils.appletLog(verbose, s"""Failed to pull docker image:
                            |${dImg}. Retrying... ${5 - retry_count}
                     """.stripMargin)
-                    Thread.sleep(1000)
-            }
-        }
-        throw new RuntimeException(s"Unable to pull docker image: ${dImg} after 5 tries")
+          Thread.sleep(1000)
+      }
     }
+    throw new RuntimeException(s"Unable to pull docker image: ${dImg} after 5 tries")
+  }
 
-    private def dockerImage(env: Map[String, WomValue]) : Option[String] = {
-        val dImg = dockerImageEval(env)
-        dImg match {
-            case Some(url) if url.startsWith(Utils.DX_URL_PREFIX) =>
-                // a tarball created with "docker save".
-                // 1. download it
-                // 2. open the tar archive
-                // 2. load into the local docker cache
-                // 3. figure out the image name
-                Utils.appletLog(verbose, s"looking up dx:url ${url}")
-                val dxFile = DxPath.resolveDxURLFile(url)
-                val fileName = dxFile.describe().name
-                val tarballDir = Paths.get(DOCKER_TARBALLS_DIR)
-                Utils.safeMkdir(tarballDir)
-                val localTar : Path = tarballDir.resolve(fileName)
+  private def dockerImage(env: Map[String, WomValue]): Option[String] = {
+    val dImg = dockerImageEval(env)
+    dImg match {
+      case Some(url) if url.startsWith(Utils.DX_URL_PREFIX) =>
+        // a tarball created with "docker save".
+        // 1. download it
+        // 2. open the tar archive
+        // 2. load into the local docker cache
+        // 3. figure out the image name
+        Utils.appletLog(verbose, s"looking up dx:url ${url}")
+        val dxFile     = DxPath.resolveDxURLFile(url)
+        val fileName   = dxFile.describe().name
+        val tarballDir = Paths.get(DOCKER_TARBALLS_DIR)
+        Utils.safeMkdir(tarballDir)
+        val localTar: Path = tarballDir.resolve(fileName)
 
-                Utils.appletLog(verbose, s"downloading docker tarball to ${localTar}")
-                DxUtils.downloadFile(localTar, dxFile, verbose)
+        Utils.appletLog(verbose, s"downloading docker tarball to ${localTar}")
+        DxUtils.downloadFile(localTar, dxFile, verbose)
 
-                Utils.appletLog(verbose, "figuring out the image name")
-                val (mContent, _) = Utils.execCommand(s"tar --to-stdout -xf ${localTar} manifest.json")
-                Utils.appletLog(verbose, s"""|manifest content:
+        Utils.appletLog(verbose, "figuring out the image name")
+        val (mContent, _) = Utils.execCommand(s"tar --to-stdout -xf ${localTar} manifest.json")
+        Utils.appletLog(
+          verbose,
+          s"""|manifest content:
                                              |${mContent}
-                                             |""".stripMargin)
-                val repo = TaskRunnerUtils.readManifestGetDockerImageName(mContent)
-                Utils.appletLog(verbose, s"repository is ${repo}")
+                                             |""".stripMargin
+        )
+        val repo = TaskRunnerUtils.readManifestGetDockerImageName(mContent)
+        Utils.appletLog(verbose, s"repository is ${repo}")
 
-                Utils.appletLog(true, s"load tarball ${localTar} to docker")
-                val (outstr,errstr) = Utils.execCommand(s"docker load --input ${localTar}")
-                Utils.appletLog(verbose, s"""|output:
+        Utils.appletLog(true, s"load tarball ${localTar} to docker")
+        val (outstr, errstr) = Utils.execCommand(s"docker load --input ${localTar}")
+        Utils.appletLog(
+          verbose,
+          s"""|output:
                                              |${outstr}
                                              |stderr:
-                                             |${errstr}""".stripMargin)
-                Some(repo)
+                                             |${errstr}""".stripMargin
+        )
+        Some(repo)
 
-            case Some(dImg) =>
-                pullImage(dImg)
+      case Some(dImg) =>
+        pullImage(dImg)
 
-            case _ =>
-                dImg
-        }
+      case _ =>
+        dImg
     }
+  }
 
-    // Figure how much memory is available for this container/image
+  // Figure how much memory is available for this container/image
+  //
+  // We may need to check the cgroup itself. Not sure how portable that is.
+  //val totalAvailableMemoryBytes = Utils.readFileContent("/sys/fs/cgroup/memory/memory.limit_in_bytes").toInt
+  //
+  private def availableMemory(): Long = {
+    val mbean = ManagementFactory
+      .getOperatingSystemMXBean()
+      .asInstanceOf[com.sun.management.OperatingSystemMXBean]
+    mbean.getTotalPhysicalMemorySize()
+  }
+
+  private def getRuntimeEnvironment(): RuntimeEnvironment = {
+    val physicalMemorySize = availableMemory()
+    val numCores           = Runtime.getRuntime().availableProcessors()
+
+    import eu.timepit.refined._
+    import eu.timepit.refined.numeric._
+    val numCoresPositiveInt = refineV[Positive](numCores).right.get
+
+    RuntimeEnvironment(
+      dxPathConfig.outputFilesDir.toAbsolutePath().toString,
+      dxPathConfig.tmpDir.toAbsolutePath().toString,
+      numCoresPositiveInt,
+      physicalMemorySize,
+      // TODO
+      1000, //outputPathSize: Long,
+      1000
+    ) //tempPathSize: Long)
+  }
+
+  // Write the core bash script into a file. In some cases, we
+  // need to run some shell setup statements before and after this
+  // script.
+  private def writeBashScript(command: String): Unit = {
+    // This is based on Cromwell code from
+    // [BackgroundAsyncJobExecutionActor.scala].  Generate a bash
+    // script that captures standard output, and standard
+    // error. We need to be careful to pipe stdout/stderr to the
+    // parent stdout/stderr, and not lose the result code of the
+    // shell command. Notes on bash magic symbols used here:
     //
-    // We may need to check the cgroup itself. Not sure how portable that is.
-    //val totalAvailableMemoryBytes = Utils.readFileContent("/sys/fs/cgroup/memory/memory.limit_in_bytes").toInt
+    //  Symbol  Explanation
+    //    >     redirect stdout
+    //    2>    redirect stderr
+    //    <     redirect stdin
     //
-    private def availableMemory() : Long = {
-        val mbean = ManagementFactory.getOperatingSystemMXBean()
-            .asInstanceOf[com.sun.management.OperatingSystemMXBean]
-        mbean.getTotalPhysicalMemorySize()
-    }
-
-    private def getRuntimeEnvironment() : RuntimeEnvironment = {
-        val physicalMemorySize = availableMemory()
-        val numCores = Runtime.getRuntime().availableProcessors()
-
-        import eu.timepit.refined._
-        import eu.timepit.refined.numeric._
-        val numCoresPositiveInt = refineV[Positive](numCores).right.get
-
-        RuntimeEnvironment(
-            dxPathConfig.outputFilesDir.toAbsolutePath().toString,
-            dxPathConfig.tmpDir.toAbsolutePath().toString,
-            numCoresPositiveInt,
-            physicalMemorySize,
-
-            // TODO
-            1000, //outputPathSize: Long,
-            1000) //tempPathSize: Long)
-    }
-
-    // Write the core bash script into a file. In some cases, we
-    // need to run some shell setup statements before and after this
-    // script.
-    private def writeBashScript(command: String) : Unit = {
-        // This is based on Cromwell code from
-        // [BackgroundAsyncJobExecutionActor.scala].  Generate a bash
-        // script that captures standard output, and standard
-        // error. We need to be careful to pipe stdout/stderr to the
-        // parent stdout/stderr, and not lose the result code of the
-        // shell command. Notes on bash magic symbols used here:
-        //
-        //  Symbol  Explanation
-        //    >     redirect stdout
-        //    2>    redirect stderr
-        //    <     redirect stdin
-        //
-        val script =
-            if (command.isEmpty) {
-                s"""|#!/bin/bash
+    val script =
+      if (command.isEmpty) {
+        s"""|#!/bin/bash
                     |echo 0 > ${dxPathConfig.rcPath}
                     |""".stripMargin.trim + "\n"
-            } else {
-                // It would have been easier to have one long
-                // section bracketed with triple quotes (`"""`). However,
-                // some characters are dropped from [command] this way, for
-                // example pipe ('|').
-                val part1 =
-                    s"""|#!/bin/bash
+      } else {
+        // It would have been easier to have one long
+        // section bracketed with triple quotes (`"""`). However,
+        // some characters are dropped from [command] this way, for
+        // example pipe ('|').
+        val part1 =
+          s"""|#!/bin/bash
                         |(
                         |    cd ${dxPathConfig.homeDir.toString}
                         |""".stripMargin
-                val part2 =
-                    s"""|) \\
+        val part2 =
+          s"""|) \\
                         |  > >( tee ${dxPathConfig.stdout} ) \\
                         |  2> >( tee ${dxPathConfig.stderr} >&2 )
                         |
@@ -324,34 +336,33 @@ case class TaskRunner(task: CallableTaskDefinition,
                         |# characters that may be in the fifo queues.
                         |sync
                         |""".stripMargin
-                List(part1, command, part2).mkString("\n")
-            }
-        Utils.appletLog(verbose, s"writing bash script to ${dxPathConfig.script}")
-        Utils.writeFileContent(dxPathConfig.script, script)
-        dxPathConfig.script.toFile.setExecutable(true)
-    }
+        List(part1, command, part2).mkString("\n")
+      }
+    Utils.appletLog(verbose, s"writing bash script to ${dxPathConfig.script}")
+    Utils.writeFileContent(dxPathConfig.script, script)
+    dxPathConfig.script.toFile.setExecutable(true)
+  }
 
-    private def writeDockerSubmitBashScript(imgName: String,
-                                            dxfuseRunning: Boolean) : Unit = {
-        // The user wants to use a docker container with the
-        // image [imgName].
-        //
-        // Map the home directory into the container, so that
-        // we can reach the result files, and upload them to
-        // the platform.
-        //
+  private def writeDockerSubmitBashScript(imgName: String, dxfuseRunning: Boolean): Unit = {
+    // The user wants to use a docker container with the
+    // image [imgName].
+    //
+    // Map the home directory into the container, so that
+    // we can reach the result files, and upload them to
+    // the platform.
+    //
 
-        // Limit the docker container to leave some memory for the rest of the
-        // ongoing system services, for example, dxfuse.
+    // Limit the docker container to leave some memory for the rest of the
+    // ongoing system services, for example, dxfuse.
 
-        val totalAvailableMemoryBytes = availableMemory()
-        val memCap =
-            if (dxfuseRunning)
-                totalAvailableMemoryBytes - Utils.DXFUSE_MAX_MEMORY_CONSUMPTION
-            else
-                totalAvailableMemoryBytes
-        val dockerRunScript =
-            s"""|#!/bin/bash -x
+    val totalAvailableMemoryBytes = availableMemory()
+    val memCap =
+      if (dxfuseRunning)
+        totalAvailableMemoryBytes - Utils.DXFUSE_MAX_MEMORY_CONSUMPTION
+      else
+        totalAvailableMemoryBytes
+    val dockerRunScript =
+      s"""|#!/bin/bash -x
                 |
                 |# make sure there is no preexisting Docker CID file
                 |rm -f ${dxPathConfig.dockerCid}
@@ -381,12 +392,12 @@ case class TaskRunner(task: CallableTaskDefinition,
                 |exit $$rc
                 |""".stripMargin
 
-        Utils.appletLog(verbose, s"writing docker run script to ${dxPathConfig.dockerSubmitScript}")
-        Utils.writeFileContent(dxPathConfig.dockerSubmitScript, dockerRunScript)
-        dxPathConfig.dockerSubmitScript.toFile.setExecutable(true)
-    }
+    Utils.appletLog(verbose, s"writing docker run script to ${dxPathConfig.dockerSubmitScript}")
+    Utils.writeFileContent(dxPathConfig.dockerSubmitScript, dockerRunScript)
+    dxPathConfig.dockerSubmitScript.toFile.setExecutable(true)
+  }
 
-/*
+  /*
     private def evalEnvironment(localizedInputs: Map[InputDefinition, WomValue]) : Map[String, WomValue] = {
         val inputs = localizedInputs.map{ case (inpDfn, value) =>
             inpDfn.name -> value
@@ -410,227 +421,246 @@ case class TaskRunner(task: CallableTaskDefinition,
 
         inputs ++ env
     }
- */
+   */
 
-    private def inputsDbg(inputs: Map[InputDefinition, WomValue]) : String = {
-        inputs.map{ case (inp, value) =>
-            val i = WomPrettyPrint.apply(inp)
-            s"${i} -> ${value}"
-        }.mkString("\n")
+  private def inputsDbg(inputs: Map[InputDefinition, WomValue]): String = {
+    inputs
+      .map {
+        case (inp, value) =>
+          val i = WomPrettyPrint.apply(inp)
+          s"${i} -> ${value}"
+      }
+      .mkString("\n")
+  }
+
+  // Calculate the input variables for the task, download the input files,
+  // and build a shell script to run the command.
+  def prolog(
+      taskInputs: Map[InputDefinition, WomValue]
+  ): (Map[String, WomValue], Map[Furl, Path]) = {
+    Utils.appletLog(verbose, s"Prolog  debugLevel=${runtimeDebugLevel}")
+    Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
+    if (maxVerboseLevel)
+      printDirStruct()
+
+    Utils.appletLog(verbose, s"Task source code:")
+    Utils.appletLog(verbose, taskSourceCode, 10000)
+    Utils.appletLog(verbose, s"inputs: ${inputsDbg(taskInputs)}")
+
+    if (commandSectionEmpty) {
+      // The command section is empty, there is no need to setup docker,
+      // or download files.
+      val inputs = taskInputs.map {
+        case (inpDfn, value) =>
+          inpDfn.name -> value
+      }.toMap
+      // write an empty bash script
+      writeBashScript("")
+      return (inputs, Map.empty)
     }
 
-    // Calculate the input variables for the task, download the input files,
-    // and build a shell script to run the command.
-    def prolog(taskInputs: Map[InputDefinition, WomValue]) :
-            (Map[String, WomValue], Map[Furl, Path]) =
-    {
-        Utils.appletLog(verbose, s"Prolog  debugLevel=${runtimeDebugLevel}")
-        Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
-        if (maxVerboseLevel)
-            printDirStruct()
-
-        Utils.appletLog(verbose, s"Task source code:")
-        Utils.appletLog(verbose, taskSourceCode, 10000)
-        Utils.appletLog(verbose, s"inputs: ${inputsDbg(taskInputs)}")
-
-        if (commandSectionEmpty) {
-            // The command section is empty, there is no need to setup docker,
-            // or download files.
-            val inputs = taskInputs.map{ case (inpDfn, value) =>
-                inpDfn.name -> value
-            }.toMap
-            // write an empty bash script
-            writeBashScript("")
-            return (inputs, Map.empty)
-        }
-
-        // Download/stream all input files.
-        //
-        // Note: this may be overly conservative,
-        // because some of the files may not actually be accessed.
-        val (localizedInputs, dxUrl2path, dxdaManifest, dxfuseManifest) =
-            jobInputOutput.localizeFiles(task.parameterMeta, taskInputs, dxPathConfig.inputFilesDir)
-
-        // build a manifest for dxda, if there are files to download
-        val DxdaManifest(manifestJs) = dxdaManifest
-        if (manifestJs.asJsObject.fields.size > 0) {
-            Utils.writeFileContent(dxPathConfig.dxdaManifest, manifestJs.prettyPrint)
-        }
-
-        // build a manifest for dxfuse
-        val DxfuseManifest(manifest2Js) = dxfuseManifest
-        if (manifest2Js != JsNull) {
-            Utils.writeFileContent(dxPathConfig.dxfuseManifest, manifest2Js.prettyPrint)
-        }
-
-        val inputs = localizedInputs.map{ case (inpDfn, value) =>
-            inpDfn.name -> value
-        }.toMap
-        val docker = dockerImage(inputs)
-
-        // instantiate the command
-        val runtimeEnvironment = getRuntimeEnvironment()
-        val womInstantiation = getErrorOr(task.instantiateCommand(localizedInputs,
-                                                                  dxIoFunctions,
-                                                                  identity,
-                                                                  runtimeEnvironment))
-        val command = womInstantiation.commandString
-
-        // Write shell script to a file. It will be executed by the dx-applet shell code.
-        writeBashScript(command)
-        docker match {
-            case Some(img) =>
-                // write a script that launches the actual command inside a docker image.
-                writeDockerSubmitBashScript(img, manifest2Js != JsNull)
-            case None => ()
-        }
-
-        // Record the localized inputs, we need them in the epilog
-        (inputs, dxUrl2path)
-    }
-
-    def epilog(localizedInputValues: Map[String, WomValue],
-               dxUrl2path: Map[Furl, Path]) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"Epilog  debugLevel=${runtimeDebugLevel}")
-        if (maxVerboseLevel)
-            printDirStruct()
-
-        // Evaluate the output declarations. Add outputs evaluated to
-        // the environment, so they can be referenced by expressions in the next
-        // lines.
-        var envFull = localizedInputValues
-        val outputsLocal: Map[String, WomValue] = task.outputs.map{
-            case (outDef: OutputDefinition) =>
-                val result: ErrorOr[WomValue] =
-                    outDef.expression.evaluateValue(envFull, dxIoFunctions)
-                val valueRaw = result match {
-                    case Valid(value) =>
-                        value
-                    case Invalid(errors) =>
-                        Utils.error(errors.toList.mkString)
-                        throw new AppInternalException(s"Error evaluating output expression ${outDef.expression}")
-                }
-
-                // cast the result value to the correct type
-                // For example, an expression like:
-                //   Float x = "3.2"
-                // requires casting from string to float
-                val value = outDef.womType.coerceRawValue(valueRaw).get
-                envFull += (outDef.name -> value)
-                outDef.name -> value
-        }.toMap
-
-        val outputs : Map[String, WomValue] =
-            if (commandSectionEmpty) {
-                // the command section is empty, so there is no manipulation of local files.
-                // we do not upload or download files.
-                outputsLocal
-            } else {
-                // Upload output files to the platform.
-                jobInputOutput.delocalizeFiles(outputsLocal, dxUrl2path)
-            }
-
-        // convert the WDL values to JSON
-        val outputFields:Map[String, JsValue] = outputs.map {
-            case (outputVarName, womValue) =>
-                val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
-                wdlVarLinksConverter.genFields(wvl, outputVarName)
-        }.toList.flatten.toMap
-        outputFields
-    }
-
-
-    // Evaluate the runtime expressions, and figure out which instance type
-    // this task requires.
+    // Download/stream all input files.
     //
-    // Do not download the files, if there are any. We may be
-    // calculating the instance type in the workflow runner, outside
-    // the task.
-    def calcInstanceType(taskInputs: Map[InputDefinition, WomValue]) : String = {
-        // evaluate the declarations
-        val inputs = taskInputs.map{ case (inpDfn, value) =>
-            inpDfn.name -> value
-        }.toMap
+    // Note: this may be overly conservative,
+    // because some of the files may not actually be accessed.
+    val (localizedInputs, dxUrl2path, dxdaManifest, dxfuseManifest) =
+      jobInputOutput.localizeFiles(task.parameterMeta, taskInputs, dxPathConfig.inputFilesDir)
 
-        def evalAttr(attrName: String) : Option[WomValue] = {
-            task.runtimeAttributes.attributes.get(attrName) match {
-                case None =>
-                    // try the defaults
-                    defaultRuntimeAttrs match {
-                        case None => None
-                        case Some(dra) => dra.m.get(attrName)
-                    }
-                case Some(expr) =>
-                    Some(getErrorOr(expr.evaluateValue(inputs, dxIoFunctions)))
-            }
+    // build a manifest for dxda, if there are files to download
+    val DxdaManifest(manifestJs) = dxdaManifest
+    if (manifestJs.asJsObject.fields.size > 0) {
+      Utils.writeFileContent(dxPathConfig.dxdaManifest, manifestJs.prettyPrint)
+    }
+
+    // build a manifest for dxfuse
+    val DxfuseManifest(manifest2Js) = dxfuseManifest
+    if (manifest2Js != JsNull) {
+      Utils.writeFileContent(dxPathConfig.dxfuseManifest, manifest2Js.prettyPrint)
+    }
+
+    val inputs = localizedInputs.map {
+      case (inpDfn, value) =>
+        inpDfn.name -> value
+    }.toMap
+    val docker = dockerImage(inputs)
+
+    // instantiate the command
+    val runtimeEnvironment = getRuntimeEnvironment()
+    val womInstantiation = getErrorOr(
+      task.instantiateCommand(localizedInputs, dxIoFunctions, identity, runtimeEnvironment)
+    )
+    val command = womInstantiation.commandString
+
+    // Write shell script to a file. It will be executed by the dx-applet shell code.
+    writeBashScript(command)
+    docker match {
+      case Some(img) =>
+        // write a script that launches the actual command inside a docker image.
+        writeDockerSubmitBashScript(img, manifest2Js != JsNull)
+      case None => ()
+    }
+
+    // Record the localized inputs, we need them in the epilog
+    (inputs, dxUrl2path)
+  }
+
+  def epilog(
+      localizedInputValues: Map[String, WomValue],
+      dxUrl2path: Map[Furl, Path]
+  ): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"Epilog  debugLevel=${runtimeDebugLevel}")
+    if (maxVerboseLevel)
+      printDirStruct()
+
+    // Evaluate the output declarations. Add outputs evaluated to
+    // the environment, so they can be referenced by expressions in the next
+    // lines.
+    var envFull = localizedInputValues
+    val outputsLocal: Map[String, WomValue] = task.outputs.map {
+      case (outDef: OutputDefinition) =>
+        val result: ErrorOr[WomValue] =
+          outDef.expression.evaluateValue(envFull, dxIoFunctions)
+        val valueRaw = result match {
+          case Valid(value) =>
+            value
+          case Invalid(errors) =>
+            Utils.error(errors.toList.mkString)
+            throw new AppInternalException(
+              s"Error evaluating output expression ${outDef.expression}"
+            )
         }
 
-        val dxInstanceType = evalAttr("dx_instance_type")
-        val memory = evalAttr("memory")
-        val diskSpace = evalAttr("disks")
-        val cores = evalAttr("cpu")
-        val gpu = evalAttr("gpu")
-        val iTypeRaw = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
-        val iType = instanceTypeDB.apply(iTypeRaw)
-        Utils.appletLog(verbose, s"""|calcInstanceType memory=${memory} disk=${diskSpace}
-                                     |cores=${cores} instancetype=${iType}"""
-                            .stripMargin.replaceAll("\n", " "))
-        iType
+        // cast the result value to the correct type
+        // For example, an expression like:
+        //   Float x = "3.2"
+        // requires casting from string to float
+        val value = outDef.womType.coerceRawValue(valueRaw).get
+        envFull += (outDef.name -> value)
+        outDef.name             -> value
+    }.toMap
+
+    val outputs: Map[String, WomValue] =
+      if (commandSectionEmpty) {
+        // the command section is empty, so there is no manipulation of local files.
+        // we do not upload or download files.
+        outputsLocal
+      } else {
+        // Upload output files to the platform.
+        jobInputOutput.delocalizeFiles(outputsLocal, dxUrl2path)
+      }
+
+    // convert the WDL values to JSON
+    val outputFields: Map[String, JsValue] = outputs
+      .map {
+        case (outputVarName, womValue) =>
+          val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
+          wdlVarLinksConverter.genFields(wvl, outputVarName)
+      }
+      .toList
+      .flatten
+      .toMap
+    outputFields
+  }
+
+  // Evaluate the runtime expressions, and figure out which instance type
+  // this task requires.
+  //
+  // Do not download the files, if there are any. We may be
+  // calculating the instance type in the workflow runner, outside
+  // the task.
+  def calcInstanceType(taskInputs: Map[InputDefinition, WomValue]): String = {
+    // evaluate the declarations
+    val inputs = taskInputs.map {
+      case (inpDfn, value) =>
+        inpDfn.name -> value
+    }.toMap
+
+    def evalAttr(attrName: String): Option[WomValue] = {
+      task.runtimeAttributes.attributes.get(attrName) match {
+        case None =>
+          // try the defaults
+          defaultRuntimeAttrs match {
+            case None      => None
+            case Some(dra) => dra.m.get(attrName)
+          }
+        case Some(expr) =>
+          Some(getErrorOr(expr.evaluateValue(inputs, dxIoFunctions)))
+      }
     }
 
-    /** Check if we are already on the correct instance type. This allows for avoiding unnecessary
-      * relaunch operations.
-      */
-    def checkInstanceType(inputs: Map[InputDefinition, WomValue]) : Boolean = {
-        // evaluate the runtime attributes
-        // determine the instance type
-        Utils.appletLog(verbose, s"inputs: ${inputsDbg(inputs)}")
+    val dxInstanceType = evalAttr("dx_instance_type")
+    val memory         = evalAttr("memory")
+    val diskSpace      = evalAttr("disks")
+    val cores          = evalAttr("cpu")
+    val gpu            = evalAttr("gpu")
+    val iTypeRaw       = InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
+    val iType          = instanceTypeDB.apply(iTypeRaw)
+    Utils.appletLog(
+      verbose,
+      s"""|calcInstanceType memory=${memory} disk=${diskSpace}
+                                     |cores=${cores} instancetype=${iType}""".stripMargin
+        .replaceAll("\n", " ")
+    )
+    iType
+  }
 
-        val requiredInstanceType:String = calcInstanceType(inputs)
-        Utils.appletLog(verbose, s"required instance type: ${requiredInstanceType}")
+  /** Check if we are already on the correct instance type. This allows for avoiding unnecessary
+    * relaunch operations.
+    */
+  def checkInstanceType(inputs: Map[InputDefinition, WomValue]): Boolean = {
+    // evaluate the runtime attributes
+    // determine the instance type
+    Utils.appletLog(verbose, s"inputs: ${inputsDbg(inputs)}")
 
-        // Figure out which instance we are on right now
-        val dxJob = DxJob(DxUtils.dxEnv.getJob())
+    val requiredInstanceType: String = calcInstanceType(inputs)
+    Utils.appletLog(verbose, s"required instance type: ${requiredInstanceType}")
 
-        val descFieldReq = JsObject("fields" -> JsObject("instanceType" -> JsBoolean(true)))
-        val retval: JsValue =
-            DxUtils.jsValueOfJsonNode(
-                DXAPI.jobDescribe(dxJob.id,
-                                  DxUtils.jsonNodeOfJsValue(descFieldReq),
-                                  classOf[JsonNode]))
-        val crntInstanceType:String = retval.asJsObject.fields.get("instanceType") match {
-            case Some(JsString(x)) => x
-            case _ => throw new Exception(s"wrong type for instanceType ${retval}")
-        }
-        Utils.appletLog(verbose, s"current instance type: ${crntInstanceType}")
+    // Figure out which instance we are on right now
+    val dxJob = DxJob(DxUtils.dxEnv.getJob())
 
-        val isSufficient = instanceTypeDB.lteqByResources(requiredInstanceType, crntInstanceType)
-        Utils.appletLog(verbose, s"isSufficient? ${isSufficient}")
-        isSufficient
+    val descFieldReq = JsObject("fields" -> JsObject("instanceType" -> JsBoolean(true)))
+    val retval: JsValue =
+      DxUtils.jsValueOfJsonNode(
+        DXAPI.jobDescribe(dxJob.id, DxUtils.jsonNodeOfJsValue(descFieldReq), classOf[JsonNode])
+      )
+    val crntInstanceType: String = retval.asJsObject.fields.get("instanceType") match {
+      case Some(JsString(x)) => x
+      case _                 => throw new Exception(s"wrong type for instanceType ${retval}")
     }
+    Utils.appletLog(verbose, s"current instance type: ${crntInstanceType}")
 
-    /** The runtime attributes need to be calculated at runtime. Evaluate them,
-      *  determine the instance type [xxxx], and relaunch the job on [xxxx]
-      */
-    def relaunch(inputs: Map[InputDefinition, WomValue], originalInputs : JsValue) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"inputs: ${inputsDbg(inputs)}")
+    val isSufficient = instanceTypeDB.lteqByResources(requiredInstanceType, crntInstanceType)
+    Utils.appletLog(verbose, s"isSufficient? ${isSufficient}")
+    isSufficient
+  }
 
-        // evaluate the runtime attributes
-        // determine the instance type
-        val instanceType:String = calcInstanceType(inputs)
+  /** The runtime attributes need to be calculated at runtime. Evaluate them,
+    *  determine the instance type [xxxx], and relaunch the job on [xxxx]
+    */
+  def relaunch(
+      inputs: Map[InputDefinition, WomValue],
+      originalInputs: JsValue
+  ): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"inputs: ${inputsDbg(inputs)}")
 
-        // Run a sub-job with the "body" entry point, and the required instance type
-        val dxSubJob : DxJob = DxUtils.runSubJob("body", Some(instanceType), originalInputs,
-                                                 Vector.empty, maxVerboseLevel)
+    // evaluate the runtime attributes
+    // determine the instance type
+    val instanceType: String = calcInstanceType(inputs)
 
-        // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
-        // is exactly the same as the parent, we can immediately exit the parent job.
-        val outputs: Map[String, JsValue] = task.outputs.map {
-            case (outDef: OutputDefinition) =>
-                val wvl = WdlVarLinks(outDef.womType,
-                                      DxlExec(dxSubJob, outDef.name))
-                wdlVarLinksConverter.genFields(wvl, outDef.name)
-        }.flatten.toMap
-        outputs
-    }
+    // Run a sub-job with the "body" entry point, and the required instance type
+    val dxSubJob: DxJob =
+      DxUtils.runSubJob("body", Some(instanceType), originalInputs, Vector.empty, maxVerboseLevel)
+
+    // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
+    // is exactly the same as the parent, we can immediately exit the parent job.
+    val outputs: Map[String, JsValue] = task.outputs
+      .map {
+        case (outDef: OutputDefinition) =>
+          val wvl = WdlVarLinks(outDef.womType, DxlExec(dxSubJob, outDef.name))
+          wdlVarLinksConverter.genFields(wvl, outDef.name)
+      }
+      .flatten
+      .toMap
+    outputs
+  }
 }

--- a/src/main/scala/dxWDL/exec/TaskRunner.scala
+++ b/src/main/scala/dxWDL/exec/TaskRunner.scala
@@ -55,7 +55,7 @@ object TaskRunnerUtils {
       case JsArray(elements) if elements.size >= 1 => elements.head
       case other =>
         throw new Exception(
-          s"bad value ${other} for manifest, expecting non empty array"
+            s"bad value ${other} for manifest, expecting non empty array"
         )
     }
     val repo: String = elem.asJsObject.fields.get("RepoTags") match {
@@ -70,7 +70,7 @@ object TaskRunnerUtils {
           case JsString(repo) => repo
           case other =>
             throw new Exception(
-              s"bad value ${other} in RepoTags manifest field"
+                s"bad value ${other} in RepoTags manifest field"
             )
         }
       case other =>
@@ -137,8 +137,8 @@ case class TaskRunner(
 
     // marshal into json, and then to a string
     val json = JsObject(
-      "localizedInputs" -> JsObject(locInputsM),
-      "dxUrl2path" -> JsObject(dxUrlM)
+        "localizedInputs" -> JsObject(locInputsM),
+        "dxUrl2path" -> JsObject(dxUrlM)
     )
     Utils.writeFileContent(dxPathConfig.runnerTaskEnv, json.prettyPrint)
   }
@@ -195,7 +195,7 @@ case class TaskRunner(
       case Some(WomString(s)) => Some(s)
       case Some(other) =>
         throw new AppInternalException(
-          s"docker is not a string expression ${other}"
+            s"docker is not a string expression ${other}"
         )
     }
   }
@@ -208,8 +208,8 @@ case class TaskRunner(
         val (outstr, errstr) = Utils.execCommand(s"docker pull ${dImg}")
 
         Utils.appletLog(
-          verbose,
-          s"""|output:
+            verbose,
+            s"""|output:
                                              |${outstr}
                                              |stderr:
                                              |${errstr}""".stripMargin
@@ -226,7 +226,7 @@ case class TaskRunner(
       }
     }
     throw new RuntimeException(
-      s"Unable to pull docker image: ${dImg} after 5 tries"
+        s"Unable to pull docker image: ${dImg} after 5 tries"
     )
   }
 
@@ -253,8 +253,8 @@ case class TaskRunner(
         val (mContent, _) =
           Utils.execCommand(s"tar --to-stdout -xf ${localTar} manifest.json")
         Utils.appletLog(
-          verbose,
-          s"""|manifest content:
+            verbose,
+            s"""|manifest content:
                                              |${mContent}
                                              |""".stripMargin
         )
@@ -265,8 +265,8 @@ case class TaskRunner(
         val (outstr, errstr) =
           Utils.execCommand(s"docker load --input ${localTar}")
         Utils.appletLog(
-          verbose,
-          s"""|output:
+            verbose,
+            s"""|output:
                                              |${outstr}
                                              |stderr:
                                              |${errstr}""".stripMargin
@@ -302,13 +302,13 @@ case class TaskRunner(
     val numCoresPositiveInt = refineV[Positive](numCores).right.get
 
     RuntimeEnvironment(
-      dxPathConfig.outputFilesDir.toAbsolutePath().toString,
-      dxPathConfig.tmpDir.toAbsolutePath().toString,
-      numCoresPositiveInt,
-      physicalMemorySize,
-      // TODO
-      1000, //outputPathSize: Long,
-      1000
+        dxPathConfig.outputFilesDir.toAbsolutePath().toString,
+        dxPathConfig.tmpDir.toAbsolutePath().toString,
+        numCoresPositiveInt,
+        physicalMemorySize,
+        // TODO
+        1000, //outputPathSize: Long,
+        1000
     ) //tempPathSize: Long)
   }
 
@@ -415,8 +415,8 @@ case class TaskRunner(
                 |""".stripMargin
 
     Utils.appletLog(
-      verbose,
-      s"writing docker run script to ${dxPathConfig.dockerSubmitScript}"
+        verbose,
+        s"writing docker run script to ${dxPathConfig.dockerSubmitScript}"
     )
     Utils.writeFileContent(dxPathConfig.dockerSubmitScript, dockerRunScript)
     dxPathConfig.dockerSubmitScript.toFile.setExecutable(true)
@@ -490,9 +490,9 @@ case class TaskRunner(
     // because some of the files may not actually be accessed.
     val (localizedInputs, dxUrl2path, dxdaManifest, dxfuseManifest) =
       jobInputOutput.localizeFiles(
-        task.parameterMeta,
-        taskInputs,
-        dxPathConfig.inputFilesDir
+          task.parameterMeta,
+          taskInputs,
+          dxPathConfig.inputFilesDir
       )
 
     // build a manifest for dxda, if there are files to download
@@ -505,8 +505,8 @@ case class TaskRunner(
     val DxfuseManifest(manifest2Js) = dxfuseManifest
     if (manifest2Js != JsNull) {
       Utils.writeFileContent(
-        dxPathConfig.dxfuseManifest,
-        manifest2Js.prettyPrint
+          dxPathConfig.dxfuseManifest,
+          manifest2Js.prettyPrint
       )
     }
 
@@ -519,12 +519,12 @@ case class TaskRunner(
     // instantiate the command
     val runtimeEnvironment = getRuntimeEnvironment()
     val womInstantiation = getErrorOr(
-      task.instantiateCommand(
-        localizedInputs,
-        dxIoFunctions,
-        identity,
-        runtimeEnvironment
-      )
+        task.instantiateCommand(
+            localizedInputs,
+            dxIoFunctions,
+            identity,
+            runtimeEnvironment
+        )
     )
     val command = womInstantiation.commandString
 
@@ -563,7 +563,7 @@ case class TaskRunner(
           case Invalid(errors) =>
             Utils.error(errors.toList.mkString)
             throw new AppInternalException(
-              s"Error evaluating output expression ${outDef.expression}"
+                s"Error evaluating output expression ${outDef.expression}"
             )
         }
 
@@ -635,10 +635,10 @@ case class TaskRunner(
       InstanceTypeDB.parse(dxInstanceType, memory, diskSpace, cores, gpu)
     val iType = instanceTypeDB.apply(iTypeRaw)
     Utils.appletLog(
-      verbose,
-      s"""|calcInstanceType memory=${memory} disk=${diskSpace}
+        verbose,
+        s"""|calcInstanceType memory=${memory} disk=${diskSpace}
                                      |cores=${cores} instancetype=${iType}""".stripMargin
-        .replaceAll("\n", " ")
+          .replaceAll("\n", " ")
     )
     iType
   }
@@ -658,15 +658,15 @@ case class TaskRunner(
     val dxJob = DxJob(DxUtils.dxEnv.getJob())
 
     val descFieldReq = JsObject(
-      "fields" -> JsObject("instanceType" -> JsBoolean(true))
+        "fields" -> JsObject("instanceType" -> JsBoolean(true))
     )
     val retval: JsValue =
       DxUtils.jsValueOfJsonNode(
-        DXAPI.jobDescribe(
-          dxJob.id,
-          DxUtils.jsonNodeOfJsValue(descFieldReq),
-          classOf[JsonNode]
-        )
+          DXAPI.jobDescribe(
+              dxJob.id,
+              DxUtils.jsonNodeOfJsValue(descFieldReq),
+              classOf[JsonNode]
+          )
       )
     val crntInstanceType: String =
       retval.asJsObject.fields.get("instanceType") match {
@@ -697,11 +697,11 @@ case class TaskRunner(
     // Run a sub-job with the "body" entry point, and the required instance type
     val dxSubJob: DxJob =
       DxUtils.runSubJob(
-        "body",
-        Some(instanceType),
-        originalInputs,
-        Vector.empty,
-        maxVerboseLevel
+          "body",
+          Some(instanceType),
+          originalInputs,
+          Vector.empty,
+          maxVerboseLevel
       )
 
     // Return promises (JBORs) for all the outputs. Since the signature of the sub-job

--- a/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
@@ -20,7 +20,7 @@ case class WfFragInputOutput(
     runtimeDebugLevel: Int,
     typeAliases: Map[String, WomType]
 ) {
-  val verbose        = runtimeDebugLevel >= 1
+  val verbose = runtimeDebugLevel >= 1
   val jobInputOutput = JobInputOutput(dxIoFunctions, runtimeDebugLevel, typeAliases)
 
   private def loadWorkflowMetaInfo(
@@ -51,7 +51,7 @@ case class WfFragInputOutput(
           case (key, JsString(value)) =>
             // Transform back to a fully qualified name with dots
             val orgKeyName = Utils.revTransformVarName(key)
-            val womType    = WomTypeSerialization(typeAliases).fromString(value)
+            val womType = WomTypeSerialization(typeAliases).fromString(value)
             orgKeyName -> womType
           case other => throw new Exception(s"Bad value ${other}")
         }.toMap

--- a/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
@@ -76,7 +76,7 @@ case class WfFragInputOutput(
     // Extract the meta information needed to setup the closure
     // for the subblock
     val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(
-      metaInfo.asJsObject.fields
+        metaInfo.asJsObject.fields
     )
 
     // What remains are inputs from other stages. Convert from JSON
@@ -87,7 +87,7 @@ case class WfFragInputOutput(
         val womType = fqnDictTypes.get(fqn) match {
           case None =>
             throw new Exception(
-              s"Did not find variable ${fqn} (${name}) in the block environment"
+                s"Did not find variable ${fqn} (${name}) in the block environment"
             )
           case Some(x) => x
         }
@@ -114,7 +114,7 @@ case class WfFragInputOutput(
           val womType = fqnDictTypes.get(fqn) match {
             case None =>
               throw new Exception(
-                s"Did not find variable ${fqn} (${name}) in the block environment"
+                  s"Did not find variable ${fqn} (${name}) in the block environment"
               )
             case Some(x) => x
           }

--- a/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
@@ -21,21 +21,23 @@ case class WfFragInputOutput(
     typeAliases: Map[String, WomType]
 ) {
   val verbose = runtimeDebugLevel >= 1
-  val jobInputOutput = JobInputOutput(dxIoFunctions, runtimeDebugLevel, typeAliases)
+  val jobInputOutput =
+    JobInputOutput(dxIoFunctions, runtimeDebugLevel, typeAliases)
 
   private def loadWorkflowMetaInfo(
       metaInfo: Map[String, JsValue]
   ): (Map[String, ExecLinkInfo], Vector[Int], Map[String, WomType]) = {
     // meta information used for running workflow fragments
-    val execLinkInfo: Map[String, ExecLinkInfo] = metaInfo.get("execLinkInfo") match {
-      case None => Map.empty
-      case Some(JsObject(fields)) =>
-        fields.map {
-          case (key, ali) =>
-            key -> ExecLinkInfo.readJson(ali, typeAliases)
-        }.toMap
-      case other => throw new Exception(s"Bad value ${other}")
-    }
+    val execLinkInfo: Map[String, ExecLinkInfo] =
+      metaInfo.get("execLinkInfo") match {
+        case None => Map.empty
+        case Some(JsObject(fields)) =>
+          fields.map {
+            case (key, ali) =>
+              key -> ExecLinkInfo.readJson(ali, typeAliases)
+          }.toMap
+        case other => throw new Exception(s"Bad value ${other}")
+      }
     val blockPath: Vector[Int] = metaInfo.get("blockPath") match {
       case None => Vector.empty
       case Some(JsArray(arr)) =>
@@ -45,18 +47,19 @@ case class WfFragInputOutput(
         }.toVector
       case other => throw new Exception(s"Bad value ${other}")
     }
-    val fqnDictTypes: Map[String, WomType] = metaInfo.get("fqnDictTypes") match {
-      case Some(JsObject(fields)) =>
-        fields.map {
-          case (key, JsString(value)) =>
-            // Transform back to a fully qualified name with dots
-            val orgKeyName = Utils.revTransformVarName(key)
-            val womType = WomTypeSerialization(typeAliases).fromString(value)
-            orgKeyName -> womType
-          case other => throw new Exception(s"Bad value ${other}")
-        }.toMap
-      case other => throw new Exception(s"Bad value ${other}")
-    }
+    val fqnDictTypes: Map[String, WomType] =
+      metaInfo.get("fqnDictTypes") match {
+        case Some(JsObject(fields)) =>
+          fields.map {
+            case (key, JsString(value)) =>
+              // Transform back to a fully qualified name with dots
+              val orgKeyName = Utils.revTransformVarName(key)
+              val womType = WomTypeSerialization(typeAliases).fromString(value)
+              orgKeyName -> womType
+            case other => throw new Exception(s"Bad value ${other}")
+          }.toMap
+        case other => throw new Exception(s"Bad value ${other}")
+      }
 
     (execLinkInfo, blockPath, fqnDictTypes)
   }
@@ -66,11 +69,15 @@ case class WfFragInputOutput(
   //    look to the WOM code as if all previous code had been evaluated.
   def loadInputs(inputs: JsValue, metaInfo: JsValue): WfFragInput = {
     val regularFields: Map[String, JsValue] = inputs.asJsObject.fields
-      .filter { case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
+      .filter {
+        case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX)
+      }
 
     // Extract the meta information needed to setup the closure
     // for the subblock
-    val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
+    val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(
+      metaInfo.asJsObject.fields
+    )
 
     // What remains are inputs from other stages. Convert from JSON
     // to wom values
@@ -79,7 +86,9 @@ case class WfFragInputOutput(
         val fqn = Utils.revTransformVarName(name)
         val womType = fqnDictTypes.get(fqn) match {
           case None =>
-            throw new Exception(s"Did not find variable ${fqn} (${name}) in the block environment")
+            throw new Exception(
+              s"Did not find variable ${fqn} (${name}) in the block environment"
+            )
           case Some(x) => x
         }
         fqn -> jobInputOutput.unpackJobInput(fqn, womType, jsValue)
@@ -91,7 +100,9 @@ case class WfFragInputOutput(
   // find all the dx:files that are referenced from the inputs
   def findRefDxFiles(inputs: JsValue, metaInfo: JsValue): Vector[DxFile] = {
     val regularFields: Map[String, JsValue] = inputs.asJsObject.fields
-      .filter { case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
+      .filter {
+        case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX)
+      }
 
     val (_, _, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
 

--- a/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
@@ -8,102 +8,108 @@ import dxWDL.base._
 import dxWDL.dx._
 import dxWDL.util._
 
-case class WfFragInput(blockPath: Vector[Int],
-                       env: Map[String, WomValue],
-                       execLinkInfo : Map[String, ExecLinkInfo])
+case class WfFragInput(
+    blockPath: Vector[Int],
+    env: Map[String, WomValue],
+    execLinkInfo: Map[String, ExecLinkInfo]
+)
 
-case class WfFragInputOutput(dxIoFunctions : DxIoFunctions,
-                             dxProject: DxProject,
-                             runtimeDebugLevel: Int,
-                             typeAliases: Map[String, WomType]) {
-    val verbose = runtimeDebugLevel >= 1
-    val jobInputOutput = JobInputOutput(dxIoFunctions, runtimeDebugLevel, typeAliases)
+case class WfFragInputOutput(
+    dxIoFunctions: DxIoFunctions,
+    dxProject: DxProject,
+    runtimeDebugLevel: Int,
+    typeAliases: Map[String, WomType]
+) {
+  val verbose        = runtimeDebugLevel >= 1
+  val jobInputOutput = JobInputOutput(dxIoFunctions, runtimeDebugLevel, typeAliases)
 
-    private def loadWorkflowMetaInfo(metaInfo : Map[String, JsValue]) :
-            (Map[String, ExecLinkInfo], Vector[Int], Map[String, WomType]) = {
-        // meta information used for running workflow fragments
-        val execLinkInfo: Map[String, ExecLinkInfo] = metaInfo.get("execLinkInfo") match {
-            case None => Map.empty
-            case Some(JsObject(fields)) =>
-                fields.map{
-                    case (key, ali) =>
-                        key -> ExecLinkInfo.readJson(ali, typeAliases)
-                }.toMap
-            case other => throw new Exception(s"Bad value ${other}")
-        }
-        val blockPath: Vector[Int] = metaInfo.get("blockPath") match {
-            case None => Vector.empty
-            case Some(JsArray(arr)) =>
-                arr.map{
-                    case JsNumber(n) => n.toInt
-                    case _ => throw new Exception("Bad value ${arr}")
-                }.toVector
-            case other => throw new Exception(s"Bad value ${other}")
-        }
-        val fqnDictTypes : Map[String, WomType] = metaInfo.get("fqnDictTypes") match {
-            case Some(JsObject(fields)) =>
-                fields.map{
-                    case (key, JsString(value)) =>
-                        // Transform back to a fully qualified name with dots
-                        val orgKeyName = Utils.revTransformVarName(key)
-                        val womType = WomTypeSerialization(typeAliases).fromString(value)
-                        orgKeyName -> womType
-                    case other => throw new Exception(s"Bad value ${other}")
-                }.toMap
-            case other => throw new Exception(s"Bad value ${other}")
-        }
-
-        (execLinkInfo, blockPath, fqnDictTypes)
-    }
-
-    // 1. Convert the inputs to WOM values
-    // 2. Setup an environment to evaluate the sub-block. This should
-    //    look to the WOM code as if all previous code had been evaluated.
-    def loadInputs(inputs : JsValue,
-                   metaInfo: JsValue) : WfFragInput = {
-        val regularFields : Map[String, JsValue] = inputs
-            .asJsObject.fields
-            .filter{ case (fieldName,_) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
-
-        // Extract the meta information needed to setup the closure
-        // for the subblock
-        val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
-
-        // What remains are inputs from other stages. Convert from JSON
-        // to wom values
-        val env : Map[String, WomValue] = regularFields.map{
-            case (name, jsValue) =>
-                val fqn = Utils.revTransformVarName(name)
-                val womType = fqnDictTypes.get(fqn) match {
-                    case None => throw new Exception(s"Did not find variable ${fqn} (${name}) in the block environment")
-                    case Some(x) => x
-                }
-                fqn -> jobInputOutput.unpackJobInput(fqn, womType, jsValue)
+  private def loadWorkflowMetaInfo(
+      metaInfo: Map[String, JsValue]
+  ): (Map[String, ExecLinkInfo], Vector[Int], Map[String, WomType]) = {
+    // meta information used for running workflow fragments
+    val execLinkInfo: Map[String, ExecLinkInfo] = metaInfo.get("execLinkInfo") match {
+      case None => Map.empty
+      case Some(JsObject(fields)) =>
+        fields.map {
+          case (key, ali) =>
+            key -> ExecLinkInfo.readJson(ali, typeAliases)
         }.toMap
-
-        WfFragInput(blockPath,
-                    env,
-                    execLinkInfo)
+      case other => throw new Exception(s"Bad value ${other}")
+    }
+    val blockPath: Vector[Int] = metaInfo.get("blockPath") match {
+      case None => Vector.empty
+      case Some(JsArray(arr)) =>
+        arr.map {
+          case JsNumber(n) => n.toInt
+          case _           => throw new Exception("Bad value ${arr}")
+        }.toVector
+      case other => throw new Exception(s"Bad value ${other}")
+    }
+    val fqnDictTypes: Map[String, WomType] = metaInfo.get("fqnDictTypes") match {
+      case Some(JsObject(fields)) =>
+        fields.map {
+          case (key, JsString(value)) =>
+            // Transform back to a fully qualified name with dots
+            val orgKeyName = Utils.revTransformVarName(key)
+            val womType    = WomTypeSerialization(typeAliases).fromString(value)
+            orgKeyName -> womType
+          case other => throw new Exception(s"Bad value ${other}")
+        }.toMap
+      case other => throw new Exception(s"Bad value ${other}")
     }
 
-    // find all the dx:files that are referenced from the inputs
-    def findRefDxFiles(inputs : JsValue,
-                       metaInfo: JsValue) : Vector[DxFile] = {
-        val regularFields : Map[String, JsValue] = inputs
-            .asJsObject.fields
-            .filter{ case (fieldName,_) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
+    (execLinkInfo, blockPath, fqnDictTypes)
+  }
 
-        val (_, _, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
+  // 1. Convert the inputs to WOM values
+  // 2. Setup an environment to evaluate the sub-block. This should
+  //    look to the WOM code as if all previous code had been evaluated.
+  def loadInputs(inputs: JsValue, metaInfo: JsValue): WfFragInput = {
+    val regularFields: Map[String, JsValue] = inputs.asJsObject.fields
+      .filter { case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
 
-        // Convert from JSON to wom values
-        regularFields.map{
-            case (name, jsValue) =>
-                val fqn = Utils.revTransformVarName(name)
-                val womType = fqnDictTypes.get(fqn) match {
-                    case None => throw new Exception(s"Did not find variable ${fqn} (${name}) in the block environment")
-                    case Some(x) => x
-                }
-                jobInputOutput.unpackJobInputFindRefFiles(womType, jsValue)
-        }.toVector.flatten
-    }
+    // Extract the meta information needed to setup the closure
+    // for the subblock
+    val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
+
+    // What remains are inputs from other stages. Convert from JSON
+    // to wom values
+    val env: Map[String, WomValue] = regularFields.map {
+      case (name, jsValue) =>
+        val fqn = Utils.revTransformVarName(name)
+        val womType = fqnDictTypes.get(fqn) match {
+          case None =>
+            throw new Exception(s"Did not find variable ${fqn} (${name}) in the block environment")
+          case Some(x) => x
+        }
+        fqn -> jobInputOutput.unpackJobInput(fqn, womType, jsValue)
+    }.toMap
+
+    WfFragInput(blockPath, env, execLinkInfo)
+  }
+
+  // find all the dx:files that are referenced from the inputs
+  def findRefDxFiles(inputs: JsValue, metaInfo: JsValue): Vector[DxFile] = {
+    val regularFields: Map[String, JsValue] = inputs.asJsObject.fields
+      .filter { case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
+
+    val (_, _, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
+
+    // Convert from JSON to wom values
+    regularFields
+      .map {
+        case (name, jsValue) =>
+          val fqn = Utils.revTransformVarName(name)
+          val womType = fqnDictTypes.get(fqn) match {
+            case None =>
+              throw new Exception(
+                s"Did not find variable ${fqn} (${name}) in the block environment"
+              )
+            case Some(x) => x
+          }
+          jobInputOutput.unpackJobInputFindRefFiles(womType, jsValue)
+      }
+      .toVector
+      .flatten
+  }
 }

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -74,17 +74,17 @@ case class WfFragRunner(
   private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
   private val wdlVarLinksConverter =
     WdlVarLinksConverter(
-      utlVerbose,
-      dxIoFunctions.fileInfoDir,
-      fragInputOutput.typeAliases
+        utlVerbose,
+        dxIoFunctions.fileInfoDir,
+        fragInputOutput.typeAliases
     )
   private val jobInputOutput = fragInputOutput.jobInputOutput
   private val collectSubJobs = CollectSubJobs(
-    jobInputOutput,
-    inputsRaw,
-    instanceTypeDB,
-    runtimeDebugLevel,
-    fragInputOutput.typeAliases
+      jobInputOutput,
+      inputsRaw,
+      instanceTypeDB,
+      runtimeDebugLevel,
+      fragInputOutput.typeAliases
   )
   // The source code for all the tasks
   private val taskSourceDir: Map[String, String] =
@@ -111,7 +111,7 @@ case class WfFragRunner(
           }
           .mkString("\n")
         throw new Exception(
-          s"""|Failed to evaluate expression ${expr.sourceString}
+            s"""|Failed to evaluate expression ${expr.sourceString}
                         |Errors:
                         |${errors}
                         |
@@ -134,7 +134,7 @@ case class WfFragRunner(
     execLinkInfo.get(calleeName) match {
       case None =>
         throw new AppInternalException(
-          s"Could not find linking information for ${calleeName}"
+            s"Could not find linking information for ${calleeName}"
         )
       case Some(eInfo) => eInfo
     }
@@ -166,15 +166,15 @@ case class WfFragRunner(
         val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
         val collectionRaw: WomValue =
           evaluateWomExpression(
-            svNode.scatterExpressionNode.womExpression,
-            WomArrayType(svNode.womType),
-            env
+              svNode.scatterExpressionNode.womExpression,
+              WomArrayType(svNode.womType),
+              env
           )
         val collection: Seq[WomValue] = collectionRaw match {
           case x: WomArray => x.value
           case other =>
             throw new AppInternalException(
-              s"Unexpected class ${other.getClass}, ${other}"
+                s"Unexpected class ${other.getClass}, ${other}"
             )
         }
 
@@ -198,7 +198,7 @@ case class WfFragRunner(
               key -> (elemType, Vector.empty[WomValue])
             case (_, other) =>
               throw new AppInternalException(
-                s"Unexpected class ${other.getClass}, ${other}"
+                  s"Unexpected class ${other.getClass}, ${other}"
               )
           }.toMap
 
@@ -225,15 +225,15 @@ case class WfFragRunner(
         // evaluate the condition
         val condValueRaw: WomValue =
           evaluateWomExpression(
-            cNode.conditionExpression.womExpression,
-            WomBooleanType,
-            env
+              cNode.conditionExpression.womExpression,
+              WomBooleanType,
+              env
           )
         val condValue: Boolean = condValueRaw match {
           case b: WomBoolean => b.value
           case other =>
             throw new AppInternalException(
-              s"Unexpected class ${other.getClass}, ${other}"
+                s"Unexpected class ${other.getClass}, ${other}"
             )
         }
         // build
@@ -272,7 +272,7 @@ case class WfFragRunner(
 
       case (env, other: CallNode) =>
         throw new Exception(
-          s"calls (${other}) cannot be evaluated as expressions"
+            s"calls (${other}) cannot be evaluated as expressions"
         )
 
       case (env, other) =>
@@ -282,8 +282,8 @@ case class WfFragRunner(
           }
           .mkString("\n")
         Utils.appletLog(
-          true,
-          s"""|Error unimplemented type ${other.getClass} while evaluating expressions
+            true,
+            s"""|Error unimplemented type ${other.getClass} while evaluating expressions
                                           |
                                           |env =
                                           |${env}
@@ -302,8 +302,8 @@ case class WfFragRunner(
       exportedVars: Set[String]
   ): Map[String, JsValue] = {
     Utils.appletLog(
-      verbose,
-      s"""|processOutputs
+        verbose,
+        s"""|processOutputs
                                      |  env = ${env.keys}
                                      |  fragResults = ${fragResults.keys}
                                      |  exportedVars = ${exportedVars}
@@ -346,8 +346,8 @@ case class WfFragRunner(
       env: Map[String, WomValue]
   ): JsValue = {
     Utils.appletLog(
-      verbose,
-      s"""|buildCallInputs (${callName})
+        verbose,
+        s"""|buildCallInputs (${callName})
                                      |env:
                                      |${env.mkString("\n")}
                                      |""".stripMargin
@@ -401,28 +401,28 @@ case class WfFragRunner(
 
     // There is runtime evaluation for the instance type
     val taskRunner = new TaskRunner(
-      task,
-      taskSourceCode,
-      typeAliases,
-      instanceTypeDB,
-      dxPathConfig,
-      dxIoFunctions,
-      jobInputOutput,
-      defaultRuntimeAttributes,
-      runtimeDebugLevel
+        task,
+        taskSourceCode,
+        typeAliases,
+        instanceTypeDB,
+        dxPathConfig,
+        dxIoFunctions,
+        jobInputOutput,
+        defaultRuntimeAttributes,
+        runtimeDebugLevel
     )
     try {
       val iType = taskRunner.calcInstanceType(taskInputs)
       Utils.appletLog(
-        verbose,
-        s"Precalculated instance type for ${task.unqualifiedName}: ${iType}"
+          verbose,
+          s"Precalculated instance type for ${task.unqualifiedName}: ${iType}"
       )
       Some(iType)
     } catch {
       case e: Throwable =>
         Utils.appletLog(
-          verbose,
-          s"""|Failed to precalculate the instance type for
+            verbose,
+            s"""|Failed to precalculate the instance type for
                                     |task ${task.unqualifiedName}.
                                     |
                                     |${e}
@@ -449,54 +449,54 @@ case class WfFragRunner(
       case None => Map.empty
       case Some(iType) =>
         Map(
-          "systemRequirements" -> JsObject(
-            "main" -> JsObject("instanceType" -> JsString(iType))
-          )
+            "systemRequirements" -> JsObject(
+                "main" -> JsObject("instanceType" -> JsString(iType))
+            )
         )
     }
     val dxExec =
       if (dxExecId.startsWith("app-")) {
         val fields = Map(
-          "name" -> JsString(dbgName),
-          "input" -> callInputs,
-          "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
+            "name" -> JsString(dbgName),
+            "input" -> callInputs,
+            "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
         )
         val req = JsObject(fields ++ instanceFields)
         val retval: JsonNode =
           DXAPI.appRun(
-            dxExecId,
-            DxUtils.jsonNodeOfJsValue(req),
-            classOf[JsonNode]
+              dxExecId,
+              DxUtils.jsonNodeOfJsValue(req),
+              classOf[JsonNode]
           )
         val info: JsValue = DxUtils.jsValueOfJsonNode(retval)
         val id: String = info.asJsObject.fields.get("id") match {
           case Some(JsString(x)) => x
           case _ =>
             throw new AppInternalException(
-              s"Bad format returned from jobNew ${info.prettyPrint}"
+                s"Bad format returned from jobNew ${info.prettyPrint}"
             )
         }
         DxJob.getInstance(id)
       } else if (dxExecId.startsWith("applet-")) {
         val applet = DxApplet.getInstance(dxExecId)
         val fields = Map(
-          "name" -> JsString(dbgName),
-          "input" -> callInputs,
-          "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
+            "name" -> JsString(dbgName),
+            "input" -> callInputs,
+            "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
         )
         val req = JsObject(fields ++ instanceFields)
         val retval: JsonNode =
           DXAPI.appletRun(
-            applet.getId,
-            DxUtils.jsonNodeOfJsValue(req),
-            classOf[JsonNode]
+              applet.getId,
+              DxUtils.jsonNodeOfJsValue(req),
+              classOf[JsonNode]
           )
         val info: JsValue = DxUtils.jsValueOfJsonNode(retval)
         val id: String = info.asJsObject.fields.get("id") match {
           case Some(JsString(x)) => x
           case _ =>
             throw new AppInternalException(
-              s"Bad format returned from jobNew ${info.prettyPrint}"
+                s"Bad format returned from jobNew ${info.prettyPrint}"
             )
         }
         DxJob.getInstance(id)
@@ -543,10 +543,10 @@ case class WfFragRunner(
         case (_, _) => None
       }
     execDNAxExecutable(
-      linkInfo.dxExec.getId,
-      dbgName,
-      callInputsJSON,
-      instanceType
+        linkInfo.dxExec.getId,
+        dbgName,
+        callInputsJSON,
+        instanceType
     )
   }
 
@@ -605,15 +605,15 @@ case class WfFragRunner(
   ): Boolean = {
     val condValueRaw: WomValue =
       evaluateWomExpression(
-        cnNode.conditionExpression.womExpression,
-        WomBooleanType,
-        env
+          cnNode.conditionExpression.womExpression,
+          WomBooleanType,
+          env
       )
     val condValue: Boolean = condValueRaw match {
       case b: WomBoolean => b.value
       case other =>
         throw new AppInternalException(
-          s"Unexpected class ${other.getClass}, ${other}"
+            s"Unexpected class ${other.getClass}, ${other}"
         )
     }
     condValue
@@ -680,10 +680,10 @@ case class WfFragRunner(
       // The subblock is complex, and requires a fragment, or a subworkflow
       val callInputs: JsValue = buildCallInputs(linkInfo.name, linkInfo, env)
       val (_, dxExec) = execDNAxExecutable(
-        linkInfo.dxExec.getId,
-        linkInfo.name,
-        callInputs,
-        None
+          linkInfo.dxExec.getId,
+          linkInfo.name,
+          callInputs,
+          None
       )
 
       // create promises for results
@@ -740,15 +740,15 @@ case class WfFragRunner(
     val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
     val collectionRaw: WomValue =
       evaluateWomExpression(
-        svNode.scatterExpressionNode.womExpression,
-        WomArrayType(svNode.womType),
-        env
+          svNode.scatterExpressionNode.womExpression,
+          WomArrayType(svNode.womType),
+          env
       )
     val collection: Seq[WomValue] = collectionRaw match {
       case x: WomArray => x.value
       case other =>
         throw new AppInternalException(
-          s"Unexpected class ${other.getClass}, ${other}"
+            s"Unexpected class ${other.getClass}, ${other}"
         )
     }
     (svNode, collection)
@@ -839,8 +839,8 @@ case class WfFragRunner(
     // Find the fragment block to execute
     val block = Block.getSubBlock(blockPath, wf.innerGraph, callsLoToHi)
     Utils.appletLog(
-      verbose,
-      s"""|Block ${blockPath} to execute:
+        verbose,
+        s"""|Block ${blockPath} to execute:
                                      |${WomPrettyPrintApproxWdl.block(block)}
                                      |
                                      |""".stripMargin
@@ -859,8 +859,8 @@ case class WfFragRunner(
           case (None, _) =>
             // input is missing, and there is no default.
             Utils.warning(
-              utlVerbose,
-              s"input is missing for ${name}, and there is no default at the callee"
+                utlVerbose,
+                s"input is missing for ${name}, and there is no default at the callee"
             )
             None
           case (Some(x), _) =>
@@ -931,13 +931,13 @@ case class WfFragRunner(
             assert(execLinkInfo.size == 1)
             val (_, linkInfo) = execLinkInfo.toVector.head
             collectSubJobs.aggregateResultsFromGeneratedSubWorkflow(
-              linkInfo,
-              childJobsComplete
+                linkInfo,
+                childJobsComplete
             )
 
           case other =>
             throw new AppInternalException(
-              s"Bad case ${other.getClass} ${other}"
+                s"Bad case ${other.getClass} ${other}"
             )
         }
     }

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -31,7 +31,7 @@ workflow wf_cond {
       Array[Int]? add_result = add.result
    }
 }
-*/
+ */
 
 package dxWDL.exec
 
@@ -54,773 +54,820 @@ import dxWDL.base._
 import dxWDL.dx._
 import dxWDL.util._
 
-case class WfFragRunner(wf: WorkflowDefinition,
-                        taskDir : Map[String, CallableTaskDefinition],
-                        typeAliases: Map[String, WomType],
-                        wfSourceCode: String,
-                        instanceTypeDB: InstanceTypeDB,
-                        execLinkInfo: Map[String, ExecLinkInfo],
-                        dxPathConfig : DxPathConfig,
-                        dxIoFunctions : DxIoFunctions,
-                        inputsRaw : JsValue,
-                        fragInputOutput : WfFragInputOutput,
-                        defaultRuntimeAttributes : Option[WdlRuntimeAttrs],
-                        runtimeDebugLevel: Int) {
-    private val MAX_JOB_NAME = 50
-    private val verbose = runtimeDebugLevel >= 1
-    //private val maxVerboseLevel = (runtimeDebugLevel == 2)
-    private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(utlVerbose,
-                                                            dxIoFunctions.fileInfoDir,
-                                                            fragInputOutput.typeAliases)
-    private val jobInputOutput = fragInputOutput.jobInputOutput
-    private val collectSubJobs = CollectSubJobs(jobInputOutput,
-                                                inputsRaw,
-                                                instanceTypeDB,
-                                                runtimeDebugLevel,
-                                                fragInputOutput.typeAliases)
-    // The source code for all the tasks
-    private val taskSourceDir : Map[String, String] = ParseWomSourceFile(verbose).scanForTasks(wfSourceCode)
+case class WfFragRunner(
+    wf: WorkflowDefinition,
+    taskDir: Map[String, CallableTaskDefinition],
+    typeAliases: Map[String, WomType],
+    wfSourceCode: String,
+    instanceTypeDB: InstanceTypeDB,
+    execLinkInfo: Map[String, ExecLinkInfo],
+    dxPathConfig: DxPathConfig,
+    dxIoFunctions: DxIoFunctions,
+    inputsRaw: JsValue,
+    fragInputOutput: WfFragInputOutput,
+    defaultRuntimeAttributes: Option[WdlRuntimeAttrs],
+    runtimeDebugLevel: Int
+) {
+  private val MAX_JOB_NAME = 50
+  private val verbose      = runtimeDebugLevel >= 1
+  //private val maxVerboseLevel = (runtimeDebugLevel == 2)
+  private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, fragInputOutput.typeAliases)
+  private val jobInputOutput = fragInputOutput.jobInputOutput
+  private val collectSubJobs = CollectSubJobs(
+    jobInputOutput,
+    inputsRaw,
+    instanceTypeDB,
+    runtimeDebugLevel,
+    fragInputOutput.typeAliases
+  )
+  // The source code for all the tasks
+  private val taskSourceDir: Map[String, String] =
+    ParseWomSourceFile(verbose).scanForTasks(wfSourceCode)
 
-    var gSeqNum = 0
-    private def launchSeqNum() : Int = {
-        gSeqNum += 1
-        gSeqNum
-    }
+  var gSeqNum = 0
+  private def launchSeqNum(): Int = {
+    gSeqNum += 1
+    gSeqNum
+  }
 
-    private def evaluateWomExpression(expr: WomExpression,
-                                      womType: WomType,
-                                      env: Map[String, WomValue]) : WomValue = {
-        val result: ErrorOr[WomValue] =
-            expr.evaluateValue(env, dxIoFunctions)
-        val value = result match {
-            case Invalid(errors) =>
-                val envDbg = env.map{
-                    case (key, value) => s"    ${key} -> ${value.toString}"
-                }.mkString("\n")
-                throw new Exception(
-                    s"""|Failed to evaluate expression ${expr.sourceString}
+  private def evaluateWomExpression(
+      expr: WomExpression,
+      womType: WomType,
+      env: Map[String, WomValue]
+  ): WomValue = {
+    val result: ErrorOr[WomValue] =
+      expr.evaluateValue(env, dxIoFunctions)
+    val value = result match {
+      case Invalid(errors) =>
+        val envDbg = env
+          .map {
+            case (key, value) => s"    ${key} -> ${value.toString}"
+          }
+          .mkString("\n")
+        throw new Exception(s"""|Failed to evaluate expression ${expr.sourceString}
                         |Errors:
                         |${errors}
                         |
                         |Environment:
                         |${envDbg}
                         |""".stripMargin)
-            case Valid(x: WomValue) => x
-        }
-
-        // cast the result value to the correct type
-        // For example, an expression like:
-        //   Float x = "3.2"
-        // requires casting from string to float
-        womType.coerceRawValue(value).get
+      case Valid(x: WomValue) => x
     }
 
-    private def getCallLinkInfo(call: CallNode) : ExecLinkInfo = {
-        val calleeName = call.callable.name
-        execLinkInfo.get(calleeName) match {
-            case None =>
-                throw new AppInternalException(
-                    s"Could not find linking information for ${calleeName}")
-            case Some(eInfo) => eInfo
-        }
+    // cast the result value to the correct type
+    // For example, an expression like:
+    //   Float x = "3.2"
+    // requires casting from string to float
+    womType.coerceRawValue(value).get
+  }
+
+  private def getCallLinkInfo(call: CallNode): ExecLinkInfo = {
+    val calleeName = call.callable.name
+    execLinkInfo.get(calleeName) match {
+      case None =>
+        throw new AppInternalException(s"Could not find linking information for ${calleeName}")
+      case Some(eInfo) => eInfo
     }
+  }
 
-    // This method is exposed so that we can unit-test it.
-    def evalExpressions(nodes: Seq[GraphNode],
-                        env: Map[String, WomValue]) : Map[String, WomValue] = {
-        val partialOrderNodes = Block.partialSortByDep(nodes.toSet)
-        partialOrderNodes.foldLeft(env) {
-            // simple expression
-            case (env, eNode: ExposedExpressionNode) =>
-                val value : WomValue =
-                    evaluateWomExpression(eNode.womExpression, eNode.womType, env)
-                env + (eNode.identifier.localName.value -> value)
+  // This method is exposed so that we can unit-test it.
+  def evalExpressions(nodes: Seq[GraphNode], env: Map[String, WomValue]): Map[String, WomValue] = {
+    val partialOrderNodes = Block.partialSortByDep(nodes.toSet)
+    partialOrderNodes.foldLeft(env) {
+      // simple expression
+      case (env, eNode: ExposedExpressionNode) =>
+        val value: WomValue =
+          evaluateWomExpression(eNode.womExpression, eNode.womType, env)
+        env + (eNode.identifier.localName.value -> value)
 
-            case (env, _ : ExpressionNode) =>
-                // create an ephemeral expression, not visible in the environment
-                env
+      case (env, _: ExpressionNode) =>
+        // create an ephemeral expression, not visible in the environment
+        env
 
-            // scatter
-            // scatter (K in collection) {
-            // }
-            case(env, sctNode : ScatterNode) =>
-                // WDL has exactly one variable
-                assert(sctNode.scatterVariableNodes.size == 1)
-                val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
-                val collectionRaw : WomValue =
-                    evaluateWomExpression(svNode.scatterExpressionNode.womExpression,
-                                          WomArrayType(svNode.womType),
-                                          env)
-                val collection : Seq[WomValue] = collectionRaw match {
-                    case x: WomArray => x.value
-                    case other => throw new AppInternalException(
-                        s"Unexpected class ${other.getClass}, ${other}")
-                }
+      // scatter
+      // scatter (K in collection) {
+      // }
+      case (env, sctNode: ScatterNode) =>
+        // WDL has exactly one variable
+        assert(sctNode.scatterVariableNodes.size == 1)
+        val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
+        val collectionRaw: WomValue =
+          evaluateWomExpression(
+            svNode.scatterExpressionNode.womExpression,
+            WomArrayType(svNode.womType),
+            env
+          )
+        val collection: Seq[WomValue] = collectionRaw match {
+          case x: WomArray => x.value
+          case other =>
+            throw new AppInternalException(s"Unexpected class ${other.getClass}, ${other}")
+        }
 
-                // iterate on the collection
-                val iterVarName = svNode.identifier.localName.value
-                val vm : Vector[Map[String, WomValue]] =
-                    collection.map{ v =>
-                        val envInner = env + (iterVarName -> v)
-                        evalExpressions(sctNode.innerGraph.nodes.toSeq, envInner)
-                    }.toVector
+        // iterate on the collection
+        val iterVarName = svNode.identifier.localName.value
+        val vm: Vector[Map[String, WomValue]] =
+          collection.map { v =>
+            val envInner = env + (iterVarName -> v)
+            evalExpressions(sctNode.innerGraph.nodes.toSeq, envInner)
+          }.toVector
 
-                val resultTypes : Map[String, WomArrayType] = sctNode.outputMapping.map{
-                    case scp : ScatterGathererPort =>
-                        scp.identifier.localName.value -> scp.womType
-                }.toMap
+        val resultTypes: Map[String, WomArrayType] = sctNode.outputMapping.map {
+          case scp: ScatterGathererPort =>
+            scp.identifier.localName.value -> scp.womType
+        }.toMap
 
-                // build a mapping from from result-key to its type
-                val initResults : Map[String, (WomType, Vector[WomValue])] = resultTypes.map{
-                    case (key, WomArrayType(elemType)) => key -> (elemType, Vector.empty[WomValue])
-                    case (_, other) =>
-                        throw new AppInternalException(
-                            s"Unexpected class ${other.getClass}, ${other}")
-                }.toMap
+        // build a mapping from from result-key to its type
+        val initResults: Map[String, (WomType, Vector[WomValue])] = resultTypes.map {
+          case (key, WomArrayType(elemType)) => key -> (elemType, Vector.empty[WomValue])
+          case (_, other) =>
+            throw new AppInternalException(s"Unexpected class ${other.getClass}, ${other}")
+        }.toMap
 
-                // merge the vector of results, each of which is a map
-                val results : Map[String, (WomType, Vector[WomValue])] =
-                    vm.foldLeft(initResults) {
-                        case (accu, m) =>
-                            accu.map{
-                                case (key, (elemType, arValues)) =>
-                                    val v : WomValue = m(key)
-                                    val vCorrectlyTyped = elemType.coerceRawValue(v).get
-                                    key -> (elemType, (arValues :+ vCorrectlyTyped))
-                            }.toMap
-                    }
+        // merge the vector of results, each of which is a map
+        val results: Map[String, (WomType, Vector[WomValue])] =
+          vm.foldLeft(initResults) {
+            case (accu, m) =>
+              accu.map {
+                case (key, (elemType, arValues)) =>
+                  val v: WomValue     = m(key)
+                  val vCorrectlyTyped = elemType.coerceRawValue(v).get
+                  key -> (elemType, (arValues :+ vCorrectlyTyped))
+              }.toMap
+          }
 
-                // Add the wom array type to each vector
-                val fullResults = results.map{ case (key, (elemType, vv)) =>
-                    key -> WomArray(WomArrayType(elemType), vv)
-                }
-                env ++ fullResults
+        // Add the wom array type to each vector
+        val fullResults = results.map {
+          case (key, (elemType, vv)) =>
+            key -> WomArray(WomArrayType(elemType), vv)
+        }
+        env ++ fullResults
 
-            case (env, cNode: ConditionalNode) =>
-                // evaluate the condition
-                val condValueRaw : WomValue =
-                    evaluateWomExpression(cNode.conditionExpression.womExpression,
-                                          WomBooleanType,
-                                          env)
-                val condValue : Boolean = condValueRaw match {
-                    case b: WomBoolean => b.value
-                    case other => throw new AppInternalException(
-                        s"Unexpected class ${other.getClass}, ${other}")
-                }
-                // build
-                val resultTypes : Map[String, WomType] = cNode.conditionalOutputPorts.map{
-                    case cop : ConditionalOutputPort =>
-                        cop.identifier.localName.value -> Utils.stripOptional(cop.womType)
-                }.toMap
-                val fullResults : Map[String, WomValue] =
-                    if (!condValue) {
-                        // condition is false, return None for all the values
-                        resultTypes.map{ case (key, womType) =>
-                            key -> WomOptionalValue(womType, None)
-                        }
-                    } else {
-                        // condition is true, evaluate the internal block.
-                        val results = evalExpressions(cNode.innerGraph.nodes.toSeq, env)
-                        resultTypes.map{ case (key, womType) =>
-                            val value: Option[WomValue] = results.get(key)
-                            key -> WomOptionalValue(womType, value)
-                        }
-                    }
-                env ++ fullResults
+      case (env, cNode: ConditionalNode) =>
+        // evaluate the condition
+        val condValueRaw: WomValue =
+          evaluateWomExpression(cNode.conditionExpression.womExpression, WomBooleanType, env)
+        val condValue: Boolean = condValueRaw match {
+          case b: WomBoolean => b.value
+          case other =>
+            throw new AppInternalException(s"Unexpected class ${other.getClass}, ${other}")
+        }
+        // build
+        val resultTypes: Map[String, WomType] = cNode.conditionalOutputPorts.map {
+          case cop: ConditionalOutputPort =>
+            cop.identifier.localName.value -> Utils.stripOptional(cop.womType)
+        }.toMap
+        val fullResults: Map[String, WomValue] =
+          if (!condValue) {
+            // condition is false, return None for all the values
+            resultTypes.map {
+              case (key, womType) =>
+                key -> WomOptionalValue(womType, None)
+            }
+          } else {
+            // condition is true, evaluate the internal block.
+            val results = evalExpressions(cNode.innerGraph.nodes.toSeq, env)
+            resultTypes.map {
+              case (key, womType) =>
+                val value: Option[WomValue] = results.get(key)
+                key -> WomOptionalValue(womType, value)
+            }
+          }
+        env ++ fullResults
 
-            // Input nodes for a subgraph
-            case (env, ogin: OuterGraphInputNode) =>
-                //Utils.appletLog(verbose, s"skipping ${ogin.getClass}")
-                env
+      // Input nodes for a subgraph
+      case (env, ogin: OuterGraphInputNode) =>
+        //Utils.appletLog(verbose, s"skipping ${ogin.getClass}")
+        env
 
-            // Output nodes from a subgraph
-            case (env, gon: GraphOutputNode) =>
-                //Utils.appletLog(verbose, s"skipping ${gon.getClass}")
-                env
+      // Output nodes from a subgraph
+      case (env, gon: GraphOutputNode) =>
+        //Utils.appletLog(verbose, s"skipping ${gon.getClass}")
+        env
 
-            case (env, other: CallNode) =>
-                throw new Exception(s"calls (${other}) cannot be evaluated as expressions")
+      case (env, other: CallNode) =>
+        throw new Exception(s"calls (${other}) cannot be evaluated as expressions")
 
-            case (env, other) =>
-                val dbgGraph = nodes.map{node => WomPrettyPrint.apply(node) }.mkString("\n")
-                Utils.appletLog(true, s"""|Error unimplemented type ${other.getClass} while evaluating expressions
+      case (env, other) =>
+        val dbgGraph = nodes
+          .map { node =>
+            WomPrettyPrint.apply(node)
+          }
+          .mkString("\n")
+        Utils.appletLog(
+          true,
+          s"""|Error unimplemented type ${other.getClass} while evaluating expressions
                                           |
                                           |env =
                                           |${env}
                                           |
                                           |graph =
                                           |${dbgGraph}
-                                          |""".stripMargin)
-                throw new Exception(s"${other.getClass} not implemented yet")
-        }
+                                          |""".stripMargin
+        )
+        throw new Exception(s"${other.getClass} not implemented yet")
     }
+  }
 
-    private def processOutputs(env: Map[String, WomValue],
-                               fragResults: Map[String, WdlVarLinks],
-                               exportedVars: Set[String]) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"""|processOutputs
+  private def processOutputs(
+      env: Map[String, WomValue],
+      fragResults: Map[String, WdlVarLinks],
+      exportedVars: Set[String]
+  ): Map[String, JsValue] = {
+    Utils.appletLog(
+      verbose,
+      s"""|processOutputs
                                      |  env = ${env.keys}
                                      |  fragResults = ${fragResults.keys}
                                      |  exportedVars = ${exportedVars}
-                                     |""".stripMargin)
+                                     |""".stripMargin
+    )
 
-        // convert the WOM values to WVLs
-        val envWvl = env.map{
-            case (name, value) =>
-                name -> wdlVarLinksConverter.importFromWDL(value.womType, value)
-        }.toMap
+    // convert the WOM values to WVLs
+    val envWvl = env.map {
+      case (name, value) =>
+        name -> wdlVarLinksConverter.importFromWDL(value.womType, value)
+    }.toMap
 
-        // filter anything that should not be exported.
-        val exportedWvls = (envWvl ++ fragResults).filter{
-            case (name, wvl) => exportedVars contains name
-        }
-
-        // convert from WVL to JSON
-        //
-        // TODO: check for each variable if it should be output
-        exportedWvls.foldLeft(Map.empty[String, JsValue]) {
-            case (accu, (varName, wvl)) =>
-                val fields = wdlVarLinksConverter.genFields(wvl, varName)
-                accu ++ fields.toMap
-        }.toMap
+    // filter anything that should not be exported.
+    val exportedWvls = (envWvl ++ fragResults).filter {
+      case (name, wvl) => exportedVars contains name
     }
 
- /**
+    // convert from WVL to JSON
+    //
+    // TODO: check for each variable if it should be output
+    exportedWvls
+      .foldLeft(Map.empty[String, JsValue]) {
+        case (accu, (varName, wvl)) =>
+          val fields = wdlVarLinksConverter.genFields(wvl, varName)
+          accu ++ fields.toMap
+      }
+      .toMap
+  }
+
+  /**
       In the workflow below, we want to correctly pass the [k] value
       to each [inc] Task invocation.
     scatter (k in integers) {
         call inc as inc {input: i=k}
    }
-   */
-    private def buildCallInputs(callName: String,
-                                linkInfo: ExecLinkInfo,
-                                env : Map[String, WomValue]) : JsValue = {
-        Utils.appletLog(verbose, s"""|buildCallInputs (${callName})
+    */
+  private def buildCallInputs(
+      callName: String,
+      linkInfo: ExecLinkInfo,
+      env: Map[String, WomValue]
+  ): JsValue = {
+    Utils.appletLog(
+      verbose,
+      s"""|buildCallInputs (${callName})
                                      |env:
                                      |${env.mkString("\n")}
-                                     |""".stripMargin)
+                                     |""".stripMargin
+    )
 
-        val inputs: Map[String, WomValue] = linkInfo.inputs.flatMap{
-            case (varName, wdlType) =>
-                env.get(varName) match {
-                    case None =>
-                        // No binding for this input. It might be optional,
-                        // it could have a default value. It could also actually be missing,
-                        // which will result in a platform error.
-                        None
-                    case Some(womValue) =>
-                        Some(varName -> womValue)
-                }
+    val inputs: Map[String, WomValue] = linkInfo.inputs.flatMap {
+      case (varName, wdlType) =>
+        env.get(varName) match {
+          case None =>
+            // No binding for this input. It might be optional,
+            // it could have a default value. It could also actually be missing,
+            // which will result in a platform error.
+            None
+          case Some(womValue) =>
+            Some(varName -> womValue)
         }
-
-        val wvlInputs = inputs.map{ case (name, womValue) =>
-            val womType = linkInfo.inputs(name)
-            name -> wdlVarLinksConverter.importFromWDL(womType, womValue)
-        }.toMap
-
-        val m = wvlInputs.foldLeft(Map.empty[String, JsValue]) {
-            case (accu, (varName, wvl)) =>
-                val fields = wdlVarLinksConverter.genFields(wvl, varName)
-                accu ++ fields.toMap
-        }
-        JsObject(m)
     }
 
-    // Figure out what instance type to launch at task in. Return None if the instance
-    // type is a constant, and is already set.
-    private def preCalcInstanceType(task: CallableTaskDefinition,
-                                    taskSourceCode: String,
-                                    taskInputs: Map[InputDefinition, WomValue]) : Option[String] = {
-        // Note: if none of these attributes are specified, the return value is None.
-        val instanceAttrs = Set("memory", "disks", "cpu")
-        val allConst = instanceAttrs.forall{ attrName =>
-            task.runtimeAttributes.attributes.get(attrName) match {
-                case None => true
-                case Some(expr) => WomValueAnalysis.isExpressionConst(WomStringType, expr)
-            }
-        }
-        if (allConst)
-            return None
+    val wvlInputs = inputs.map {
+      case (name, womValue) =>
+        val womType = linkInfo.inputs(name)
+        name -> wdlVarLinksConverter.importFromWDL(womType, womValue)
+    }.toMap
 
-        // There is runtime evaluation for the instance type
-        val taskRunner = new TaskRunner(task,
-                                        taskSourceCode,
-                                        typeAliases,
-                                        instanceTypeDB,
-                                        dxPathConfig,
-                                        dxIoFunctions,
-                                        jobInputOutput,
-                                        defaultRuntimeAttributes,
-                                        runtimeDebugLevel)
-        try {
-            val iType = taskRunner.calcInstanceType(taskInputs)
-            Utils.appletLog(verbose, s"Precalculated instance type for ${task.unqualifiedName}: ${iType}")
-            Some(iType)
-        } catch {
-            case e : Throwable =>
-                Utils.appletLog(verbose,
-                                s"""|Failed to precalculate the instance type for
+    val m = wvlInputs.foldLeft(Map.empty[String, JsValue]) {
+      case (accu, (varName, wvl)) =>
+        val fields = wdlVarLinksConverter.genFields(wvl, varName)
+        accu ++ fields.toMap
+    }
+    JsObject(m)
+  }
+
+  // Figure out what instance type to launch at task in. Return None if the instance
+  // type is a constant, and is already set.
+  private def preCalcInstanceType(
+      task: CallableTaskDefinition,
+      taskSourceCode: String,
+      taskInputs: Map[InputDefinition, WomValue]
+  ): Option[String] = {
+    // Note: if none of these attributes are specified, the return value is None.
+    val instanceAttrs = Set("memory", "disks", "cpu")
+    val allConst = instanceAttrs.forall { attrName =>
+      task.runtimeAttributes.attributes.get(attrName) match {
+        case None       => true
+        case Some(expr) => WomValueAnalysis.isExpressionConst(WomStringType, expr)
+      }
+    }
+    if (allConst)
+      return None
+
+    // There is runtime evaluation for the instance type
+    val taskRunner = new TaskRunner(
+      task,
+      taskSourceCode,
+      typeAliases,
+      instanceTypeDB,
+      dxPathConfig,
+      dxIoFunctions,
+      jobInputOutput,
+      defaultRuntimeAttributes,
+      runtimeDebugLevel
+    )
+    try {
+      val iType = taskRunner.calcInstanceType(taskInputs)
+      Utils.appletLog(verbose, s"Precalculated instance type for ${task.unqualifiedName}: ${iType}")
+      Some(iType)
+    } catch {
+      case e: Throwable =>
+        Utils.appletLog(
+          verbose,
+          s"""|Failed to precalculate the instance type for
                                     |task ${task.unqualifiedName}.
                                     |
                                     |${e}
-                                    |""".stripMargin)
-                None
-        }
+                                    |""".stripMargin
+        )
+        None
     }
+  }
 
-    private def execDNAxExecutable(dxExecId: String,
-                                   dbgName: String,
-                                   callInputs : JsValue,
-                                   instanceType: Option[String]) : (Int, DxExecution) = {
-        // We may need to run a collect subjob. Add the the sequence
-        // number to each invocation, so the collect subjob will be
-        // able to put the results back together in the correct order.
-        val seqNum: Int = launchSeqNum()
+  private def execDNAxExecutable(
+      dxExecId: String,
+      dbgName: String,
+      callInputs: JsValue,
+      instanceType: Option[String]
+  ): (Int, DxExecution) = {
+    // We may need to run a collect subjob. Add the the sequence
+    // number to each invocation, so the collect subjob will be
+    // able to put the results back together in the correct order.
+    val seqNum: Int = launchSeqNum()
 
-        // If this is a task that specifies the instance type
-        // at runtime, launch it in the requested instance.
-        val instanceFields = instanceType match {
-            case None => Map.empty
-            case Some(iType) =>
-                Map("systemRequirements" -> JsObject(
-                        "main" -> JsObject("instanceType" -> JsString(iType))
-                    ))
-        }
-        val dxExec =
-            if (dxExecId.startsWith("app-")) {
-                val fields = Map(
-                    "name" -> JsString(dbgName),
-                    "input" -> callInputs,
-                    "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
-                )
-                val req = JsObject(fields ++ instanceFields)
-                val retval: JsonNode = DXAPI.appRun(dxExecId,
-                                                    DxUtils.jsonNodeOfJsValue(req),
-                                                    classOf[JsonNode])
-                val info: JsValue =  DxUtils.jsValueOfJsonNode(retval)
-                val id:String = info.asJsObject.fields.get("id") match {
-                    case Some(JsString(x)) => x
-                    case _ => throw new AppInternalException(
-                        s"Bad format returned from jobNew ${info.prettyPrint}")
-                }
-                DxJob.getInstance(id)
-            } else if (dxExecId.startsWith("applet-")) {
-                val applet = DxApplet.getInstance(dxExecId)
-                val fields = Map(
-                    "name" -> JsString(dbgName),
-                    "input" -> callInputs,
-                    "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
-                )
-                val req = JsObject(fields ++ instanceFields)
-                val retval: JsonNode = DXAPI.appletRun(applet.getId,
-                                                       DxUtils.jsonNodeOfJsValue(req),
-                                                       classOf[JsonNode])
-                val info: JsValue =  DxUtils.jsValueOfJsonNode(retval)
-                val id:String = info.asJsObject.fields.get("id") match {
-                    case Some(JsString(x)) => x
-                    case _ => throw new AppInternalException(
-                        s"Bad format returned from jobNew ${info.prettyPrint}")
-                }
-                DxJob.getInstance(id)
-            } else if (dxExecId.startsWith("workflow-")) {
-                val workflow = DxWorkflow.getInstance(dxExecId)
-                val dxAnalysis :DxAnalysis = workflow.newRun(
-                    input = callInputs,
-                    name = dbgName)
-                val props = Map("seq_number" -> seqNum.toString)
-                dxAnalysis.setProperties(props)
-                dxAnalysis
-            } else {
-                throw new Exception(s"Unsupported execution ${dxExecId}")
-            }
-        (seqNum, dxExec)
+    // If this is a task that specifies the instance type
+    // at runtime, launch it in the requested instance.
+    val instanceFields = instanceType match {
+      case None => Map.empty
+      case Some(iType) =>
+        Map(
+          "systemRequirements" -> JsObject(
+            "main" -> JsObject("instanceType" -> JsString(iType))
+          )
+        )
     }
+    val dxExec =
+      if (dxExecId.startsWith("app-")) {
+        val fields = Map(
+          "name"       -> JsString(dbgName),
+          "input"      -> callInputs,
+          "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
+        )
+        val req = JsObject(fields ++ instanceFields)
+        val retval: JsonNode =
+          DXAPI.appRun(dxExecId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+        val info: JsValue = DxUtils.jsValueOfJsonNode(retval)
+        val id: String = info.asJsObject.fields.get("id") match {
+          case Some(JsString(x)) => x
+          case _ =>
+            throw new AppInternalException(s"Bad format returned from jobNew ${info.prettyPrint}")
+        }
+        DxJob.getInstance(id)
+      } else if (dxExecId.startsWith("applet-")) {
+        val applet = DxApplet.getInstance(dxExecId)
+        val fields = Map(
+          "name"       -> JsString(dbgName),
+          "input"      -> callInputs,
+          "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
+        )
+        val req = JsObject(fields ++ instanceFields)
+        val retval: JsonNode =
+          DXAPI.appletRun(applet.getId, DxUtils.jsonNodeOfJsValue(req), classOf[JsonNode])
+        val info: JsValue = DxUtils.jsValueOfJsonNode(retval)
+        val id: String = info.asJsObject.fields.get("id") match {
+          case Some(JsString(x)) => x
+          case _ =>
+            throw new AppInternalException(s"Bad format returned from jobNew ${info.prettyPrint}")
+        }
+        DxJob.getInstance(id)
+      } else if (dxExecId.startsWith("workflow-")) {
+        val workflow               = DxWorkflow.getInstance(dxExecId)
+        val dxAnalysis: DxAnalysis = workflow.newRun(input = callInputs, name = dbgName)
+        val props                  = Map("seq_number" -> seqNum.toString)
+        dxAnalysis.setProperties(props)
+        dxAnalysis
+      } else {
+        throw new Exception(s"Unsupported execution ${dxExecId}")
+      }
+    (seqNum, dxExec)
+  }
 
-    private def execCall(call: CallNode,
-                         callInputs: Map[String, WomValue],
-                         callNameHint: Option[String]) : (Int, DxExecution) = {
-        val linkInfo = getCallLinkInfo(call)
-        val callName = call.identifier.localName.value
-        val calleeName = call.callable.name
-        val callInputsJSON : JsValue = buildCallInputs(callName, linkInfo, callInputs)
-/*        Utils.appletLog(verbose, s"""|Call ${callName}
+  private def execCall(
+      call: CallNode,
+      callInputs: Map[String, WomValue],
+      callNameHint: Option[String]
+  ): (Int, DxExecution) = {
+    val linkInfo                = getCallLinkInfo(call)
+    val callName                = call.identifier.localName.value
+    val calleeName              = call.callable.name
+    val callInputsJSON: JsValue = buildCallInputs(callName, linkInfo, callInputs)
+    /*        Utils.appletLog(verbose, s"""|Call ${callName}
                                      |calleeName= ${calleeName}
                                      |inputs = ${callInputsJSON}""".stripMargin)*/
 
-        // This is presented in the UI, to inform the user
-        val dbgName = callNameHint match {
-            case None => call.identifier.localName.value
-            case Some(hint) => s"${callName} ${hint}"
-        }
-
-        // If this is a call to a task that computes the required instance type at runtime,
-        // do the calculation right now. This saves a job relaunch down the road.
-        val instanceType : Option[String] =
-            (taskDir.get(calleeName), taskSourceDir.get(calleeName)) match {
-                case (Some(task), Some(taskSourceCode)) =>
-                    val taskInputs = jobInputOutput.loadInputs(callInputsJSON, task)
-                    preCalcInstanceType(task, taskSourceCode, taskInputs)
-                case (_, _) => None
-        }
-        execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputsJSON, instanceType)
+    // This is presented in the UI, to inform the user
+    val dbgName = callNameHint match {
+      case None       => call.identifier.localName.value
+      case Some(hint) => s"${callName} ${hint}"
     }
 
-    // create promises to this call. This allows returning
-    // from the parent job immediately.
-    private def genPromisesForCall(call: CallNode,
-                                   dxExec: DxExecution) : Map[String, WdlVarLinks] = {
-        val linkInfo = getCallLinkInfo(call)
-        val callName = call.identifier.localName.value
-        linkInfo.outputs.map{
-            case (varName, womType) =>
-                val oName = s"${callName}.${varName}"
-                oName -> WdlVarLinks(womType,
-                                     DxlExec(dxExec, varName))
-        }.toMap
-    }
+    // If this is a call to a task that computes the required instance type at runtime,
+    // do the calculation right now. This saves a job relaunch down the road.
+    val instanceType: Option[String] =
+      (taskDir.get(calleeName), taskSourceDir.get(calleeName)) match {
+        case (Some(task), Some(taskSourceCode)) =>
+          val taskInputs = jobInputOutput.loadInputs(callInputsJSON, task)
+          preCalcInstanceType(task, taskSourceCode, taskInputs)
+        case (_, _) => None
+      }
+    execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputsJSON, instanceType)
+  }
 
-    // task input expression. The issue here is a mismatch between WDL draft-2 and version 1.0.
-    // in an expression like:
-    //    call volume { input: i = 10 }
-    // the "i" parameter, under WDL draft-2, is compiled as "volume.i"
-    // under WDL version 1.0, it is compiled as "i".
-    // We just want the "i" component.
-    def evalCallInputs(call: CallNode,
-                       env: Map[String, WomValue]) : Map[String, WomValue] = {
-        // Find the type required for a call input
-        def findWomType(paramName: String) : WomType = {
-            val retval = call.inputDefinitionMappings.find{
-                case (iDef, iDefPtr) =>
-                    (iDef.localName.value == paramName) ||
-                        (Utils.getUnqualifiedName(iDef.localName.value) == paramName)
-            }
-            retval match {
-                case None => throw new Exception(s"Could not find ${paramName}")
-                case Some((iDef, iDefPtr)) =>
-                    iDef.womType
-            }
+  // create promises to this call. This allows returning
+  // from the parent job immediately.
+  private def genPromisesForCall(call: CallNode, dxExec: DxExecution): Map[String, WdlVarLinks] = {
+    val linkInfo = getCallLinkInfo(call)
+    val callName = call.identifier.localName.value
+    linkInfo.outputs.map {
+      case (varName, womType) =>
+        val oName = s"${callName}.${varName}"
+        oName -> WdlVarLinks(womType, DxlExec(dxExec, varName))
+    }.toMap
+  }
+
+  // task input expression. The issue here is a mismatch between WDL draft-2 and version 1.0.
+  // in an expression like:
+  //    call volume { input: i = 10 }
+  // the "i" parameter, under WDL draft-2, is compiled as "volume.i"
+  // under WDL version 1.0, it is compiled as "i".
+  // We just want the "i" component.
+  def evalCallInputs(call: CallNode, env: Map[String, WomValue]): Map[String, WomValue] = {
+    // Find the type required for a call input
+    def findWomType(paramName: String): WomType = {
+      val retval = call.inputDefinitionMappings.find {
+        case (iDef, iDefPtr) =>
+          (iDef.localName.value == paramName) ||
+            (Utils.getUnqualifiedName(iDef.localName.value) == paramName)
+      }
+      retval match {
+        case None => throw new Exception(s"Could not find ${paramName}")
+        case Some((iDef, iDefPtr)) =>
+          iDef.womType
+      }
+    }
+    call.upstream.collect {
+      case exprNode: ExpressionNode =>
+        val paramName  = Utils.getUnqualifiedName(exprNode.identifier.localName.value)
+        val expression = exprNode.womExpression
+        val womType    = findWomType(paramName)
+        paramName -> evaluateWomExpression(expression, womType, env)
+    }.toMap
+  }
+
+  // Evaluate the condition
+  private def evalCondition(cnNode: ConditionalNode, env: Map[String, WomValue]): Boolean = {
+    val condValueRaw: WomValue =
+      evaluateWomExpression(cnNode.conditionExpression.womExpression, WomBooleanType, env)
+    val condValue: Boolean = condValueRaw match {
+      case b: WomBoolean => b.value
+      case other         => throw new AppInternalException(s"Unexpected class ${other.getClass}, ${other}")
+    }
+    condValue
+  }
+
+  // A subblock containing exactly one call.
+  // For example:
+  //
+  // if (flag) {
+  //   call zinc as inc3 { input: a = num}
+  // }
+  //
+  private def execConditionalCall(
+      cnNode: ConditionalNode,
+      call: CallNode,
+      env: Map[String, WomValue]
+  ): Map[String, WdlVarLinks] = {
+    if (!evalCondition(cnNode, env)) {
+      // Condition is false, no need to execute the call
+      Map.empty
+    } else {
+      // evaluate the call inputs, and add to the environment
+      val callInputs                            = evalCallInputs(call, env)
+      val (_, dxExec)                           = execCall(call, callInputs, None)
+      val callResults: Map[String, WdlVarLinks] = genPromisesForCall(call, dxExec)
+
+      // Add optional modifier to the return types.
+      callResults.map {
+        case (key, WdlVarLinks(womType, dxl)) =>
+          // be careful not to make double optionals
+          val optionalType = womType match {
+            case WomOptionalType(_) => womType
+            case _                  => WomOptionalType(womType)
+          }
+          key -> WdlVarLinks(optionalType, dxl)
+      }.toMap
+    }
+  }
+
+  // A complex subblock requiring a fragment runner, or a subworkflow
+  // For example:
+  //
+  // if (flag) {
+  //   call zinc as inc3 { input: a = num}
+  //   call zinc as inc4 { input: a = num + 3 }
+  //
+  //   Int b = inc4.result + 14
+  //   call zinc as inc5 { input: a = b * 4 }
+  // }
+  //
+  private def execConditionalSubblock(
+      cnNode: ConditionalNode,
+      env: Map[String, WomValue]
+  ): Map[String, WdlVarLinks] = {
+    if (!evalCondition(cnNode, env)) {
+      // Condition is false, no need to execute the call
+      Map.empty
+    } else {
+      // There must be exactly one sub-workflow
+      assert(execLinkInfo.size == 1)
+      val (_, linkInfo) = execLinkInfo.toVector.head
+
+      // The subblock is complex, and requires a fragment, or a subworkflow
+      val callInputs: JsValue = buildCallInputs(linkInfo.name, linkInfo, env)
+      val (_, dxExec)         = execDNAxExecutable(linkInfo.dxExec.getId, linkInfo.name, callInputs, None)
+
+      // create promises for results
+      linkInfo.outputs.map {
+        case (varName, womType) =>
+          // Add optional modifier to the return types.
+          // be careful not to make double optionals
+          val optionalType = womType match {
+            case WomOptionalType(_) => womType
+            case _                  => WomOptionalType(womType)
+          }
+          varName -> WdlVarLinks(optionalType, DxlExec(dxExec, varName))
+      }.toMap
+    }
+  }
+
+  // create a short, easy to read, description for a scatter element.
+  private def readableNameForScatterItem(item: WomValue): Option[String] = {
+    item match {
+      case WomBoolean(_) | WomInteger(_) | WomFloat(_) =>
+        Some(item.toWomString)
+      case WomString(s) =>
+        Some(s)
+      case WomSingleFile(path) =>
+        val p = Paths.get(path).getFileName()
+        Some(p.toString)
+      case WomPair(l, r) =>
+        val ls = readableNameForScatterItem(l)
+        val rs = readableNameForScatterItem(r)
+        (ls, rs) match {
+          case (Some(ls1), Some(rs1)) => Some(s"(${ls1}, ${rs1})")
+          case _                      => None
         }
-        call.upstream.collect{
-            case exprNode: ExpressionNode =>
-                val paramName = Utils.getUnqualifiedName(exprNode.identifier.localName.value)
-                val expression = exprNode.womExpression
-                val womType = findWomType(paramName)
-                paramName -> evaluateWomExpression(expression, womType, env)
-        }.toMap
+      case WomOptionalValue(_, Some(x)) =>
+        readableNameForScatterItem(x)
+      case WomArray(_, arrValues) =>
+        // Create a name by concatenating the initial elements of the array.
+        // Limit the total size of the name.
+        val arrBeginning = arrValues.slice(0, 3)
+        val elements     = arrBeginning.flatMap(readableNameForScatterItem(_))
+        Some(Utils.buildLimitedSizeName(elements, MAX_JOB_NAME))
+      case _ =>
+        None
     }
+  }
 
-    // Evaluate the condition
-    private def evalCondition(cnNode: ConditionalNode,
-                              env: Map[String, WomValue]) : Boolean = {
-        val condValueRaw : WomValue =
-            evaluateWomExpression(cnNode.conditionExpression.womExpression,
-                                  WomBooleanType,
-                                  env)
-        val condValue : Boolean = condValueRaw match {
-            case b: WomBoolean => b.value
-            case other => throw new AppInternalException(
-                s"Unexpected class ${other.getClass}, ${other}")
+  // Evaluate the collection on which we are scattering
+  private def evalScatterCollection(
+      sctNode: ScatterNode,
+      env: Map[String, WomValue]
+  ): (ScatterVariableNode, Seq[WomValue]) = {
+    // WDL has exactly one variable
+    assert(sctNode.scatterVariableNodes.size == 1)
+    val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
+    val collectionRaw: WomValue =
+      evaluateWomExpression(
+        svNode.scatterExpressionNode.womExpression,
+        WomArrayType(svNode.womType),
+        env
+      )
+    val collection: Seq[WomValue] = collectionRaw match {
+      case x: WomArray => x.value
+      case other       => throw new AppInternalException(s"Unexpected class ${other.getClass}, ${other}")
+    }
+    (svNode, collection)
+  }
+
+  // Launch a subjob to collect and marshal the call results.
+  // Remove the declarations already calculated
+  private def collectScatter(
+      sctNode: ScatterNode,
+      childJobs: Vector[DxExecution]
+  ): Map[String, WdlVarLinks] = {
+    val resultTypes: Map[String, WomArrayType] = sctNode.outputMapping.map {
+      case scp: ScatterGathererPort =>
+        scp.identifier.localName.value -> scp.womType
+    }.toMap
+    val promises    = collectSubJobs.launch(childJobs, resultTypes)
+    val promisesStr = promises.mkString("\n")
+
+    Utils.appletLog(verbose, s"resultTypes=${resultTypes}")
+    Utils.appletLog(verbose, s"promises=${promisesStr}")
+    promises
+  }
+
+  private def execScatterCall(
+      sctNode: ScatterNode,
+      call: CallNode,
+      env: Map[String, WomValue]
+  ): Map[String, WdlVarLinks] = {
+    val (svNode, collection) = evalScatterCollection(sctNode, env)
+
+    // loop on the collection, call the applet in the inner loop
+    val childJobs: Vector[DxExecution] =
+      collection.map { item =>
+        val innerEnv   = env + (svNode.identifier.localName.value -> item)
+        val callInputs = evalCallInputs(call, innerEnv)
+        val callHint   = readableNameForScatterItem(item)
+        val (_, dxJob) = execCall(call, callInputs, callHint)
+        dxJob
+      }.toVector
+
+    collectScatter(sctNode, childJobs)
+  }
+
+  private def execScatterSubblock(
+      sctNode: ScatterNode,
+      env: Map[String, WomValue]
+  ): Map[String, WdlVarLinks] = {
+    val (svNode, collection) = evalScatterCollection(sctNode, env)
+
+    // There must be exactly one sub-workflow
+    assert(execLinkInfo.size == 1)
+    val (_, linkInfo) = execLinkInfo.toVector.head
+
+    // loop on the collection, call the applet in the inner loop
+    val childJobs: Vector[DxExecution] =
+      collection.map { item =>
+        val innerEnv = env + (svNode.identifier.localName.value -> item)
+        val callHint = readableNameForScatterItem(item)
+        val dbgName = callHint match {
+          case None       => linkInfo.name
+          case Some(hint) => s"${linkInfo.name} ${hint}"
         }
-        condValue
-    }
 
-    // A subblock containing exactly one call.
-    // For example:
-    //
-    // if (flag) {
-    //   call zinc as inc3 { input: a = num}
-    // }
-    //
-    private def execConditionalCall(cnNode: ConditionalNode,
-                                    call: CallNode,
-                                    env: Map[String, WomValue]) : Map[String, WdlVarLinks] = {
-        if (!evalCondition(cnNode, env)) {
-            // Condition is false, no need to execute the call
+        // The subblock is complex, and requires a fragment, or a subworkflow
+        val callInputs: JsValue = buildCallInputs(linkInfo.name, linkInfo, innerEnv)
+        val (_, dxJob)          = execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputs, None)
+        dxJob
+      }.toVector
+
+    collectScatter(sctNode, childJobs)
+  }
+
+  def apply(
+      blockPath: Vector[Int],
+      envInitial: Map[String, WomValue],
+      runMode: RunnerWfFragmentMode.Value
+  ): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
+    Utils.appletLog(verbose, s"link info=${execLinkInfo}")
+    Utils.appletLog(verbose, s"Environment: ${envInitial}")
+
+    // sort from low to high according to the source lines.
+    val callsLoToHi: Vector[String] =
+      ParseWomSourceFile(verbose).scanForCalls(wf.innerGraph, wfSourceCode)
+
+    // Find the fragment block to execute
+    val block = Block.getSubBlock(blockPath, wf.innerGraph, callsLoToHi)
+    Utils.appletLog(
+      verbose,
+      s"""|Block ${blockPath} to execute:
+                                     |${WomPrettyPrintApproxWdl.block(block)}
+                                     |
+                                     |""".stripMargin
+    )
+
+    // Some of the inputs could be optional. If they are missing,
+    // add in a None value.
+    val allInputs = Block.closure(block)
+    val envInitialFilled: Map[String, WomValue] = allInputs.flatMap {
+      case (name, (womType, hasDefaultVal)) =>
+        (envInitial.get(name), womType) match {
+          case (None, WomOptionalType(t)) =>
+            Some(name -> WomOptionalValue(t, None))
+          case (None, _) if hasDefaultVal =>
+            None
+          case (None, _) =>
+            // input is missing, and there is no default.
+            Utils.warning(
+              utlVerbose,
+              s"input is missing for ${name}, and there is no default at the callee"
+            )
+            None
+          case (Some(x), _) =>
+            Some(name -> x)
+        }
+    }.toMap
+
+    val catg = Block.categorize(block)
+    val env  = evalExpressions(catg.nodes, envInitialFilled)
+
+    val fragResults: Map[String, WdlVarLinks] = runMode match {
+      case RunnerWfFragmentMode.Launch =>
+        // The last node could be a call or a block. All the other nodes
+        // are expressions.
+        catg match {
+          case Block.AllExpressions(_) =>
             Map.empty
-        } else {
-            // evaluate the call inputs, and add to the environment
-            val callInputs = evalCallInputs(call, env)
-            val (_, dxExec) = execCall(call, callInputs,  None)
-            val callResults: Map[String, WdlVarLinks] = genPromisesForCall(call, dxExec)
 
-            // Add optional modifier to the return types.
-            callResults.map{
-                case (key, WdlVarLinks(womType, dxl)) =>
-                    // be careful not to make double optionals
-                    val optionalType = womType match {
-                        case WomOptionalType(_) => womType
-                        case _ => WomOptionalType(womType)
-                    }
-                    key -> WdlVarLinks(optionalType, dxl)
-            }.toMap
+          case Block.CallDirect(_, _) =>
+            throw new Exception("sanity, shouldn't reach this state")
+
+          // A single call at the end of the block
+          case Block.CallWithSubexpressions(_, call: CallNode) =>
+            val callInputs  = evalCallInputs(call, env)
+            val (_, dxExec) = execCall(call, callInputs, None)
+            genPromisesForCall(call, dxExec)
+
+          // The block contains a call and a bunch of expressions
+          // that will be part of the output.
+          case Block.CallFragment(_, call: CallNode) =>
+            val callInputs  = evalCallInputs(call, env)
+            val (_, dxExec) = execCall(call, callInputs, None)
+            genPromisesForCall(call, dxExec)
+
+          // The block contains a single call. We can execute it
+          // right here, without another job.
+          case Block.CondOneCall(_, cnNode, call) =>
+            execConditionalCall(cnNode, call, env)
+
+          // a conditional with a subblock inside it. We
+          // need to call an applet or a subworkflow.
+          case Block.CondFullBlock(_, cnNode) =>
+            execConditionalSubblock(cnNode, env)
+
+          // a scatter with a subblock inside it. Iterate
+          // on the scatter variable, and make the applet call
+          // for each value.
+          case Block.ScatterOneCall(_, sctNode, call) =>
+            execScatterCall(sctNode, call, env)
+
+          // Same as previous case, but call a subworkflow
+          // or fragment.
+          case Block.ScatterFullBlock(_, sctNode) =>
+            execScatterSubblock(sctNode, env)
         }
-    }
 
-    // A complex subblock requiring a fragment runner, or a subworkflow
-    // For example:
-    //
-    // if (flag) {
-    //   call zinc as inc3 { input: a = num}
-    //   call zinc as inc4 { input: a = num + 3 }
-    //
-    //   Int b = inc4.result + 14
-    //   call zinc as inc5 { input: a = b * 4 }
-    // }
-    //
-    private def execConditionalSubblock(cnNode: ConditionalNode,
-                                        env: Map[String, WomValue]) : Map[String, WdlVarLinks] = {
-        if (!evalCondition(cnNode, env)) {
-            // Condition is false, no need to execute the call
-            Map.empty
-        } else {
+      // A subjob that collects results from scatters
+      case RunnerWfFragmentMode.Collect =>
+        val childJobsComplete = collectSubJobs.executableFromSeqNum()
+        catg match {
+          case Block.ScatterOneCall(_, sctNode, call) =>
+            // scatter with a single call
+            collectSubJobs.aggregateResults(call, childJobsComplete)
+
+          case Block.ScatterFullBlock(_, sctNode) =>
+            // A scatter with a complex sub-block, compiled as a sub-workflow
             // There must be exactly one sub-workflow
             assert(execLinkInfo.size == 1)
             val (_, linkInfo) = execLinkInfo.toVector.head
+            collectSubJobs.aggregateResultsFromGeneratedSubWorkflow(linkInfo, childJobsComplete)
 
-            // The subblock is complex, and requires a fragment, or a subworkflow
-            val callInputs:JsValue = buildCallInputs(linkInfo.name, linkInfo, env)
-            val (_, dxExec) = execDNAxExecutable(linkInfo.dxExec.getId, linkInfo.name, callInputs, None)
-
-            // create promises for results
-            linkInfo.outputs.map{
-                case (varName, womType) =>
-                    // Add optional modifier to the return types.
-                    // be careful not to make double optionals
-                    val optionalType = womType match {
-                        case WomOptionalType(_) => womType
-                        case _ => WomOptionalType(womType)
-                    }
-                    varName -> WdlVarLinks(optionalType,
-                                           DxlExec(dxExec, varName))
-            }.toMap
+          case other =>
+            throw new AppInternalException(s"Bad case ${other.getClass} ${other}")
         }
     }
 
+    // figure out what outputs need to be exported
+    val blockOutputs: Map[String, WomType] = Block.outputs(block)
+    val exportedVars: Set[String]          = blockOutputs.keys.toSet
 
-    // create a short, easy to read, description for a scatter element.
-    private def readableNameForScatterItem(item: WomValue) : Option[String] = {
-        item match {
-            case WomBoolean(_) | WomInteger(_) | WomFloat(_) =>
-                Some(item.toWomString)
-            case WomString(s) =>
-                Some(s)
-            case WomSingleFile(path) =>
-                val p = Paths.get(path).getFileName()
-                Some(p.toString)
-            case WomPair(l, r) =>
-                val ls = readableNameForScatterItem(l)
-                val rs = readableNameForScatterItem(r)
-                (ls, rs) match {
-                    case (Some(ls1), Some(rs1)) => Some(s"(${ls1}, ${rs1})")
-                    case _ => None
-                }
-            case WomOptionalValue(_, Some(x)) =>
-                readableNameForScatterItem(x)
-            case WomArray(_, arrValues) =>
-                // Create a name by concatenating the initial elements of the array.
-                // Limit the total size of the name.
-                val arrBeginning = arrValues.slice(0, 3)
-                val elements = arrBeginning.flatMap(readableNameForScatterItem(_))
-                Some(Utils.buildLimitedSizeName(elements, MAX_JOB_NAME))
-            case _ =>
-                None
-        }
-    }
-
-    // Evaluate the collection on which we are scattering
-    private def evalScatterCollection(sctNode: ScatterNode,
-                                      env: Map[String, WomValue])
-            : (ScatterVariableNode, Seq[WomValue]) = {
-        // WDL has exactly one variable
-        assert(sctNode.scatterVariableNodes.size == 1)
-        val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
-        val collectionRaw : WomValue =
-            evaluateWomExpression(svNode.scatterExpressionNode.womExpression,
-                                  WomArrayType(svNode.womType),
-                                  env)
-        val collection : Seq[WomValue] = collectionRaw match {
-            case x: WomArray => x.value
-            case other => throw new AppInternalException(
-                s"Unexpected class ${other.getClass}, ${other}")
-        }
-        (svNode, collection)
-    }
-
-
-    // Launch a subjob to collect and marshal the call results.
-    // Remove the declarations already calculated
-    private def collectScatter(sctNode: ScatterNode,
-                               childJobs : Vector[DxExecution]) : Map[String, WdlVarLinks] = {
-        val resultTypes : Map[String, WomArrayType] = sctNode.outputMapping.map{
-            case scp : ScatterGathererPort =>
-                scp.identifier.localName.value -> scp.womType
-        }.toMap
-        val promises = collectSubJobs.launch(childJobs, resultTypes)
-        val promisesStr = promises.mkString("\n")
-
-        Utils.appletLog(verbose, s"resultTypes=${resultTypes}")
-        Utils.appletLog(verbose, s"promises=${promisesStr}")
-        promises
-    }
-
-    private def execScatterCall(sctNode: ScatterNode,
-                                call: CallNode,
-                                env: Map[String, WomValue]) : Map[String, WdlVarLinks] = {
-        val (svNode, collection) = evalScatterCollection(sctNode, env)
-
-        // loop on the collection, call the applet in the inner loop
-        val childJobs : Vector[DxExecution] =
-            collection.map{ item =>
-                val innerEnv = env + (svNode.identifier.localName.value -> item)
-                val callInputs = evalCallInputs(call, innerEnv)
-                val callHint = readableNameForScatterItem(item)
-                val (_, dxJob) = execCall(call, callInputs, callHint)
-                dxJob
-            }.toVector
-
-        collectScatter(sctNode, childJobs)
-    }
-
-    private def execScatterSubblock(sctNode: ScatterNode,
-                                    env: Map[String, WomValue]) : Map[String, WdlVarLinks] = {
-        val (svNode, collection) = evalScatterCollection(sctNode, env)
-
-        // There must be exactly one sub-workflow
-        assert(execLinkInfo.size == 1)
-        val (_, linkInfo) = execLinkInfo.toVector.head
-
-        // loop on the collection, call the applet in the inner loop
-        val childJobs : Vector[DxExecution] =
-            collection.map{ item =>
-                val innerEnv = env + (svNode.identifier.localName.value -> item)
-                val callHint = readableNameForScatterItem(item)
-                val dbgName = callHint  match {
-                    case None => linkInfo.name
-                    case Some(hint) => s"${linkInfo.name} ${hint}"
-                }
-
-                // The subblock is complex, and requires a fragment, or a subworkflow
-                val callInputs:JsValue = buildCallInputs(linkInfo.name, linkInfo, innerEnv)
-                val (_, dxJob) = execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputs, None)
-                dxJob
-            }.toVector
-
-        collectScatter(sctNode, childJobs)
-    }
-
-    def apply(blockPath: Vector[Int],
-              envInitial: Map[String, WomValue],
-              runMode: RunnerWfFragmentMode.Value) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
-        Utils.appletLog(verbose, s"link info=${execLinkInfo}")
-        Utils.appletLog(verbose, s"Environment: ${envInitial}")
-
-        // sort from low to high according to the source lines.
-        val callsLoToHi : Vector[String] = ParseWomSourceFile(verbose).scanForCalls(wf.innerGraph, wfSourceCode)
-
-        // Find the fragment block to execute
-        val block = Block.getSubBlock(blockPath, wf.innerGraph, callsLoToHi)
-        Utils.appletLog(verbose, s"""|Block ${blockPath} to execute:
-                                     |${WomPrettyPrintApproxWdl.block(block)}
-                                     |
-                                     |""".stripMargin)
-
-        // Some of the inputs could be optional. If they are missing,
-        // add in a None value.
-        val allInputs = Block.closure(block)
-        val envInitialFilled : Map[String, WomValue] = allInputs.flatMap { case (name, (womType, hasDefaultVal)) =>
-            (envInitial.get(name), womType) match {
-                case (None, WomOptionalType(t)) =>
-                    Some(name -> WomOptionalValue(t, None))
-                case (None, _) if hasDefaultVal =>
-                    None
-                case (None, _) =>
-                    // input is missing, and there is no default.
-                    Utils.warning(utlVerbose, s"input is missing for ${name}, and there is no default at the callee")
-                    None
-                case (Some(x), _) =>
-                    Some(name -> x)
-            }
-        }.toMap
-
-        val catg = Block.categorize(block)
-        val env = evalExpressions(catg.nodes, envInitialFilled)
-
-        val fragResults : Map[String, WdlVarLinks] = runMode match {
-            case RunnerWfFragmentMode.Launch =>
-                // The last node could be a call or a block. All the other nodes
-                // are expressions.
-                catg match {
-                    case Block.AllExpressions(_) =>
-                        Map.empty
-
-                    case Block.CallDirect(_,_) =>
-                        throw new Exception("sanity, shouldn't reach this state")
-
-                    // A single call at the end of the block
-                    case Block.CallWithSubexpressions(_, call: CallNode) =>
-                        val callInputs = evalCallInputs(call, env)
-                        val (_, dxExec) = execCall(call, callInputs,  None)
-                        genPromisesForCall(call, dxExec)
-
-                    // The block contains a call and a bunch of expressions
-                    // that will be part of the output.
-                    case Block.CallFragment(_, call: CallNode) =>
-                        val callInputs = evalCallInputs(call, env)
-                        val (_, dxExec) = execCall(call, callInputs,  None)
-                        genPromisesForCall(call, dxExec)
-
-                    // The block contains a single call. We can execute it
-                    // right here, without another job.
-                    case Block.CondOneCall(_, cnNode, call) =>
-                        execConditionalCall(cnNode, call, env)
-
-                    // a conditional with a subblock inside it. We
-                    // need to call an applet or a subworkflow.
-                    case Block.CondFullBlock(_, cnNode) =>
-                        execConditionalSubblock(cnNode, env)
-
-                    // a scatter with a subblock inside it. Iterate
-                    // on the scatter variable, and make the applet call
-                    // for each value.
-                    case Block.ScatterOneCall(_, sctNode, call) =>
-                        execScatterCall(sctNode, call, env)
-
-                    // Same as previous case, but call a subworkflow
-                    // or fragment.
-                    case Block.ScatterFullBlock(_, sctNode) =>
-                        execScatterSubblock(sctNode, env)
-                }
-
-            // A subjob that collects results from scatters
-            case RunnerWfFragmentMode.Collect =>
-                val childJobsComplete = collectSubJobs.executableFromSeqNum()
-                catg match {
-                    case Block.ScatterOneCall(_, sctNode, call) =>
-                        // scatter with a single call
-                        collectSubJobs.aggregateResults(call, childJobsComplete)
-
-                    case Block.ScatterFullBlock(_, sctNode) =>
-                        // A scatter with a complex sub-block, compiled as a sub-workflow
-                        // There must be exactly one sub-workflow
-                        assert(execLinkInfo.size == 1)
-                        val (_, linkInfo) = execLinkInfo.toVector.head
-                        collectSubJobs.aggregateResultsFromGeneratedSubWorkflow(linkInfo, childJobsComplete)
-
-                    case other =>
-                        throw new AppInternalException(s"Bad case ${other.getClass} ${other}")
-                }
-        }
-
-        // figure out what outputs need to be exported
-        val blockOutputs : Map[String, WomType] = Block.outputs(block)
-        val exportedVars : Set[String] = blockOutputs.keys.toSet
-
-        val jsOutputs : Map[String, JsValue] = processOutputs(env, fragResults, exportedVars)
-        val jsOutputsDbgStr = jsOutputs.mkString("\n")
-        Utils.appletLog(verbose, s"""|JSON outputs:
+    val jsOutputs: Map[String, JsValue] = processOutputs(env, fragResults, exportedVars)
+    val jsOutputsDbgStr                 = jsOutputs.mkString("\n")
+    Utils.appletLog(verbose, s"""|JSON outputs:
                                      |${jsOutputsDbgStr}""".stripMargin)
-        jsOutputs
-    }
+    jsOutputs
+  }
 }

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -69,7 +69,7 @@ case class WfFragRunner(
     runtimeDebugLevel: Int
 ) {
   private val MAX_JOB_NAME = 50
-  private val verbose      = runtimeDebugLevel >= 1
+  private val verbose = runtimeDebugLevel >= 1
   //private val maxVerboseLevel = (runtimeDebugLevel == 2)
   private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
   private val wdlVarLinksConverter =
@@ -191,7 +191,7 @@ case class WfFragRunner(
             case (accu, m) =>
               accu.map {
                 case (key, (elemType, arValues)) =>
-                  val v: WomValue     = m(key)
+                  val v: WomValue = m(key)
                   val vCorrectlyTyped = elemType.coerceRawValue(v).get
                   key -> (elemType, (arValues :+ vCorrectlyTyped))
               }.toMap
@@ -427,8 +427,8 @@ case class WfFragRunner(
     val dxExec =
       if (dxExecId.startsWith("app-")) {
         val fields = Map(
-          "name"       -> JsString(dbgName),
-          "input"      -> callInputs,
+          "name" -> JsString(dbgName),
+          "input" -> callInputs,
           "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
         )
         val req = JsObject(fields ++ instanceFields)
@@ -444,8 +444,8 @@ case class WfFragRunner(
       } else if (dxExecId.startsWith("applet-")) {
         val applet = DxApplet.getInstance(dxExecId)
         val fields = Map(
-          "name"       -> JsString(dbgName),
-          "input"      -> callInputs,
+          "name" -> JsString(dbgName),
+          "input" -> callInputs,
           "properties" -> JsObject("seq_number" -> JsString(seqNum.toString))
         )
         val req = JsObject(fields ++ instanceFields)
@@ -459,9 +459,9 @@ case class WfFragRunner(
         }
         DxJob.getInstance(id)
       } else if (dxExecId.startsWith("workflow-")) {
-        val workflow               = DxWorkflow.getInstance(dxExecId)
+        val workflow = DxWorkflow.getInstance(dxExecId)
         val dxAnalysis: DxAnalysis = workflow.newRun(input = callInputs, name = dbgName)
-        val props                  = Map("seq_number" -> seqNum.toString)
+        val props = Map("seq_number" -> seqNum.toString)
         dxAnalysis.setProperties(props)
         dxAnalysis
       } else {
@@ -475,9 +475,9 @@ case class WfFragRunner(
       callInputs: Map[String, WomValue],
       callNameHint: Option[String]
   ): (Int, DxExecution) = {
-    val linkInfo                = getCallLinkInfo(call)
-    val callName                = call.identifier.localName.value
-    val calleeName              = call.callable.name
+    val linkInfo = getCallLinkInfo(call)
+    val callName = call.identifier.localName.value
+    val calleeName = call.callable.name
     val callInputsJSON: JsValue = buildCallInputs(callName, linkInfo, callInputs)
     /*        Utils.appletLog(verbose, s"""|Call ${callName}
                                      |calleeName= ${calleeName}
@@ -535,9 +535,9 @@ case class WfFragRunner(
     }
     call.upstream.collect {
       case exprNode: ExpressionNode =>
-        val paramName  = Utils.getUnqualifiedName(exprNode.identifier.localName.value)
+        val paramName = Utils.getUnqualifiedName(exprNode.identifier.localName.value)
         val expression = exprNode.womExpression
-        val womType    = findWomType(paramName)
+        val womType = findWomType(paramName)
         paramName -> evaluateWomExpression(expression, womType, env)
     }.toMap
   }
@@ -570,8 +570,8 @@ case class WfFragRunner(
       Map.empty
     } else {
       // evaluate the call inputs, and add to the environment
-      val callInputs                            = evalCallInputs(call, env)
-      val (_, dxExec)                           = execCall(call, callInputs, None)
+      val callInputs = evalCallInputs(call, env)
+      val (_, dxExec) = execCall(call, callInputs, None)
       val callResults: Map[String, WdlVarLinks] = genPromisesForCall(call, dxExec)
 
       // Add optional modifier to the return types.
@@ -612,7 +612,7 @@ case class WfFragRunner(
 
       // The subblock is complex, and requires a fragment, or a subworkflow
       val callInputs: JsValue = buildCallInputs(linkInfo.name, linkInfo, env)
-      val (_, dxExec)         = execDNAxExecutable(linkInfo.dxExec.getId, linkInfo.name, callInputs, None)
+      val (_, dxExec) = execDNAxExecutable(linkInfo.dxExec.getId, linkInfo.name, callInputs, None)
 
       // create promises for results
       linkInfo.outputs.map {
@@ -651,7 +651,7 @@ case class WfFragRunner(
         // Create a name by concatenating the initial elements of the array.
         // Limit the total size of the name.
         val arrBeginning = arrValues.slice(0, 3)
-        val elements     = arrBeginning.flatMap(readableNameForScatterItem(_))
+        val elements = arrBeginning.flatMap(readableNameForScatterItem(_))
         Some(Utils.buildLimitedSizeName(elements, MAX_JOB_NAME))
       case _ =>
         None
@@ -689,7 +689,7 @@ case class WfFragRunner(
       case scp: ScatterGathererPort =>
         scp.identifier.localName.value -> scp.womType
     }.toMap
-    val promises    = collectSubJobs.launch(childJobs, resultTypes)
+    val promises = collectSubJobs.launch(childJobs, resultTypes)
     val promisesStr = promises.mkString("\n")
 
     Utils.appletLog(verbose, s"resultTypes=${resultTypes}")
@@ -707,9 +707,9 @@ case class WfFragRunner(
     // loop on the collection, call the applet in the inner loop
     val childJobs: Vector[DxExecution] =
       collection.map { item =>
-        val innerEnv   = env + (svNode.identifier.localName.value -> item)
+        val innerEnv = env + (svNode.identifier.localName.value -> item)
         val callInputs = evalCallInputs(call, innerEnv)
-        val callHint   = readableNameForScatterItem(item)
+        val callHint = readableNameForScatterItem(item)
         val (_, dxJob) = execCall(call, callInputs, callHint)
         dxJob
       }.toVector
@@ -739,7 +739,7 @@ case class WfFragRunner(
 
         // The subblock is complex, and requires a fragment, or a subworkflow
         val callInputs: JsValue = buildCallInputs(linkInfo.name, linkInfo, innerEnv)
-        val (_, dxJob)          = execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputs, None)
+        val (_, dxJob) = execDNAxExecutable(linkInfo.dxExec.getId, dbgName, callInputs, None)
         dxJob
       }.toVector
 
@@ -792,7 +792,7 @@ case class WfFragRunner(
     }.toMap
 
     val catg = Block.categorize(block)
-    val env  = evalExpressions(catg.nodes, envInitialFilled)
+    val env = evalExpressions(catg.nodes, envInitialFilled)
 
     val fragResults: Map[String, WdlVarLinks] = runMode match {
       case RunnerWfFragmentMode.Launch =>
@@ -807,14 +807,14 @@ case class WfFragRunner(
 
           // A single call at the end of the block
           case Block.CallWithSubexpressions(_, call: CallNode) =>
-            val callInputs  = evalCallInputs(call, env)
+            val callInputs = evalCallInputs(call, env)
             val (_, dxExec) = execCall(call, callInputs, None)
             genPromisesForCall(call, dxExec)
 
           // The block contains a call and a bunch of expressions
           // that will be part of the output.
           case Block.CallFragment(_, call: CallNode) =>
-            val callInputs  = evalCallInputs(call, env)
+            val callInputs = evalCallInputs(call, env)
             val (_, dxExec) = execCall(call, callInputs, None)
             genPromisesForCall(call, dxExec)
 
@@ -862,10 +862,10 @@ case class WfFragRunner(
 
     // figure out what outputs need to be exported
     val blockOutputs: Map[String, WomType] = Block.outputs(block)
-    val exportedVars: Set[String]          = blockOutputs.keys.toSet
+    val exportedVars: Set[String] = blockOutputs.keys.toSet
 
     val jsOutputs: Map[String, JsValue] = processOutputs(env, fragResults, exportedVars)
-    val jsOutputsDbgStr                 = jsOutputs.mkString("\n")
+    val jsOutputsDbgStr = jsOutputs.mkString("\n")
     Utils.appletLog(verbose, s"""|JSON outputs:
                                      |${jsOutputsDbgStr}""".stripMargin)
     jsOutputs

--- a/src/main/scala/dxWDL/exec/WfInputs.scala
+++ b/src/main/scala/dxWDL/exec/WfInputs.scala
@@ -11,30 +11,40 @@ import wom.types.WomType
 import dxWDL.base.{Utils, Verbose}
 import dxWDL.util._
 
-case class WfInputs(wf: WorkflowDefinition,
-                    wfSourceCode: String,
-                    typeAliases: Map[String, WomType],
-                    dxPathConfig: DxPathConfig,
-                    dxIoFunctions : DxIoFunctions,
-                    runtimeDebugLevel: Int) {
-    private val verbose = runtimeDebugLevel >= 1
-    //private val maxVerboseLevel = (runtimeDebugLevel == 2)
-    private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
+case class WfInputs(
+    wf: WorkflowDefinition,
+    wfSourceCode: String,
+    typeAliases: Map[String, WomType],
+    dxPathConfig: DxPathConfig,
+    dxIoFunctions: DxIoFunctions,
+    runtimeDebugLevel: Int
+) {
+  private val verbose = runtimeDebugLevel >= 1
+  //private val maxVerboseLevel = (runtimeDebugLevel == 2)
+  private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
 
-    def apply(inputs: Map[String, WomValue]) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
-        Utils.appletLog(verbose, s"Environment: ${inputs}")
-        Utils.appletLog(verbose, s"""|Artificial applet for unlocked workflow inputs
+  def apply(inputs: Map[String, WomValue]): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
+    Utils.appletLog(verbose, s"Environment: ${inputs}")
+    Utils.appletLog(
+      verbose,
+      s"""|Artificial applet for unlocked workflow inputs
                                      |${WomPrettyPrintApproxWdl.graphInputs(wf.inputs.toSeq)}
-                                     |""".stripMargin)
+                                     |""".stripMargin
+    )
 
-        // convert the WDL values to JSON
-        val outputFields:Map[String, JsValue] = inputs.map {
-            case (outputVarName, womValue) =>
-                val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
-                wdlVarLinksConverter.genFields(wvl, outputVarName)
-        }.toList.flatten.toMap
-        outputFields
-    }
+    // convert the WDL values to JSON
+    val outputFields: Map[String, JsValue] = inputs
+      .map {
+        case (outputVarName, womValue) =>
+          val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
+          wdlVarLinksConverter.genFields(wvl, outputVarName)
+      }
+      .toList
+      .flatten
+      .toMap
+    outputFields
+  }
 }

--- a/src/main/scala/dxWDL/exec/WfInputs.scala
+++ b/src/main/scala/dxWDL/exec/WfInputs.scala
@@ -31,7 +31,9 @@ case class WfInputs(
     Utils.appletLog(
       verbose,
       s"""|Artificial applet for unlocked workflow inputs
-                                     |${WomPrettyPrintApproxWdl.graphInputs(wf.inputs.toSeq)}
+                                     |${WomPrettyPrintApproxWdl.graphInputs(
+           wf.inputs.toSeq
+         )}
                                      |""".stripMargin
     )
 
@@ -39,7 +41,8 @@ case class WfInputs(
     val outputFields: Map[String, JsValue] = inputs
       .map {
         case (outputVarName, womValue) =>
-          val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
+          val wvl =
+            wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
           wdlVarLinksConverter.genFields(wvl, outputVarName)
       }
       .toList

--- a/src/main/scala/dxWDL/exec/WfInputs.scala
+++ b/src/main/scala/dxWDL/exec/WfInputs.scala
@@ -29,11 +29,11 @@ case class WfInputs(
     Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
     Utils.appletLog(verbose, s"Environment: ${inputs}")
     Utils.appletLog(
-      verbose,
-      s"""|Artificial applet for unlocked workflow inputs
+        verbose,
+        s"""|Artificial applet for unlocked workflow inputs
                                      |${WomPrettyPrintApproxWdl.graphInputs(
-           wf.inputs.toSeq
-         )}
+               wf.inputs.toSeq
+           )}
                                      |""".stripMargin
     )
 

--- a/src/main/scala/dxWDL/exec/WfOutputs.scala
+++ b/src/main/scala/dxWDL/exec/WfOutputs.scala
@@ -38,7 +38,9 @@ case class WfOutputs(
       expr.evaluateValue(env, dxIoFunctions)
     val value = result match {
       case Invalid(errors) =>
-        throw new Exception(s"Failed to evaluate expression ${expr} with ${errors}")
+        throw new Exception(
+          s"Failed to evaluate expression ${expr} with ${errors}"
+        )
       case Valid(x: WomValue) => x
     }
 
@@ -49,14 +51,20 @@ case class WfOutputs(
     womType.coerceRawValue(value).get
   }
 
-  def apply(envInitial: Map[String, WomValue], addStatus: Boolean = false): Map[String, JsValue] = {
+  def apply(
+      envInitial: Map[String, WomValue],
+      addStatus: Boolean = false
+  ): Map[String, JsValue] = {
     Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
     Utils.appletLog(verbose, s"Environment: ${envInitial}")
-    val outputNodes: Vector[GraphOutputNode] = wf.innerGraph.outputNodes.toVector
+    val outputNodes: Vector[GraphOutputNode] =
+      wf.innerGraph.outputNodes.toVector
     Utils.appletLog(
       verbose,
       s"""|Evaluating workflow outputs
-                                     |${WomPrettyPrintApproxWdl.graphOutputs(outputNodes)}
+                                     |${WomPrettyPrintApproxWdl.graphOutputs(
+           outputNodes
+         )}
                                      |""".stripMargin
     )
 
@@ -99,7 +107,8 @@ case class WfOutputs(
         name -> value
 
       case expr: ExpressionBasedGraphOutputNode =>
-        val value = evaluateWomExpression(expr.womExpression, expr.womType, envFull)
+        val value =
+          evaluateWomExpression(expr.womExpression, expr.womType, envFull)
         val name = expr.graphOutputPort.name
         envFull += (name -> value)
         name -> value
@@ -112,7 +121,8 @@ case class WfOutputs(
     val outputFields: Map[String, JsValue] = outputs
       .map {
         case (outputVarName, womValue) =>
-          val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
+          val wvl =
+            wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
           wdlVarLinksConverter.genFields(wvl, outputVarName)
       }
       .toList
@@ -120,7 +130,9 @@ case class WfOutputs(
       .toMap
 
     if (addStatus) {
-      outputFields + (Utils.REORG_STATUS -> JsString(Utils.REORG_STATUS_COMPLETE))
+      outputFields + (Utils.REORG_STATUS -> JsString(
+        Utils.REORG_STATUS_COMPLETE
+      ))
     } else {
       outputFields
     }

--- a/src/main/scala/dxWDL/exec/WfOutputs.scala
+++ b/src/main/scala/dxWDL/exec/WfOutputs.scala
@@ -15,100 +15,114 @@ import wom.types._
 import dxWDL.base.{Utils, Verbose}
 import dxWDL.util._
 
-case class WfOutputs(wf: WorkflowDefinition,
-                     wfSourceCode: String,
-                     typeAliases : Map[String, WomType],
-                     dxPathConfig : DxPathConfig,
-                     dxIoFunctions : DxIoFunctions,
-                     runtimeDebugLevel: Int) {
-    private val verbose = runtimeDebugLevel >= 1
-    //private val maxVerboseLevel = (runtimeDebugLevel == 2)
-    private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
-    private val wdlVarLinksConverter = WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
+case class WfOutputs(
+    wf: WorkflowDefinition,
+    wfSourceCode: String,
+    typeAliases: Map[String, WomType],
+    dxPathConfig: DxPathConfig,
+    dxIoFunctions: DxIoFunctions,
+    runtimeDebugLevel: Int
+) {
+  private val verbose = runtimeDebugLevel >= 1
+  //private val maxVerboseLevel = (runtimeDebugLevel == 2)
+  private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)
+  private val wdlVarLinksConverter =
+    WdlVarLinksConverter(utlVerbose, dxIoFunctions.fileInfoDir, typeAliases)
 
-    private def evaluateWomExpression(expr: WomExpression,
-                                      womType: WomType,
-                                      env: Map[String, WomValue]) : WomValue = {
-        val result: ErrorOr[WomValue] =
-            expr.evaluateValue(env, dxIoFunctions)
-        val value = result match {
-            case Invalid(errors) => throw new Exception(
-                s"Failed to evaluate expression ${expr} with ${errors}")
-            case Valid(x: WomValue) => x
-        }
-
-        // cast the result value to the correct type
-        // For example, an expression like:
-        //   Float x = "3.2"
-        // requires casting from string to float
-        womType.coerceRawValue(value).get
+  private def evaluateWomExpression(
+      expr: WomExpression,
+      womType: WomType,
+      env: Map[String, WomValue]
+  ): WomValue = {
+    val result: ErrorOr[WomValue] =
+      expr.evaluateValue(env, dxIoFunctions)
+    val value = result match {
+      case Invalid(errors) =>
+        throw new Exception(s"Failed to evaluate expression ${expr} with ${errors}")
+      case Valid(x: WomValue) => x
     }
 
-    def apply(envInitial: Map[String, WomValue], addStatus: Boolean = false) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
-        Utils.appletLog(verbose, s"Environment: ${envInitial}")
-        val outputNodes : Vector[GraphOutputNode] = wf.innerGraph.outputNodes.toVector
-        Utils.appletLog(verbose, s"""|Evaluating workflow outputs
+    // cast the result value to the correct type
+    // For example, an expression like:
+    //   Float x = "3.2"
+    // requires casting from string to float
+    womType.coerceRawValue(value).get
+  }
+
+  def apply(envInitial: Map[String, WomValue], addStatus: Boolean = false): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
+    Utils.appletLog(verbose, s"Environment: ${envInitial}")
+    val outputNodes: Vector[GraphOutputNode] = wf.innerGraph.outputNodes.toVector
+    Utils.appletLog(
+      verbose,
+      s"""|Evaluating workflow outputs
                                      |${WomPrettyPrintApproxWdl.graphOutputs(outputNodes)}
-                                     |""".stripMargin)
+                                     |""".stripMargin
+    )
 
-        // Some of the inputs could be optional. If they are missing,
-        // add in a None value.
-        val allInputs = Block.closure(Block(wf.innerGraph.outputNodes.toVector))
-        val envInitialFilled : Map[String, WomValue] = allInputs.flatMap { case (name, (womType, hasDefaultVal)) =>
-            (envInitial.get(name), womType) match {
-                case (None, WomOptionalType(t)) =>
-                    Some(name -> WomOptionalValue(t, None))
-                case (None, _) if hasDefaultVal =>
-                    None
-                case (None, _) =>
-                    // input is missing, and there is no default at the callee,
-                    Utils.warning(utlVerbose, s"input is missing for ${name}, and there is no default at the callee")
-                    None
-                case (Some(x), _) =>
-                    Some(name -> x)
-            }
-        }.toMap
-
-        // Evaluate the output declarations. Add outputs evaluated to
-        // the environment, so they can be referenced by expressions in the next
-        // lines.
-        var envFull = envInitialFilled
-        val outputs: Map[String, WomValue] = outputNodes.map{
-            case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-                val value = envFull.get(sourcePort.name) match {
-                    case None =>
-                        throw new Exception(s"could not find ${sourcePort}")
-                    case Some(value) =>
-                        value
-                }
-                val name = id.workflowLocalName
-                envFull += (name -> value)
-                name -> value
-
-            case expr :ExpressionBasedGraphOutputNode =>
-                val value = evaluateWomExpression(expr.womExpression,
-                    expr.womType,
-                    envFull)
-                val name = expr.graphOutputPort.name
-                envFull += (name -> value)
-                name -> value
-
-            case other =>
-                throw new Exception(s"unhandled output ${other}")
-        }.toMap
-
-        // convert the WDL values to JSON
-        val outputFields:Map[String, JsValue] = outputs.map {
-            case (outputVarName, womValue) =>
-                val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
-                wdlVarLinksConverter.genFields(wvl, outputVarName)
-        }.toList.flatten.toMap
-
-        if (addStatus) {
-            outputFields + (Utils.REORG_STATUS -> JsString(Utils.REORG_STATUS_COMPLETE))
-        } else {
-            outputFields
+    // Some of the inputs could be optional. If they are missing,
+    // add in a None value.
+    val allInputs = Block.closure(Block(wf.innerGraph.outputNodes.toVector))
+    val envInitialFilled: Map[String, WomValue] = allInputs.flatMap {
+      case (name, (womType, hasDefaultVal)) =>
+        (envInitial.get(name), womType) match {
+          case (None, WomOptionalType(t)) =>
+            Some(name -> WomOptionalValue(t, None))
+          case (None, _) if hasDefaultVal =>
+            None
+          case (None, _) =>
+            // input is missing, and there is no default at the callee,
+            Utils.warning(
+              utlVerbose,
+              s"input is missing for ${name}, and there is no default at the callee"
+            )
+            None
+          case (Some(x), _) =>
+            Some(name -> x)
         }
+    }.toMap
+
+    // Evaluate the output declarations. Add outputs evaluated to
+    // the environment, so they can be referenced by expressions in the next
+    // lines.
+    var envFull = envInitialFilled
+    val outputs: Map[String, WomValue] = outputNodes.map {
+      case PortBasedGraphOutputNode(id, womType, sourcePort) =>
+        val value = envFull.get(sourcePort.name) match {
+          case None =>
+            throw new Exception(s"could not find ${sourcePort}")
+          case Some(value) =>
+            value
+        }
+        val name = id.workflowLocalName
+        envFull += (name -> value)
+        name             -> value
+
+      case expr: ExpressionBasedGraphOutputNode =>
+        val value = evaluateWomExpression(expr.womExpression, expr.womType, envFull)
+        val name  = expr.graphOutputPort.name
+        envFull += (name -> value)
+        name             -> value
+
+      case other =>
+        throw new Exception(s"unhandled output ${other}")
+    }.toMap
+
+    // convert the WDL values to JSON
+    val outputFields: Map[String, JsValue] = outputs
+      .map {
+        case (outputVarName, womValue) =>
+          val wvl = wdlVarLinksConverter.importFromWDL(womValue.womType, womValue)
+          wdlVarLinksConverter.genFields(wvl, outputVarName)
+      }
+      .toList
+      .flatten
+      .toMap
+
+    if (addStatus) {
+      outputFields + (Utils.REORG_STATUS -> JsString(Utils.REORG_STATUS_COMPLETE))
+    } else {
+      outputFields
     }
+  }
 }

--- a/src/main/scala/dxWDL/exec/WfOutputs.scala
+++ b/src/main/scala/dxWDL/exec/WfOutputs.scala
@@ -39,7 +39,7 @@ case class WfOutputs(
     val value = result match {
       case Invalid(errors) =>
         throw new Exception(
-          s"Failed to evaluate expression ${expr} with ${errors}"
+            s"Failed to evaluate expression ${expr} with ${errors}"
         )
       case Valid(x: WomValue) => x
     }
@@ -60,11 +60,11 @@ case class WfOutputs(
     val outputNodes: Vector[GraphOutputNode] =
       wf.innerGraph.outputNodes.toVector
     Utils.appletLog(
-      verbose,
-      s"""|Evaluating workflow outputs
+        verbose,
+        s"""|Evaluating workflow outputs
                                      |${WomPrettyPrintApproxWdl.graphOutputs(
-           outputNodes
-         )}
+               outputNodes
+           )}
                                      |""".stripMargin
     )
 
@@ -81,8 +81,8 @@ case class WfOutputs(
           case (None, _) =>
             // input is missing, and there is no default at the callee,
             Utils.warning(
-              utlVerbose,
-              s"input is missing for ${name}, and there is no default at the callee"
+                utlVerbose,
+                s"input is missing for ${name}, and there is no default at the callee"
             )
             None
           case (Some(x), _) =>
@@ -131,7 +131,7 @@ case class WfOutputs(
 
     if (addStatus) {
       outputFields + (Utils.REORG_STATUS -> JsString(
-        Utils.REORG_STATUS_COMPLETE
+          Utils.REORG_STATUS_COMPLETE
       ))
     } else {
       outputFields

--- a/src/main/scala/dxWDL/exec/WfOutputs.scala
+++ b/src/main/scala/dxWDL/exec/WfOutputs.scala
@@ -96,13 +96,13 @@ case class WfOutputs(
         }
         val name = id.workflowLocalName
         envFull += (name -> value)
-        name             -> value
+        name -> value
 
       case expr: ExpressionBasedGraphOutputNode =>
         val value = evaluateWomExpression(expr.womExpression, expr.womType, envFull)
-        val name  = expr.graphOutputPort.name
+        val name = expr.graphOutputPort.name
         envFull += (name -> value)
-        name             -> value
+        name -> value
 
       case other =>
         throw new Exception(s"unhandled output ${other}")

--- a/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
+++ b/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
@@ -32,7 +32,10 @@ case class WorkflowOutputReorg(
   //
   // In other words, this code is an efficient replacement for:
   // files.map(_.describe().getName())
-  def bulkGetFilenames(files: Seq[DxFile], dxProject: DxProject): Vector[String] = {
+  def bulkGetFilenames(
+      files: Seq[DxFile],
+      dxProject: DxProject
+  ): Vector[String] = {
     val info: Map[DxFile, DxFileDescribe] = DxFile.bulkDescribe(files.toVector)
     info.values.map(_.name).toVector
   }
@@ -47,9 +50,15 @@ case class WorkflowOutputReorg(
   // however, that would require a describe API call per output
   // file. Instead, we find all the output files that do not also
   // appear in the input.
-  def analysisFileOutputs(dxProject: DxProject, dxAnalysis: DxAnalysis): Vector[DxFile] = {
+  def analysisFileOutputs(
+      dxProject: DxProject,
+      dxAnalysis: DxAnalysis
+  ): Vector[DxFile] = {
     val req = JsObject(
-      "fields" -> JsObject("input" -> JsBoolean(true), "output" -> JsBoolean(true))
+      "fields" -> JsObject(
+        "input" -> JsBoolean(true),
+        "output" -> JsBoolean(true)
+      )
     )
     val rep = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
@@ -90,7 +99,10 @@ case class WorkflowOutputReorg(
         else
           None
     }.toVector
-    Utils.appletLog(verbose, s"analysis has ${outputFiles.length} verified output files")
+    Utils.appletLog(
+      verbose,
+      s"analysis has ${outputFiles.length} verified output files"
+    )
 
     outputFiles
   }
@@ -106,7 +118,8 @@ case class WorkflowOutputReorg(
     Utils.appletLog(verbose, s"proj=${dxProjDesc.name} outFolder=${outFolder}")
 
     // find all analysis output files
-    val analysisFiles: Vector[DxFile] = analysisFileOutputs(dxProject, dxAnalysis)
+    val analysisFiles: Vector[DxFile] =
+      analysisFileOutputs(dxProject, dxAnalysis)
     if (analysisFiles.isEmpty)
       return
 
@@ -126,10 +139,16 @@ case class WorkflowOutputReorg(
     val folderContents: FolderContents = dxProject.listFolder(outFolder)
     Utils.appletLog(verbose, s"subfolders=${folderContents.subFolders}")
     if (!(folderContents.subFolders contains intermFolder)) {
-      Utils.appletLog(verbose, s"Creating intermediate results sub-folder ${intermFolder}")
+      Utils.appletLog(
+        verbose,
+        s"Creating intermediate results sub-folder ${intermFolder}"
+      )
       dxProject.newFolder(intermFolder, true)
     } else {
-      Utils.appletLog(verbose, s"Intermediate results sub-folder ${intermFolder} already exists")
+      Utils.appletLog(
+        verbose,
+        s"Intermediate results sub-folder ${intermFolder} already exists"
+      )
     }
     dxProject.moveObjects(intermediateFiles, intermFolder)
   }

--- a/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
+++ b/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
@@ -16,128 +16,131 @@ import dxWDL.base.Utils
 import dxWDL.dx._
 import dxWDL.util._
 
-case class WorkflowOutputReorg(wf: WorkflowDefinition,
-                               wfSourceCode: String,
-                               typeAliases: Map[String, WomType],
-                               dxPathConfig : DxPathConfig,
-                               dxIoFunctions : DxIoFunctions,
-                               runtimeDebugLevel: Int) {
-    private val verbose = runtimeDebugLevel >= 1
+case class WorkflowOutputReorg(
+    wf: WorkflowDefinition,
+    wfSourceCode: String,
+    typeAliases: Map[String, WomType],
+    dxPathConfig: DxPathConfig,
+    dxIoFunctions: DxIoFunctions,
+    runtimeDebugLevel: Int
+) {
+  private val verbose = runtimeDebugLevel >= 1
 
-    // Efficiently get the names of many files. We
-    // don't want to do a `describe` each one of them, instead,
-    // we do a bulk-describe.
-    //
-    // In other words, this code is an efficient replacement for:
-    // files.map(_.describe().getName())
-    def bulkGetFilenames(files: Seq[DxFile], dxProject: DxProject) : Vector[String] = {
-        val info : Map[DxFile, DxFileDescribe] = DxFile.bulkDescribe(files.toVector)
-        info.values.map(_.name).toVector
+  // Efficiently get the names of many files. We
+  // don't want to do a `describe` each one of them, instead,
+  // we do a bulk-describe.
+  //
+  // In other words, this code is an efficient replacement for:
+  // files.map(_.describe().getName())
+  def bulkGetFilenames(files: Seq[DxFile], dxProject: DxProject): Vector[String] = {
+    val info: Map[DxFile, DxFileDescribe] = DxFile.bulkDescribe(files.toVector)
+    info.values.map(_.name).toVector
+  }
+
+  // find all output files from the analysis
+  //
+  // We want to find all inputs and outputs with little platform overhead.
+  // Here, we use a describe API call on the analysis.
+  //
+  // The output files could include some of the inputs, and we need
+  // to filter those out. One way, is to check file creation dates,
+  // however, that would require a describe API call per output
+  // file. Instead, we find all the output files that do not also
+  // appear in the input.
+  def analysisFileOutputs(dxProject: DxProject, dxAnalysis: DxAnalysis): Vector[DxFile] = {
+    val req = JsObject(
+      "fields" -> JsObject("input" -> JsBoolean(true), "output" -> JsBoolean(true))
+    )
+    val rep            = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
+    val outputs = repJs.asJsObject.fields.get("output") match {
+      case None    => throw new Exception("Failed to get analysis outputs")
+      case Some(x) => x
+    }
+    val inputs = repJs.asJsObject.fields.get("input") match {
+      case None    => throw new Exception("Failed to get analysis inputs")
+      case Some(x) => x
     }
 
-    // find all output files from the analysis
-    //
-    // We want to find all inputs and outputs with little platform overhead.
-    // Here, we use a describe API call on the analysis.
-    //
-    // The output files could include some of the inputs, and we need
-    // to filter those out. One way, is to check file creation dates,
-    // however, that would require a describe API call per output
-    // file. Instead, we find all the output files that do not also
-    // appear in the input.
-    def analysisFileOutputs(dxProject: DxProject,
-                            dxAnalysis: DxAnalysis) : Vector[DxFile]= {
-        val req = JsObject("fields" -> JsObject(
-                               "input" -> JsBoolean(true),
-                               "output" -> JsBoolean(true)))
-        val rep = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(rep)
-        val outputs = repJs.asJsObject.fields.get("output") match {
-            case None => throw new Exception("Failed to get analysis outputs")
-            case Some(x) => x
-        }
-        val inputs = repJs.asJsObject.fields.get("input") match {
-            case None => throw new Exception("Failed to get analysis inputs")
-            case Some(x) => x
-        }
+    val fileOutputs: Set[DxFile] = DxUtils.findDxFiles(outputs).toSet
+    val fileInputs: Set[DxFile]  = DxUtils.findDxFiles(inputs).toSet
+    val realOutputs: Set[DxFile] = fileOutputs.toSet -- fileInputs.toSet
+    Utils.appletLog(verbose, s"analysis has ${fileOutputs.size} output files")
+    Utils.appletLog(verbose, s"analysis has ${fileInputs.size} input files")
+    Utils.appletLog(verbose, s"analysis has ${realOutputs.size} real outputs")
 
-        val fileOutputs : Set[DxFile] = DxUtils.findDxFiles(outputs).toSet
-        val fileInputs: Set[DxFile] = DxUtils.findDxFiles(inputs).toSet
-        val realOutputs:Set[DxFile] = fileOutputs.toSet -- fileInputs.toSet
-        Utils.appletLog(verbose, s"analysis has ${fileOutputs.size} output files")
-        Utils.appletLog(verbose, s"analysis has ${fileInputs.size} input files")
-        Utils.appletLog(verbose, s"analysis has ${realOutputs.size} real outputs")
-
-        Utils.appletLog(verbose, "Checking timestamps")
-        if (realOutputs.size > Utils.MAX_NUM_FILES_MOVE_LIMIT) {
-            Utils.appletLog(verbose, s"WARNING: Large number of outputs (${realOutputs.size}), not moving objects")
-            return Vector.empty
-        }
-        val realFreshOutputs : Map[DxFile, DxFileDescribe] =
-            DxFile.bulkDescribe(realOutputs.toVector)
-
-        // Retain only files that were created AFTER the analysis started
-        val anlCreateTs:java.util.Date = dxAnalysis.describe().getCreationDate()
-        val outputFiles: Vector[DxFile] = realFreshOutputs.flatMap{
-            case (dxFile, desc) =>
-                val creationDate = new java.util.Date(desc.created)
-                if (creationDate.compareTo(anlCreateTs) >= 0)
-                    Some(dxFile)
-                else
-                    None
-        }.toVector
-        Utils.appletLog(verbose, s"analysis has ${outputFiles.length} verified output files")
-
-        outputFiles
+    Utils.appletLog(verbose, "Checking timestamps")
+    if (realOutputs.size > Utils.MAX_NUM_FILES_MOVE_LIMIT) {
+      Utils.appletLog(
+        verbose,
+        s"WARNING: Large number of outputs (${realOutputs.size}), not moving objects"
+      )
+      return Vector.empty
     }
+    val realFreshOutputs: Map[DxFile, DxFileDescribe] =
+      DxFile.bulkDescribe(realOutputs.toVector)
 
-    // Move all intermediate results to a sub-folder
-    def moveIntermediateResultFiles(exportFiles: Vector[DxFile]): Unit = {
-        val dxEnv = DxUtils.dxEnv
-        val dxProject = DxProject(dxEnv.getProjectContext())
-        val dxProjDesc = dxProject.describe()
-        val dxAnalysis = DxJob(dxEnv.getJob).describe().analysis.get
-        val outFolder = dxAnalysis.describe().folder
-        val intermFolder = outFolder + "/" + Utils.INTERMEDIATE_RESULTS_FOLDER
-        Utils.appletLog(verbose, s"proj=${dxProjDesc.name} outFolder=${outFolder}")
+    // Retain only files that were created AFTER the analysis started
+    val anlCreateTs: java.util.Date = dxAnalysis.describe().getCreationDate()
+    val outputFiles: Vector[DxFile] = realFreshOutputs.flatMap {
+      case (dxFile, desc) =>
+        val creationDate = new java.util.Date(desc.created)
+        if (creationDate.compareTo(anlCreateTs) >= 0)
+          Some(dxFile)
+        else
+          None
+    }.toVector
+    Utils.appletLog(verbose, s"analysis has ${outputFiles.length} verified output files")
 
-        // find all analysis output files
-        val analysisFiles: Vector[DxFile] = analysisFileOutputs(dxProject, dxAnalysis)
-        if (analysisFiles.isEmpty)
-            return
+    outputFiles
+  }
 
-        val exportIds:Set[String] = exportFiles.map(_.id).toSet
-        val exportNames:Seq[String] = bulkGetFilenames(exportFiles, dxProject)
-        Utils.appletLog(verbose, s"exportFiles=${exportNames}")
+  // Move all intermediate results to a sub-folder
+  def moveIntermediateResultFiles(exportFiles: Vector[DxFile]): Unit = {
+    val dxEnv        = DxUtils.dxEnv
+    val dxProject    = DxProject(dxEnv.getProjectContext())
+    val dxProjDesc   = dxProject.describe()
+    val dxAnalysis   = DxJob(dxEnv.getJob).describe().analysis.get
+    val outFolder    = dxAnalysis.describe().folder
+    val intermFolder = outFolder + "/" + Utils.INTERMEDIATE_RESULTS_FOLDER
+    Utils.appletLog(verbose, s"proj=${dxProjDesc.name} outFolder=${outFolder}")
 
-        // Figure out which of the files should be kept
-        val intermediateFiles = analysisFiles.filter(x => !(exportIds contains x.id))
-        val iNames:Seq[String] = bulkGetFilenames(intermediateFiles, dxProject)
-        Utils.appletLog(verbose, s"intermediate files=${iNames}")
-        if (intermediateFiles.isEmpty)
-            return
+    // find all analysis output files
+    val analysisFiles: Vector[DxFile] = analysisFileOutputs(dxProject, dxAnalysis)
+    if (analysisFiles.isEmpty)
+      return
 
-        // Move all non exported results to the subdir. Do this in
-        // a single API call, to improve performance.
-        val folderContents : FolderContents = dxProject.listFolder(outFolder)
-        Utils.appletLog(verbose, s"subfolders=${folderContents.subFolders}")
-        if (!(folderContents.subFolders contains intermFolder)) {
-            Utils.appletLog(verbose, s"Creating intermediate results sub-folder ${intermFolder}")
-            dxProject.newFolder(intermFolder, true)
-        } else {
-            Utils.appletLog(verbose, s"Intermediate results sub-folder ${intermFolder} already exists")
-        }
-        dxProject.moveObjects(intermediateFiles, intermFolder)
+    val exportIds: Set[String]   = exportFiles.map(_.id).toSet
+    val exportNames: Seq[String] = bulkGetFilenames(exportFiles, dxProject)
+    Utils.appletLog(verbose, s"exportFiles=${exportNames}")
+
+    // Figure out which of the files should be kept
+    val intermediateFiles   = analysisFiles.filter(x => !(exportIds contains x.id))
+    val iNames: Seq[String] = bulkGetFilenames(intermediateFiles, dxProject)
+    Utils.appletLog(verbose, s"intermediate files=${iNames}")
+    if (intermediateFiles.isEmpty)
+      return
+
+    // Move all non exported results to the subdir. Do this in
+    // a single API call, to improve performance.
+    val folderContents: FolderContents = dxProject.listFolder(outFolder)
+    Utils.appletLog(verbose, s"subfolders=${folderContents.subFolders}")
+    if (!(folderContents.subFolders contains intermFolder)) {
+      Utils.appletLog(verbose, s"Creating intermediate results sub-folder ${intermFolder}")
+      dxProject.newFolder(intermFolder, true)
+    } else {
+      Utils.appletLog(verbose, s"Intermediate results sub-folder ${intermFolder} already exists")
     }
+    dxProject.moveObjects(intermediateFiles, intermFolder)
+  }
 
+  def apply(wfOutputFiles: Vector[DxFile]): Map[String, JsValue] = {
+    Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
 
-    def apply(wfOutputFiles: Vector[DxFile]) : Map[String, JsValue] = {
-        Utils.appletLog(verbose, s"dxWDL version: ${Utils.getVersion()}")
+    // Reorganize directory structure
+    moveIntermediateResultFiles(wfOutputFiles)
 
-        // Reorganize directory structure
-        moveIntermediateResultFiles(wfOutputFiles)
-
-        // empty results
-        Map.empty[String, JsValue]
-    }
+    // empty results
+    Map.empty[String, JsValue]
+  }
 }

--- a/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
+++ b/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
@@ -51,7 +51,7 @@ case class WorkflowOutputReorg(
     val req = JsObject(
       "fields" -> JsObject("input" -> JsBoolean(true), "output" -> JsBoolean(true))
     )
-    val rep            = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
+    val rep = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
     val outputs = repJs.asJsObject.fields.get("output") match {
       case None    => throw new Exception("Failed to get analysis outputs")
@@ -63,7 +63,7 @@ case class WorkflowOutputReorg(
     }
 
     val fileOutputs: Set[DxFile] = DxUtils.findDxFiles(outputs).toSet
-    val fileInputs: Set[DxFile]  = DxUtils.findDxFiles(inputs).toSet
+    val fileInputs: Set[DxFile] = DxUtils.findDxFiles(inputs).toSet
     val realOutputs: Set[DxFile] = fileOutputs.toSet -- fileInputs.toSet
     Utils.appletLog(verbose, s"analysis has ${fileOutputs.size} output files")
     Utils.appletLog(verbose, s"analysis has ${fileInputs.size} input files")
@@ -97,11 +97,11 @@ case class WorkflowOutputReorg(
 
   // Move all intermediate results to a sub-folder
   def moveIntermediateResultFiles(exportFiles: Vector[DxFile]): Unit = {
-    val dxEnv        = DxUtils.dxEnv
-    val dxProject    = DxProject(dxEnv.getProjectContext())
-    val dxProjDesc   = dxProject.describe()
-    val dxAnalysis   = DxJob(dxEnv.getJob).describe().analysis.get
-    val outFolder    = dxAnalysis.describe().folder
+    val dxEnv = DxUtils.dxEnv
+    val dxProject = DxProject(dxEnv.getProjectContext())
+    val dxProjDesc = dxProject.describe()
+    val dxAnalysis = DxJob(dxEnv.getJob).describe().analysis.get
+    val outFolder = dxAnalysis.describe().folder
     val intermFolder = outFolder + "/" + Utils.INTERMEDIATE_RESULTS_FOLDER
     Utils.appletLog(verbose, s"proj=${dxProjDesc.name} outFolder=${outFolder}")
 
@@ -110,12 +110,12 @@ case class WorkflowOutputReorg(
     if (analysisFiles.isEmpty)
       return
 
-    val exportIds: Set[String]   = exportFiles.map(_.id).toSet
+    val exportIds: Set[String] = exportFiles.map(_.id).toSet
     val exportNames: Seq[String] = bulkGetFilenames(exportFiles, dxProject)
     Utils.appletLog(verbose, s"exportFiles=${exportNames}")
 
     // Figure out which of the files should be kept
-    val intermediateFiles   = analysisFiles.filter(x => !(exportIds contains x.id))
+    val intermediateFiles = analysisFiles.filter(x => !(exportIds contains x.id))
     val iNames: Seq[String] = bulkGetFilenames(intermediateFiles, dxProject)
     Utils.appletLog(verbose, s"intermediate files=${iNames}")
     if (intermediateFiles.isEmpty)

--- a/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
+++ b/src/main/scala/dxWDL/exec/WorkflowOutputReorg.scala
@@ -55,10 +55,10 @@ case class WorkflowOutputReorg(
       dxAnalysis: DxAnalysis
   ): Vector[DxFile] = {
     val req = JsObject(
-      "fields" -> JsObject(
-        "input" -> JsBoolean(true),
-        "output" -> JsBoolean(true)
-      )
+        "fields" -> JsObject(
+            "input" -> JsBoolean(true),
+            "output" -> JsBoolean(true)
+        )
     )
     val rep = DXAPI.analysisDescribe(dxAnalysis.id, req, classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
@@ -81,8 +81,8 @@ case class WorkflowOutputReorg(
     Utils.appletLog(verbose, "Checking timestamps")
     if (realOutputs.size > Utils.MAX_NUM_FILES_MOVE_LIMIT) {
       Utils.appletLog(
-        verbose,
-        s"WARNING: Large number of outputs (${realOutputs.size}), not moving objects"
+          verbose,
+          s"WARNING: Large number of outputs (${realOutputs.size}), not moving objects"
       )
       return Vector.empty
     }
@@ -100,8 +100,8 @@ case class WorkflowOutputReorg(
           None
     }.toVector
     Utils.appletLog(
-      verbose,
-      s"analysis has ${outputFiles.length} verified output files"
+        verbose,
+        s"analysis has ${outputFiles.length} verified output files"
     )
 
     outputFiles
@@ -140,14 +140,14 @@ case class WorkflowOutputReorg(
     Utils.appletLog(verbose, s"subfolders=${folderContents.subFolders}")
     if (!(folderContents.subFolders contains intermFolder)) {
       Utils.appletLog(
-        verbose,
-        s"Creating intermediate results sub-folder ${intermFolder}"
+          verbose,
+          s"Creating intermediate results sub-folder ${intermFolder}"
       )
       dxProject.newFolder(intermFolder, true)
     } else {
       Utils.appletLog(
-        verbose,
-        s"Intermediate results sub-folder ${intermFolder} already exists"
+          verbose,
+          s"Intermediate results sub-folder ${intermFolder} already exists"
       )
     }
     dxProject.moveObjects(intermediateFiles, intermFolder)

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -318,7 +318,7 @@ object Block {
 
     // separate out the inputs
     val (inputBlock, innerInputs) = distinguishTopLevelInputs(
-      graph.inputNodes.toSeq
+        graph.inputNodes.toSeq
     )
     rest --= graph.inputNodes.toSet
 
@@ -524,7 +524,7 @@ object Block {
         case sct: ScatterFullBlock => sct.value.innerGraph
         case other =>
           throw new UnsupportedOperationException(
-            s"${other.getClass.toString} does not have an inner graph"
+              s"${other.getClass.toString} does not have an inner graph"
           )
       }
     }

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -100,7 +100,7 @@ case class Block(nodes: Vector[GraphNode]) {
   def validate(): Unit = {
     // There can be no calls in the first nodes
     val allButLast: Vector[GraphNode] = this.nodes.dropRight(1)
-    val allCalls                      = Block.deepFindCalls(allButLast)
+    val allCalls = Block.deepFindCalls(allButLast)
     assert(allCalls.size == 0)
   }
 
@@ -126,8 +126,8 @@ case class Block(nodes: Vector[GraphNode]) {
         // WDL allows scatter on one element only
         assert(ssc.scatterVariableNodes.size == 1)
         val svNode: ScatterVariableNode = ssc.scatterVariableNodes.head
-        val collection                  = svNode.scatterExpressionNode.womExpression.sourceString
-        val name                        = svNode.identifier.localName.value
+        val collection = svNode.scatterExpressionNode.womExpression.sourceString
+        val name = svNode.identifier.localName.value
         s"scatter (${name} in ${collection})"
       case cond: ConditionalNode =>
         s"if (${cond.conditionExpression.womExpression.sourceString})"
@@ -203,7 +203,7 @@ object Block {
     assert(nodes.size > 0)
     nodes.flatMap { node =>
       val ancestors = node.upstreamAncestry
-      val others    = nodes - node
+      val others = nodes - node
       if ((ancestors.intersect(others)).isEmpty) {
         Some(node)
       } else {
@@ -215,7 +215,7 @@ object Block {
   // Sort a group of nodes according to dependencies. Note that this is a partial
   // ordering only.
   def partialSortByDep(nodes: Set[GraphNode]): Vector[GraphNode] = {
-    var ordered              = Vector.empty[GraphNode]
+    var ordered = Vector.empty[GraphNode]
     var rest: Set[GraphNode] = nodes
 
     while (!rest.isEmpty) {
@@ -303,12 +303,12 @@ object Block {
   def splitGraph(graph: Graph, callsLoToHi: Vector[String]): (
       Vector[GraphInputNode], // inputs
       Vector[GraphInputNode], // missing inner inputs that propagate
-      Vector[Block],          // blocks
+      Vector[Block], // blocks
       Vector[GraphOutputNode]
   ) // outputs
   = {
     var rest: Set[GraphNode] = graph.nodes
-    var blocks               = Vector.empty[Block]
+    var blocks = Vector.empty[Block]
 
     // separate out the inputs
     val (inputBlock, innerInputs) = distinguishTopLevelInputs(graph.inputNodes.toSeq)
@@ -367,7 +367,7 @@ object Block {
   def split(graph: Graph, wfSource: String): (
       Vector[GraphInputNode], // inputs
       Vector[GraphInputNode], // implicit inputs
-      Vector[Block],          // blocks
+      Vector[Block], // blocks
       Vector[GraphOutputNode]
   ) // outputs
   = {
@@ -476,7 +476,7 @@ object Block {
   sealed trait Category {
     val nodes: Vector[GraphNode]
   }
-  case class AllExpressions(override val nodes: Vector[GraphNode])              extends Category
+  case class AllExpressions(override val nodes: Vector[GraphNode]) extends Category
   case class CallDirect(override val nodes: Vector[GraphNode], value: CallNode) extends Category
   case class CallWithSubexpressions(override val nodes: Vector[GraphNode], value: CallNode)
       extends Category
@@ -510,7 +510,7 @@ object Block {
     def toString(catg: Category): String = {
       // convert Block$Cond to Cond
       val fullClassName = catg.getClass.toString
-      val index         = fullClassName.lastIndexOf('$')
+      val index = fullClassName.lastIndexOf('$')
       if (index == -1)
         fullClassName
       else
@@ -556,10 +556,10 @@ object Block {
     assert(path.size >= 1)
 
     val (_, _, blocks, _) = splitGraph(graph, callsLoToHi)
-    var subBlock          = blocks(path.head)
+    var subBlock = blocks(path.head)
     for (i <- path.tail) {
-      val catg               = categorize(subBlock)
-      val innerGraph         = Category.getInnerGraph(catg)
+      val catg = categorize(subBlock)
+      val innerGraph = Category.getInnerGraph(catg)
       val (_, _, blocks2, _) = splitGraph(innerGraph, callsLoToHi)
       subBlock = blocks2(i)
     }
@@ -650,7 +650,7 @@ object Block {
     //
     val optionalInputs: Set[String] = block.nodes.flatMap {
       case cNode: CallNode =>
-        val missingCallArgs  = cNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+        val missingCallArgs = cNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
         val callee: Callable = cNode.callable
         missingCallArgs.flatMap {
           case (name, womType) =>
@@ -690,7 +690,7 @@ object Block {
 
     xtrnPorts.map { outputPort =>
       // Is this really the fully qualified name?
-      val fqn     = outputPort.identifier.localName.value
+      val fqn = outputPort.identifier.localName.value
       val womType = outputPort.womType
       fqn -> womType
     }.toMap
@@ -748,7 +748,7 @@ object Block {
   ): Set[String] = {
     // Figure out all the variables needed to calculate the outputs
     val outputs: Set[String] = outputClosure(outputNodes)
-    val inputs: Set[String]  = inputNodes.map(iNode => iNode.identifier.localName.value).toSet
+    val inputs: Set[String] = inputNodes.map(iNode => iNode.identifier.localName.value).toSet
     //System.out.println(s"inputsUsedAsOutputs: ${outputs} ${inputs}")
     inputs.intersect(outputs)
   }

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -71,7 +71,7 @@ These are not blocks, because we need a subworkflow to run them:
      if (x > 3) {
         call Dec {input: a=x }
      }
-*/
+ */
 
 package dxWDL.util
 
@@ -84,176 +84,560 @@ import wom.types._
 
 // A sorted group of graph nodes, that match some original
 // set of WDL statements.
-case class Block(nodes : Vector[GraphNode]) {
-    def prettyPrint : String = {
-        val desc = nodes.map{ node =>
-            "    " + WomPrettyPrint.apply(node) + "\n"
-        }.mkString("")
-        s"""|Block [
+case class Block(nodes: Vector[GraphNode]) {
+  def prettyPrint: String = {
+    val desc = nodes
+      .map { node =>
+        "    " + WomPrettyPrint.apply(node) + "\n"
+      }
+      .mkString("")
+    s"""|Block [
             |${desc}
             |]""".stripMargin
+  }
+
+  // Check that this block is valid.
+  def validate(): Unit = {
+    // There can be no calls in the first nodes
+    val allButLast: Vector[GraphNode] = this.nodes.dropRight(1)
+    val allCalls                      = Block.deepFindCalls(allButLast)
+    assert(allCalls.size == 0)
+  }
+
+  // Create a human readable name for a block of statements
+  //
+  // 1. Ignore all declarations
+  // 2. If there is a scatter/if, use that
+  // 3. if there is at least one call, use the first one.
+  //
+  // If the entire block is made up of expressions, return None
+  def makeName: Option[String] = {
+    val coreStmts = nodes.filter {
+      case _: ScatterNode     => true
+      case _: ConditionalNode => true
+      case _: CallNode        => true
+      case _                  => false
     }
 
-    // Check that this block is valid.
-    def validate() : Unit = {
-        // There can be no calls in the first nodes
-        val allButLast : Vector[GraphNode] = this.nodes.dropRight(1)
-        val allCalls = Block.deepFindCalls(allButLast)
-        assert(allCalls.size == 0)
+    if (coreStmts.isEmpty)
+      return None
+    val name = coreStmts.head match {
+      case ssc: ScatterNode =>
+        // WDL allows scatter on one element only
+        assert(ssc.scatterVariableNodes.size == 1)
+        val svNode: ScatterVariableNode = ssc.scatterVariableNodes.head
+        val collection                  = svNode.scatterExpressionNode.womExpression.sourceString
+        val name                        = svNode.identifier.localName.value
+        s"scatter (${name} in ${collection})"
+      case cond: ConditionalNode =>
+        s"if (${cond.conditionExpression.womExpression.sourceString})"
+      case call: CallNode =>
+        s"frag ${call.identifier.localName.value}"
+      case _ =>
+        throw new Exception("sanity")
     }
-
-    // Create a human readable name for a block of statements
-    //
-    // 1. Ignore all declarations
-    // 2. If there is a scatter/if, use that
-    // 3. if there is at least one call, use the first one.
-    //
-    // If the entire block is made up of expressions, return None
-    def makeName : Option[String] = {
-        val coreStmts = nodes.filter{
-            case _: ScatterNode => true
-            case _: ConditionalNode => true
-            case _: CallNode => true
-            case _ => false
-        }
-
-        if (coreStmts.isEmpty)
-            return None
-        val name = coreStmts.head match {
-            case ssc : ScatterNode =>
-                // WDL allows scatter on one element only
-                assert(ssc.scatterVariableNodes.size == 1)
-                val svNode: ScatterVariableNode = ssc.scatterVariableNodes.head
-                val collection = svNode.scatterExpressionNode.womExpression.sourceString
-                val name = svNode.identifier.localName.value
-                s"scatter (${name} in ${collection})"
-            case cond : ConditionalNode =>
-                s"if (${cond.conditionExpression.womExpression.sourceString})"
-            case call : CallNode =>
-                s"frag ${call.identifier.localName.value}"
-            case _ =>
-                throw new Exception("sanity")
-        }
-        return Some(name)
-    }
+    return Some(name)
+  }
 
 }
 
 object Block {
-    // A trivial expression has no operators, it is either a constant WomValue
-    // or a single identifier. For example: '5' and 'x' are trivial. 'x + y'
-    // is not.
-    def isTrivialExpression(womType: WomType,
-                            expr: WomExpression) : Boolean = {
-        val inputs = expr.inputs
-        if (inputs.size > 1)
-            return false
-        if (WomValueAnalysis.isExpressionConst(womType, expr))
-            return true
-        // The expression may have one input, but could still have an operator.
-        // For example: x+1, x + x.
-        expr.sourceString == inputs.head
+  // A trivial expression has no operators, it is either a constant WomValue
+  // or a single identifier. For example: '5' and 'x' are trivial. 'x + y'
+  // is not.
+  def isTrivialExpression(womType: WomType, expr: WomExpression): Boolean = {
+    val inputs = expr.inputs
+    if (inputs.size > 1)
+      return false
+    if (WomValueAnalysis.isExpressionConst(womType, expr))
+      return true
+    // The expression may have one input, but could still have an operator.
+    // For example: x+1, x + x.
+    expr.sourceString == inputs.head
+  }
+
+  // The block is a singleton with one statement which is a call. The call
+  // has no subexpressions. Note that the call may not provide
+  // all the callee's arguments.
+  def isCallWithNoSubexpressions(node: GraphNode): Boolean = {
+    node match {
+      case call: CallNode =>
+        call.inputDefinitionMappings.forall {
+          case (inputDef, expr: WomExpression) =>
+            isTrivialExpression(inputDef.womType, expr)
+          case (_, _) => true
+        }
+      case _ => false
+    }
+  }
+
+  // Is the call [callName] invoked in one of the nodes, or their
+  // inner graphs?
+  private def graphContainsCall(callName: String, nodes: Set[GraphNode]): Boolean = {
+    nodes.exists {
+      case callNode: CallNode =>
+        callNode.identifier.localName.value == callName
+      case cNode: ConditionalNode =>
+        graphContainsCall(callName, cNode.innerGraph.nodes)
+      case scNode: ScatterNode =>
+        graphContainsCall(callName, scNode.innerGraph.nodes)
+      case _ => false
+    }
+  }
+
+  // Find the toplevel graph node that contains this call
+  def findCallByName(callName: String, nodes: Set[GraphNode]): Option[GraphNode] = {
+    val gnode: Option[GraphNode] = nodes.find {
+      case callNode: CallNode =>
+        callNode.identifier.localName.value == callName
+      case cNode: ConditionalNode =>
+        graphContainsCall(callName, cNode.innerGraph.nodes)
+      case scNode: ScatterNode =>
+        graphContainsCall(callName, scNode.innerGraph.nodes)
+      case _ => false
+    }
+    gnode
+  }
+
+  private def pickTopNodes(nodes: Set[GraphNode]) = {
+    assert(nodes.size > 0)
+    nodes.flatMap { node =>
+      val ancestors = node.upstreamAncestry
+      val others    = nodes - node
+      if ((ancestors.intersect(others)).isEmpty) {
+        Some(node)
+      } else {
+        None
+      }
+    }
+  }
+
+  // Sort a group of nodes according to dependencies. Note that this is a partial
+  // ordering only.
+  def partialSortByDep(nodes: Set[GraphNode]): Vector[GraphNode] = {
+    var ordered              = Vector.empty[GraphNode]
+    var rest: Set[GraphNode] = nodes
+
+    while (!rest.isEmpty) {
+      val tops = pickTopNodes(rest)
+      assert(!tops.isEmpty)
+      ordered = ordered ++ tops
+      rest = rest -- tops
     }
 
-    // The block is a singleton with one statement which is a call. The call
-    // has no subexpressions. Note that the call may not provide
-    // all the callee's arguments.
-    def isCallWithNoSubexpressions(node: GraphNode) : Boolean = {
-        node match {
-            case call : CallNode =>
-                call.inputDefinitionMappings.forall{
-                    case (inputDef, expr: WomExpression) =>
-                        isTrivialExpression(inputDef.womType, expr)
-                    case (_, _) => true
-                }
-            case _ => false
+    assert(ordered.size == nodes.size)
+    ordered
+  }
+
+  private def deepAncestors(node: GraphNode): Set[GraphNode] = {
+    node match {
+      case cndNode: ConditionalNode =>
+        cndNode.upstreamAncestry ++
+          cndNode.innerGraph.nodes.flatMap(deepAncestors(_))
+      case sctNode: ScatterNode =>
+        sctNode.upstreamAncestry ++
+          sctNode.innerGraph.nodes.flatMap(deepAncestors(_))
+      case ogin: OuterGraphInputNode =>
+        // follow the indirection, this is not by default
+        val sourceNode = ogin.linkToOuterGraphNode
+        sourceNode.upstreamAncestry + sourceNode
+      case _ =>
+        node.upstreamAncestry
+    }
+  }
+
+  // remove non local inputs, propagated from inner calls.
+  // In this workflow:
+  //
+  // workflow inner_wf {
+  //     input {}
+  //     call foo
+  //     output {}
+  // }
+  //
+  // task foo {
+  //     input {
+  //         Boolean unpassed_arg_default = true
+  //     }
+  //     command {}
+  //     output {}
+  // }
+  // unpassed_arg_default becomes a inner_wf argument, called
+  // 'inner_wf.foo.unpassed_arg_default'.
+  //
+  // As a result, we filter out any argument that has a dot it in.
+  private def distinguishTopLevelInputs(
+      inputs: Seq[GraphInputNode]
+  ): (Vector[GraphInputNode], Vector[GraphInputNode]) = {
+    val (inner, topLevelInputs) = inputs.partition { inNode =>
+      val name = inNode.identifier.localName.value
+      name contains '.'
+    }
+
+    (topLevelInputs.toVector, inner.toVector)
+  }
+
+  // Split an entire workflow.
+  //
+  // Sort the graph into a linear set of blocks, according to
+  // dependencies.  Each block is itself sorted. The dependencies
+  // impose a partial ordering on the graph. To make it correspond
+  // to the original WDL, we attempt to maintain the original line
+  // ordering.
+  //
+  // For example, in the workflow below:
+  // workflow foo {
+  //    call A
+  //    call B
+  //    call C
+  // }
+  // the block splitting algorithm could generate six permutions.
+  // For example:
+  //
+  //    1           2
+  //  [ call C ]  [ call A ]
+  //  [ call A ]  [ call B ]
+  //  [ call B ]  [ call C ]
+  //
+  // We choose option #2 because it resembles the original.
+  def splitGraph(graph: Graph, callsLoToHi: Vector[String]): (
+      Vector[GraphInputNode], // inputs
+      Vector[GraphInputNode], // missing inner inputs that propagate
+      Vector[Block],          // blocks
+      Vector[GraphOutputNode]
+  ) // outputs
+  = {
+    var rest: Set[GraphNode] = graph.nodes
+    var blocks               = Vector.empty[Block]
+
+    // separate out the inputs
+    val (inputBlock, innerInputs) = distinguishTopLevelInputs(graph.inputNodes.toSeq)
+    rest --= graph.inputNodes.toSet
+
+    // separate out the outputs
+    val outputBlock = graph.outputNodes.toVector
+    rest --= graph.outputNodes.toSet
+
+    if (graph.nodes.isEmpty)
+      return (inputBlock, innerInputs, Vector.empty, outputBlock)
+
+    // Create a separate block for each call. This maintains
+    // the sort order from the origial code.
+    //
+    for (callName <- callsLoToHi) {
+      findCallByName(callName, rest) match {
+        case None =>
+          // we already accounted for this call. Several
+          // calls can be in the same node. For example, a
+          // scatter can have many calls inside its subgraph.
+          ()
+        case Some(node) =>
+          assert(!rest.isEmpty)
+          rest = rest - node
+
+          // Build a vector where the callNode comes LAST. Choose
+          // the nodes from the ones that have not been picked yet.
+          val ancestors = deepAncestors(node).intersect(rest)
+          val nodes: Vector[GraphNode] =
+            (partialSortByDep(ancestors) :+ node)
+              .filter { x =>
+                !x.isInstanceOf[GraphInputNode]
+              }
+          val crnt = Block(nodes)
+          blocks :+= crnt
+          rest = rest -- nodes.toSet
+      }
+    }
+
+    val allBlocks =
+      if (rest.size > 0) {
+        // Add an additional block for anything not belonging to the calls
+        val lastBlock = partialSortByDep(rest)
+        blocks :+ Block(lastBlock)
+      } else {
+        blocks
+      }
+    allBlocks.foreach { b =>
+      b.validate()
+    }
+    (inputBlock, innerInputs, allBlocks, outputBlock)
+  }
+
+  // An easy to use method that takes the workflow source
+  def split(graph: Graph, wfSource: String): (
+      Vector[GraphInputNode], // inputs
+      Vector[GraphInputNode], // implicit inputs
+      Vector[Block],          // blocks
+      Vector[GraphOutputNode]
+  ) // outputs
+  = {
+    // sort from low to high according to the source lines.
+    val callsLoToHi: Vector[String] = ParseWomSourceFile(false).scanForCalls(graph, wfSource)
+    splitGraph(graph, callsLoToHi)
+  }
+
+  // A block of nodes that represents a call with no subexpressions. These
+  // can be compiled directly into a dx:workflow stage.
+  //
+  // For example, the WDL code:
+  // call add { input: a=x, b=y }
+  //
+  // Is represented by the graph:
+  // Block [
+  //   TaskCallInputExpressionNode(a, x, WomIntegerType, GraphNodeOutputPort(a))
+  //   TaskCallInputExpressionNode(b, y, WomIntegerType, GraphNodeOutputPort(b))
+  //   CommandCall(add, Set(a, b))
+  // ]
+  private def isSimpleCall(nodes: Seq[GraphNode], trivialExpressionsOnly: Boolean): Boolean = {
+    // find the call
+    val calls: Seq[CallNode] = nodes.collect {
+      case cNode: CallNode => cNode
+    }
+    if (calls.size != 1)
+      return false
+    val oneCall = calls.head
+
+    // All the other nodes have to be call inputs
+    //
+    // Some of the inputs may be missing, which is why we
+    // have the -subsetOf- call.
+    val rest = nodes.toSet - oneCall
+    //val callInputs = oneCall.upstream.toSet
+    //if (!rest.subsetOf(callInputs))
+    //return false
+
+    // All the call inputs have to be simple expressions, if the call is
+    // to be called "simple"
+    val retval = rest.forall {
+      case expr: AnonymousExpressionNode =>
+        if (trivialExpressionsOnly)
+          isTrivialExpression(expr.womType, expr.womExpression)
+        else
+          true
+
+      // These are ignored
+      case _: PortBasedGraphOutputNode =>
+        true
+      case _: GraphInputNode =>
+        true
+
+      case other =>
+        false
+    }
+    retval
+  }
+
+  private def getOneCall(graph: Graph): CallNode = {
+    val calls = graph.nodes.collect {
+      case node: CallNode => node
+    }
+    assert(calls.size == 1)
+    calls.head
+  }
+
+  // Deep search for all calls in a graph
+  def deepFindCalls(nodes: Seq[GraphNode]): Vector[CallNode] = {
+    nodes
+      .foldLeft(Vector.empty[CallNode]) {
+        case (accu: Vector[CallNode], call: CallNode) =>
+          accu :+ call
+        case (accu, ssc: ScatterNode) =>
+          accu ++ deepFindCalls(ssc.innerGraph.nodes.toVector)
+        case (accu, ifStmt: ConditionalNode) =>
+          accu ++ deepFindCalls(ifStmt.innerGraph.nodes.toVector)
+        case (accu, _) =>
+          accu
+      }
+      .toVector
+  }
+
+  // These are the kinds of blocks that are run by the workflow-fragment-runner.
+  //
+  // A block can have expressions, input ports, and output ports in the beginning.
+  // The block can be one of these types:
+  //
+  //   Purely expressions (no asynchronous calls at any nesting level).
+  //
+  //   Call
+  //      - with no subexpressions to evaluate
+  //      - with subexpressions requiring evaluation
+  //      - Fragment with expressions and one call
+  //
+  //   Conditional block
+  //      - with exactly one call
+  //      - a complex subblock
+  //
+  //   Scatter block
+  //      - with exactly one call
+  //      - with a complex subblock
+  //
+  //   Compound
+  //      contains multiple calls and/or dependencies
+  sealed trait Category {
+    val nodes: Vector[GraphNode]
+  }
+  case class AllExpressions(override val nodes: Vector[GraphNode])              extends Category
+  case class CallDirect(override val nodes: Vector[GraphNode], value: CallNode) extends Category
+  case class CallWithSubexpressions(override val nodes: Vector[GraphNode], value: CallNode)
+      extends Category
+  case class CallFragment(override val nodes: Vector[GraphNode], value: CallNode) extends Category
+  case class CondOneCall(
+      override val nodes: Vector[GraphNode],
+      value: ConditionalNode,
+      call: CallNode
+  ) extends Category
+  case class CondFullBlock(override val nodes: Vector[GraphNode], value: ConditionalNode)
+      extends Category
+  case class ScatterOneCall(
+      override val nodes: Vector[GraphNode],
+      value: ScatterNode,
+      call: CallNode
+  ) extends Category
+  case class ScatterFullBlock(override val nodes: Vector[GraphNode], value: ScatterNode)
+      extends Category
+
+  object Category {
+    def getInnerGraph(catg: Category): Graph = {
+      catg match {
+        case cond: CondFullBlock   => cond.value.innerGraph
+        case sct: ScatterFullBlock => sct.value.innerGraph
+        case other =>
+          throw new UnsupportedOperationException(
+            s"${other.getClass.toString} does not have an inner graph"
+          )
+      }
+    }
+    def toString(catg: Category): String = {
+      // convert Block$Cond to Cond
+      val fullClassName = catg.getClass.toString
+      val index         = fullClassName.lastIndexOf('$')
+      if (index == -1)
+        fullClassName
+      else
+        fullClassName.substring(index + 1)
+    }
+  }
+
+  def categorize(block: Block): Category = {
+    assert(!block.nodes.isEmpty)
+    val allButLast: Vector[GraphNode] = block.nodes.dropRight(1)
+    assert(deepFindCalls(allButLast).isEmpty)
+    val lastNode = block.nodes.last
+    lastNode match {
+      case _ if deepFindCalls(Seq(lastNode)).isEmpty =>
+        // The block comprises of expressions only
+        AllExpressions(allButLast :+ lastNode)
+
+      case callNode: CallNode =>
+        if (isSimpleCall(block.nodes, true))
+          CallDirect(allButLast, callNode)
+        else if (isSimpleCall(block.nodes.toSeq, false))
+          CallWithSubexpressions(allButLast, callNode)
+        else
+          CallFragment(allButLast, callNode)
+
+      case condNode: ConditionalNode =>
+        if (isSimpleCall(condNode.innerGraph.nodes.toSeq, false)) {
+          CondOneCall(allButLast, condNode, getOneCall(condNode.innerGraph))
+        } else {
+          CondFullBlock(allButLast, condNode)
+        }
+
+      case sctNode: ScatterNode =>
+        if (isSimpleCall(sctNode.innerGraph.nodes.toSeq, false)) {
+          ScatterOneCall(allButLast, sctNode, getOneCall(sctNode.innerGraph))
+        } else {
+          ScatterFullBlock(allButLast, sctNode)
         }
     }
+  }
 
-    // Is the call [callName] invoked in one of the nodes, or their
-    // inner graphs?
-    private def graphContainsCall(callName: String,
-                                  nodes: Set[GraphNode]) : Boolean = {
-        nodes.exists{
-            case callNode: CallNode =>
-                callNode.identifier.localName.value == callName
-            case cNode: ConditionalNode =>
-                graphContainsCall(callName, cNode.innerGraph.nodes)
-            case scNode: ScatterNode =>
-                graphContainsCall(callName, scNode.innerGraph.nodes)
-            case _ => false
-        }
+  def getSubBlock(path: Vector[Int], graph: Graph, callsLoToHi: Vector[String]): Block = {
+    assert(path.size >= 1)
+
+    val (_, _, blocks, _) = splitGraph(graph, callsLoToHi)
+    var subBlock          = blocks(path.head)
+    for (i <- path.tail) {
+      val catg               = categorize(subBlock)
+      val innerGraph         = Category.getInnerGraph(catg)
+      val (_, _, blocks2, _) = splitGraph(innerGraph, callsLoToHi)
+      subBlock = blocks2(i)
+    }
+    return subBlock
+  }
+
+  // Find all the inputs required for a block. For example,
+  // in the workflow:
+  //
+  // workflow optionals {
+  //   input {
+  //     Boolean flag
+  //   }
+  //   Int? rain = 13
+  //   if (flag) {
+  //     call opt_MaybeInt as mi3 { input: a=rain }
+  //   }
+  // }
+  //
+  // The conditional block:
+  //    if (flag) {
+  //     call opt_MaybeInt as mi3 { input: a=rain }
+  //    }
+  // requires "flag" and "rain".
+  //
+  // For each input also return whether is has a default. This makes it,
+  // de facto, optional.
+  //
+  def closure(block: Block): Map[String, (WomType, Boolean)] = {
+    // make a deep list of all the nodes inside the block
+    val allBlockNodes: Set[GraphNode] = block.nodes
+      .map {
+        case sctNode: ScatterNode =>
+          sctNode.innerGraph.allNodes + sctNode
+        case cndNode: ConditionalNode =>
+          cndNode.innerGraph.allNodes + cndNode
+        case node: GraphNode =>
+          Set(node)
+      }
+      .flatten
+      .toSet
+
+    // Examine an input port, and keep it only if it points outside the block.
+    def keepOnlyOutsideRefs(inPort: GraphNodePort.InputPort): Option[(String, WomType)] = {
+      if (allBlockNodes contains inPort.upstream.graphNode) None
+      else Some((inPort.name, inPort.womType))
     }
 
-    // Find the toplevel graph node that contains this call
-    def findCallByName(callName: String,
-                       nodes: Set[GraphNode]) : Option[GraphNode] = {
-        val gnode: Option[GraphNode] = nodes.find{
-            case callNode: CallNode =>
-                callNode.identifier.localName.value == callName
-            case cNode: ConditionalNode =>
-                graphContainsCall(callName, cNode.innerGraph.nodes)
-            case scNode: ScatterNode =>
-                graphContainsCall(callName, scNode.innerGraph.nodes)
-            case _ => false
-        }
-        gnode
+    // Examine only the outer input nodes, check that they
+    // originate in a node outside the block.
+    def getInputsToGraph(graph: Graph): Map[String, WomType] = {
+      graph.nodes.flatMap {
+        case ogin: OuterGraphInputNode =>
+          if (allBlockNodes contains ogin.linkToOuterGraphNode)
+            None
+          else
+            Some((ogin.identifier.localName.value, ogin.womType))
+        case _ => None
+      }.toMap
     }
 
-    private def pickTopNodes(nodes: Set[GraphNode]) = {
-        assert(nodes.size > 0)
-        nodes.flatMap{ node =>
-            val ancestors = node.upstreamAncestry
-            val others = nodes - node
-            if ((ancestors.intersect(others)).isEmpty) {
-                Some(node)
-            } else {
-                None
-            }
-        }
-    }
+    val allInputs: Map[String, WomType] = block.nodes.flatMap {
+      case scNode: ScatterNode =>
+        val scNodeInputs = scNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+        scNodeInputs ++ getInputsToGraph(scNode.innerGraph)
+      case cnNode: ConditionalNode =>
+        val cnInputs = cnNode.conditionExpression.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+        cnInputs ++ getInputsToGraph(cnNode.innerGraph)
+      case node: GraphNode =>
+        node.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+    }.toMap
 
-    // Sort a group of nodes according to dependencies. Note that this is a partial
-    // ordering only.
-    def partialSortByDep(nodes: Set[GraphNode]) : Vector[GraphNode] = {
-        var ordered = Vector.empty[GraphNode]
-        var rest : Set[GraphNode] = nodes
-
-        while (!rest.isEmpty) {
-            val tops = pickTopNodes(rest)
-            assert(!tops.isEmpty)
-            ordered = ordered ++ tops
-            rest = rest -- tops
-        }
-
-        assert(ordered.size == nodes.size)
-        ordered
-    }
-
-    private def deepAncestors(node: GraphNode) : Set[GraphNode] = {
-        node match {
-            case cndNode: ConditionalNode =>
-                cndNode.upstreamAncestry ++
-                cndNode.innerGraph.nodes.flatMap(deepAncestors(_))
-            case sctNode: ScatterNode =>
-                sctNode.upstreamAncestry ++
-                sctNode.innerGraph.nodes.flatMap(deepAncestors(_))
-            case ogin: OuterGraphInputNode =>
-                // follow the indirection, this is not by default
-                val sourceNode = ogin.linkToOuterGraphNode
-                sourceNode.upstreamAncestry + sourceNode
-            case _ =>
-                node.upstreamAncestry
-        }
-    }
-
-    // remove non local inputs, propagated from inner calls.
-    // In this workflow:
+    // make list of call arguments that have defaults.
+    // In the example below, it is "unpassed_arg_default".
+    // It has a default, so it can be omitted.
     //
     // workflow inner_wf {
-    //     input {}
     //     call foo
-    //     output {}
     // }
     //
     // task foo {
@@ -263,480 +647,109 @@ object Block {
     //     command {}
     //     output {}
     // }
-    // unpassed_arg_default becomes a inner_wf argument, called
-    // 'inner_wf.foo.unpassed_arg_default'.
     //
-    // As a result, we filter out any argument that has a dot it in.
-    private def distinguishTopLevelInputs(inputs : Seq[GraphInputNode]) :
-            (Vector[GraphInputNode], Vector[GraphInputNode]) = {
-        val (inner, topLevelInputs) = inputs.partition{ inNode =>
-            val name = inNode.identifier.localName.value
-            name contains '.'
+    val optionalInputs: Set[String] = block.nodes.flatMap {
+      case cNode: CallNode =>
+        val missingCallArgs  = cNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+        val callee: Callable = cNode.callable
+        missingCallArgs.flatMap {
+          case (name, womType) =>
+            val inputDef: InputDefinition = callee.inputs.find {
+              case iDef: InputDefinition => iDef.name == name
+            }.get
+            if (inputDef.optional) Some(name)
+            else None
         }
+      case _ => None
+    }.toSet
 
-        (topLevelInputs.toVector, inner.toVector)
+    allInputs.map {
+      case (name, womType) =>
+        val hasDefault = optionalInputs contains name
+        name -> (womType, hasDefault)
+    }.toMap
+  }
+
+  // Figure out all the outputs from a sequence of WDL statements.
+  //
+  // Note: The type outside a scatter/conditional block is *different* than the type in
+  // the block.  For example, 'Int x' declared inside a scatter, is
+  // 'Array[Int] x' outside the scatter.
+  //
+  def outputs(block: Block): Map[String, WomType] = {
+    val xtrnPorts: Vector[GraphNodePort.OutputPort] =
+      block.nodes.map {
+        case node: ExposedExpressionNode =>
+          node.outputPorts
+        case _: ExpressionNode =>
+          // an anonymous expression node, ignore it
+          Set.empty
+        case node =>
+          node.outputPorts
+      }.flatten
+
+    xtrnPorts.map { outputPort =>
+      // Is this really the fully qualified name?
+      val fqn     = outputPort.identifier.localName.value
+      val womType = outputPort.womType
+      fqn -> womType
+    }.toMap
+  }
+
+  // Does this output require evaluation? If so, we will need to create
+  // another applet for this.
+  def isSimpleOutput(outputNode: GraphOutputNode): Boolean = {
+    outputNode match {
+      case PortBasedGraphOutputNode(id, womType, sourcePort) =>
+        true
+      case expr: ExpressionBasedGraphOutputNode
+          if (Block.isTrivialExpression(expr.womType, expr.womExpression)) =>
+        true
+      case expr: ExpressionBasedGraphOutputNode =>
+        // An expression that requires evaluation
+        false
+      case other =>
+        throw new Exception(s"unhandled output class ${other}")
     }
+  }
 
-    // Split an entire workflow.
-    //
-    // Sort the graph into a linear set of blocks, according to
-    // dependencies.  Each block is itself sorted. The dependencies
-    // impose a partial ordering on the graph. To make it correspond
-    // to the original WDL, we attempt to maintain the original line
-    // ordering.
-    //
-    // For example, in the workflow below:
-    // workflow foo {
-    //    call A
-    //    call B
-    //    call C
-    // }
-    // the block splitting algorithm could generate six permutions.
-    // For example:
-    //
-    //    1           2
-    //  [ call C ]  [ call A ]
-    //  [ call A ]  [ call B ]
-    //  [ call B ]  [ call C ]
-    //
-    // We choose option #2 because it resembles the original.
-    def splitGraph(graph: Graph, callsLoToHi: Vector[String]):
-            (Vector[GraphInputNode], // inputs
-             Vector[GraphInputNode], // missing inner inputs that propagate
-             Vector[Block], // blocks
-             Vector[GraphOutputNode]) // outputs
-    = {
-        var rest : Set[GraphNode] = graph.nodes
-        var blocks = Vector.empty[Block]
+  // Figure out what variables from the environment we need to pass
+  // into the applet. In other words, the closure.
+  def outputClosure(outputNodes: Vector[GraphOutputNode]): Set[String] = {
+    outputNodes.foldLeft(Set.empty[String]) {
+      case (accu, PortBasedGraphOutputNode(id, womType, sourcePort)) =>
+        accu + sourcePort.name
+      case (accu, expr: ExpressionBasedGraphOutputNode) =>
+        accu ++ expr.inputPorts.map(_.name)
+      case other =>
+        throw new Exception(s"unhandled output ${other}")
 
-        // separate out the inputs
-        val (inputBlock, innerInputs) = distinguishTopLevelInputs(graph.inputNodes.toSeq)
-        rest --= graph.inputNodes.toSet
-
-        // separate out the outputs
-        val outputBlock = graph.outputNodes.toVector
-        rest --= graph.outputNodes.toSet
-
-        if (graph.nodes.isEmpty)
-            return (inputBlock, innerInputs, Vector.empty, outputBlock)
-
-        // Create a separate block for each call. This maintains
-        // the sort order from the origial code.
-        //
-        for (callName <- callsLoToHi) {
-            findCallByName(callName, rest) match {
-                case None =>
-                    // we already accounted for this call. Several
-                    // calls can be in the same node. For example, a
-                    // scatter can have many calls inside its subgraph.
-                    ()
-                case Some(node) =>
-                    assert(!rest.isEmpty)
-                    rest = rest - node
-
-                    // Build a vector where the callNode comes LAST. Choose
-                    // the nodes from the ones that have not been picked yet.
-                    val ancestors = deepAncestors(node).intersect(rest)
-                    val nodes: Vector[GraphNode] =
-                        (partialSortByDep(ancestors) :+ node)
-                            .filter{ x => !x.isInstanceOf[GraphInputNode] }
-                    val crnt = Block(nodes)
-                    blocks :+= crnt
-                    rest = rest -- nodes.toSet
-            }
-        }
-
-        val allBlocks =
-            if (rest.size > 0) {
-                // Add an additional block for anything not belonging to the calls
-                val lastBlock = partialSortByDep(rest)
-                blocks :+ Block(lastBlock)
-            } else {
-                blocks
-            }
-        allBlocks.foreach{ b => b.validate() }
-        (inputBlock, innerInputs, allBlocks, outputBlock)
     }
+  }
 
-
-    // An easy to use method that takes the workflow source
-    def split(graph: Graph, wfSource: String) :  (Vector[GraphInputNode],   // inputs
-                                                  Vector[GraphInputNode],   // implicit inputs
-                                                  Vector[Block], // blocks
-                                                  Vector[GraphOutputNode]) // outputs
-    = {
-        // sort from low to high according to the source lines.
-        val callsLoToHi : Vector[String] = ParseWomSourceFile(false).scanForCalls(graph, wfSource)
-        splitGraph(graph, callsLoToHi)
-    }
-
-    // A block of nodes that represents a call with no subexpressions. These
-    // can be compiled directly into a dx:workflow stage.
-    //
-    // For example, the WDL code:
-    // call add { input: a=x, b=y }
-    //
-    // Is represented by the graph:
-    // Block [
-    //   TaskCallInputExpressionNode(a, x, WomIntegerType, GraphNodeOutputPort(a))
-    //   TaskCallInputExpressionNode(b, y, WomIntegerType, GraphNodeOutputPort(b))
-    //   CommandCall(add, Set(a, b))
-    // ]
-    private def isSimpleCall(nodes: Seq[GraphNode],
-                             trivialExpressionsOnly : Boolean) : Boolean = {
-        // find the call
-        val calls : Seq[CallNode] = nodes.collect{
-            case cNode : CallNode => cNode
-        }
-        if (calls.size != 1)
-            return false
-        val oneCall = calls.head
-
-        // All the other nodes have to be call inputs
-        //
-        // Some of the inputs may be missing, which is why we
-        // have the -subsetOf- call.
-        val rest = nodes.toSet - oneCall
-        //val callInputs = oneCall.upstream.toSet
-        //if (!rest.subsetOf(callInputs))
-        //return false
-
-        // All the call inputs have to be simple expressions, if the call is
-        // to be called "simple"
-        val retval = rest.forall{
-            case expr: AnonymousExpressionNode =>
-                if (trivialExpressionsOnly)
-                    isTrivialExpression(expr.womType, expr.womExpression)
-                else
-                    true
-
-            // These are ignored
-            case _ : PortBasedGraphOutputNode =>
-                true
-            case _ : GraphInputNode =>
-                true
-
-            case other =>
-                false
-        }
-        retval
-    }
-
-
-    private def getOneCall(graph: Graph) : CallNode = {
-        val calls = graph.nodes.collect{
-            case node : CallNode => node
-        }
-        assert(calls.size == 1)
-        calls.head
-    }
-
-    // Deep search for all calls in a graph
-    def deepFindCalls(nodes: Seq[GraphNode]) : Vector[CallNode] = {
-        nodes.foldLeft(Vector.empty[CallNode]) {
-            case (accu: Vector[CallNode], call:CallNode) =>
-                accu :+ call
-            case (accu, ssc:ScatterNode) =>
-                accu ++ deepFindCalls(ssc.innerGraph.nodes.toVector)
-            case (accu, ifStmt:ConditionalNode) =>
-                accu ++ deepFindCalls(ifStmt.innerGraph.nodes.toVector)
-            case (accu, _) =>
-                accu
-        }.toVector
-    }
-
-    // These are the kinds of blocks that are run by the workflow-fragment-runner.
-    //
-    // A block can have expressions, input ports, and output ports in the beginning.
-    // The block can be one of these types:
-    //
-    //   Purely expressions (no asynchronous calls at any nesting level).
-    //
-    //   Call
-    //      - with no subexpressions to evaluate
-    //      - with subexpressions requiring evaluation
-    //      - Fragment with expressions and one call
-    //
-    //   Conditional block
-    //      - with exactly one call
-    //      - a complex subblock
-    //
-    //   Scatter block
-    //      - with exactly one call
-    //      - with a complex subblock
-    //
-    //   Compound
-    //      contains multiple calls and/or dependencies
-    sealed trait Category {
-        val nodes: Vector[GraphNode]
-    }
-    case class AllExpressions(override val nodes: Vector[GraphNode]) extends Category
-    case class CallDirect(override val nodes: Vector[GraphNode],
-                          value: CallNode) extends Category
-    case class CallWithSubexpressions(override val nodes: Vector[GraphNode],
-                                      value: CallNode) extends Category
-    case class CallFragment(override val nodes: Vector[GraphNode],
-                            value: CallNode) extends Category
-    case class CondOneCall(override val nodes: Vector[GraphNode],
-                           value: ConditionalNode,
-                           call: CallNode) extends Category
-    case class CondFullBlock(override val nodes: Vector[GraphNode],
-                             value: ConditionalNode) extends Category
-    case class ScatterOneCall(override val nodes: Vector[GraphNode],
-                              value: ScatterNode,
-                              call: CallNode) extends Category
-    case class ScatterFullBlock(override val nodes: Vector[GraphNode],
-                                value: ScatterNode) extends Category
-
-    object Category {
-        def getInnerGraph(catg: Category) : Graph = {
-            catg match {
-                case cond: CondFullBlock => cond.value.innerGraph
-                case sct: ScatterFullBlock => sct.value.innerGraph
-                case other =>
-                    throw new UnsupportedOperationException(
-                        s"${other.getClass.toString} does not have an inner graph")
-            }
-        }
-        def toString(catg: Category) : String = {
-            // convert Block$Cond to Cond
-            val fullClassName = catg.getClass.toString
-            val index = fullClassName.lastIndexOf('$')
-            if (index == -1)
-                fullClassName
-            else
-                fullClassName.substring(index + 1)
-        }
-    }
-
-    def categorize(block: Block) : Category = {
-        assert(!block.nodes.isEmpty)
-        val allButLast : Vector[GraphNode] = block.nodes.dropRight(1)
-        assert(deepFindCalls(allButLast).isEmpty)
-        val lastNode = block.nodes.last
-        lastNode match {
-            case _ if deepFindCalls(Seq(lastNode)).isEmpty =>
-                // The block comprises of expressions only
-                AllExpressions(allButLast :+ lastNode)
-
-            case callNode: CallNode =>
-                if (isSimpleCall(block.nodes, true))
-                    CallDirect(allButLast, callNode)
-                else if (isSimpleCall(block.nodes.toSeq, false))
-                    CallWithSubexpressions(allButLast, callNode)
-                else
-                    CallFragment(allButLast, callNode)
-
-            case condNode: ConditionalNode =>
-                if (isSimpleCall(condNode.innerGraph.nodes.toSeq, false)) {
-                    CondOneCall(allButLast, condNode, getOneCall(condNode.innerGraph))
-                } else {
-                    CondFullBlock(allButLast, condNode)
-                }
-
-            case sctNode: ScatterNode =>
-                if (isSimpleCall(sctNode.innerGraph.nodes.toSeq, false)) {
-                    ScatterOneCall(allButLast, sctNode, getOneCall(sctNode.innerGraph))
-                } else {
-                    ScatterFullBlock(allButLast, sctNode)
-                }
-        }
-    }
-
-    def getSubBlock(path: Vector[Int],
-                    graph: Graph,
-                    callsLoToHi: Vector[String]) : Block = {
-        assert(path.size >= 1)
-
-        val (_, _, blocks, _) = splitGraph(graph, callsLoToHi)
-        var subBlock = blocks(path.head)
-        for (i <- path.tail) {
-            val catg = categorize(subBlock)
-            val innerGraph = Category.getInnerGraph(catg)
-            val (_, _, blocks2, _) = splitGraph(innerGraph, callsLoToHi)
-            subBlock = blocks2(i)
-        }
-        return subBlock
-    }
-
-    // Find all the inputs required for a block. For example,
-    // in the workflow:
-    //
-    // workflow optionals {
-    //   input {
-    //     Boolean flag
-    //   }
-    //   Int? rain = 13
-    //   if (flag) {
-    //     call opt_MaybeInt as mi3 { input: a=rain }
-    //   }
-    // }
-    //
-    // The conditional block:
-    //    if (flag) {
-    //     call opt_MaybeInt as mi3 { input: a=rain }
-    //    }
-    // requires "flag" and "rain".
-    //
-    // For each input also return whether is has a default. This makes it,
-    // de facto, optional.
-    //
-    def closure(block: Block) : Map[String, (WomType, Boolean)] = {
-        // make a deep list of all the nodes inside the block
-        val allBlockNodes : Set[GraphNode] = block.nodes.map{
-            case sctNode: ScatterNode =>
-                sctNode.innerGraph.allNodes + sctNode
-            case cndNode: ConditionalNode =>
-                cndNode.innerGraph.allNodes + cndNode
-            case node : GraphNode =>
-                Set(node)
-        }.flatten.toSet
-
-        // Examine an input port, and keep it only if it points outside the block.
-        def keepOnlyOutsideRefs(inPort : GraphNodePort.InputPort) : Option[(String, WomType)] = {
-            if (allBlockNodes contains inPort.upstream.graphNode) None
-            else Some((inPort.name, inPort.womType))
-        }
-
-        // Examine only the outer input nodes, check that they
-        // originate in a node outside the block.
-        def getInputsToGraph(graph: Graph) : Map[String, WomType] = {
-            graph.nodes.flatMap {
-                case ogin: OuterGraphInputNode =>
-                    if (allBlockNodes contains ogin.linkToOuterGraphNode)
-                        None
-                    else
-                        Some((ogin.identifier.localName.value, ogin.womType))
-                case _ => None
-            }.toMap
-        }
-
-        val allInputs : Map[String, WomType] = block.nodes.flatMap{
-            case scNode : ScatterNode =>
-                val scNodeInputs = scNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
-                scNodeInputs ++ getInputsToGraph(scNode.innerGraph)
-            case cnNode : ConditionalNode =>
-                val cnInputs = cnNode.conditionExpression.inputPorts.flatMap(keepOnlyOutsideRefs(_))
-                cnInputs ++ getInputsToGraph(cnNode.innerGraph)
-            case node : GraphNode =>
-                node.inputPorts.flatMap(keepOnlyOutsideRefs(_))
-        }.toMap
-
-        // make list of call arguments that have defaults.
-        // In the example below, it is "unpassed_arg_default".
-        // It has a default, so it can be omitted.
-        //
-        // workflow inner_wf {
-        //     call foo
-        // }
-        //
-        // task foo {
-        //     input {
-        //         Boolean unpassed_arg_default = true
-        //     }
-        //     command {}
-        //     output {}
-        // }
-        //
-        val optionalInputs: Set[String] = block.nodes.flatMap{
-            case cNode : CallNode =>
-                val missingCallArgs = cNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
-                val callee: Callable = cNode.callable
-                missingCallArgs.flatMap{
-                    case (name, womType) =>
-                        val inputDef: InputDefinition = callee.inputs.find{
-                            case iDef : InputDefinition => iDef.name == name
-                        }.get
-                        if (inputDef.optional) Some(name)
-                        else None
-                }
-            case _ => None
-        }.toSet
-
-        allInputs.map {
-            case (name, womType) =>
-                val hasDefault = optionalInputs contains name
-                name -> (womType, hasDefault)
-        }.toMap
-    }
-
-    // Figure out all the outputs from a sequence of WDL statements.
-    //
-    // Note: The type outside a scatter/conditional block is *different* than the type in
-    // the block.  For example, 'Int x' declared inside a scatter, is
-    // 'Array[Int] x' outside the scatter.
-    //
-    def outputs(block: Block) : Map[String, WomType] = {
-        val xtrnPorts : Vector[GraphNodePort.OutputPort] =
-            block.nodes.map {
-                case node : ExposedExpressionNode =>
-                    node.outputPorts
-                case _ : ExpressionNode =>
-                    // an anonymous expression node, ignore it
-                    Set.empty
-                case node =>
-                    node.outputPorts
-            }.flatten
-
-        xtrnPorts.map{ outputPort =>
-            // Is this really the fully qualified name?
-            val fqn = outputPort.identifier.localName.value
-            val womType = outputPort.womType
-            fqn -> womType
-        }.toMap
-    }
-
-    // Does this output require evaluation? If so, we will need to create
-    // another applet for this.
-    def isSimpleOutput(outputNode: GraphOutputNode) : Boolean = {
-        outputNode match {
-            case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-                true
-            case expr :ExpressionBasedGraphOutputNode if (Block.isTrivialExpression(expr.womType, expr.womExpression)) =>
-                true
-            case expr :ExpressionBasedGraphOutputNode =>
-                // An expression that requires evaluation
-                false
-            case other =>
-                throw new Exception(s"unhandled output class ${other}")
-        }
-    }
-
-    // Figure out what variables from the environment we need to pass
-    // into the applet. In other words, the closure.
-    def outputClosure(outputNodes : Vector[GraphOutputNode]) : Set[String] = {
-        outputNodes.foldLeft(Set.empty[String]) {
-            case (accu, PortBasedGraphOutputNode(id, womType, sourcePort)) =>
-                accu + sourcePort.name
-            case (accu, expr : ExpressionBasedGraphOutputNode) =>
-                accu ++ expr.inputPorts.map(_.name)
-            case other =>
-                throw new Exception(s"unhandled output ${other}")
-
-        }
-    }
-
-    // is an output used directly as an input? For example, in the
-    // small workflow below, 'lane' is used in such a manner.
-    //
-    // This makes a difference, because in locked dx:workflows, it is
-    // not possible to access a workflow input directly from a workflow
-    // output. It is only allowed to access a stage input/output.
-    //
-    // workflow inner {
-    //   input {
-    //      String lane
-    //   }
-    //   output {
-    //      String blah = lane
-    //   }
-    // }
-    def inputsUsedAsOutputs( inputNodes : Vector[GraphInputNode],
-                             outputNodes : Vector[GraphOutputNode] ) : Set[String] = {
-        // Figure out all the variables needed to calculate the outputs
-        val outputs : Set[String] = outputClosure(outputNodes)
-        val inputs : Set[String] = inputNodes.map(iNode => iNode.identifier.localName.value).toSet
-        //System.out.println(s"inputsUsedAsOutputs: ${outputs} ${inputs}")
-        inputs.intersect(outputs)
-    }
+  // is an output used directly as an input? For example, in the
+  // small workflow below, 'lane' is used in such a manner.
+  //
+  // This makes a difference, because in locked dx:workflows, it is
+  // not possible to access a workflow input directly from a workflow
+  // output. It is only allowed to access a stage input/output.
+  //
+  // workflow inner {
+  //   input {
+  //      String lane
+  //   }
+  //   output {
+  //      String blah = lane
+  //   }
+  // }
+  def inputsUsedAsOutputs(
+      inputNodes: Vector[GraphInputNode],
+      outputNodes: Vector[GraphOutputNode]
+  ): Set[String] = {
+    // Figure out all the variables needed to calculate the outputs
+    val outputs: Set[String] = outputClosure(outputNodes)
+    val inputs: Set[String]  = inputNodes.map(iNode => iNode.identifier.localName.value).toSet
+    //System.out.println(s"inputsUsedAsOutputs: ${outputs} ${inputs}")
+    inputs.intersect(outputs)
+  }
 }

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -173,7 +173,10 @@ object Block {
 
   // Is the call [callName] invoked in one of the nodes, or their
   // inner graphs?
-  private def graphContainsCall(callName: String, nodes: Set[GraphNode]): Boolean = {
+  private def graphContainsCall(
+      callName: String,
+      nodes: Set[GraphNode]
+  ): Boolean = {
     nodes.exists {
       case callNode: CallNode =>
         callNode.identifier.localName.value == callName
@@ -186,7 +189,10 @@ object Block {
   }
 
   // Find the toplevel graph node that contains this call
-  def findCallByName(callName: String, nodes: Set[GraphNode]): Option[GraphNode] = {
+  def findCallByName(
+      callName: String,
+      nodes: Set[GraphNode]
+  ): Option[GraphNode] = {
     val gnode: Option[GraphNode] = nodes.find {
       case callNode: CallNode =>
         callNode.identifier.localName.value == callName
@@ -311,7 +317,9 @@ object Block {
     var blocks = Vector.empty[Block]
 
     // separate out the inputs
-    val (inputBlock, innerInputs) = distinguishTopLevelInputs(graph.inputNodes.toSeq)
+    val (inputBlock, innerInputs) = distinguishTopLevelInputs(
+      graph.inputNodes.toSeq
+    )
     rest --= graph.inputNodes.toSet
 
     // separate out the outputs
@@ -372,7 +380,8 @@ object Block {
   ) // outputs
   = {
     // sort from low to high according to the source lines.
-    val callsLoToHi: Vector[String] = ParseWomSourceFile(false).scanForCalls(graph, wfSource)
+    val callsLoToHi: Vector[String] =
+      ParseWomSourceFile(false).scanForCalls(graph, wfSource)
     splitGraph(graph, callsLoToHi)
   }
 
@@ -388,7 +397,10 @@ object Block {
   //   TaskCallInputExpressionNode(b, y, WomIntegerType, GraphNodeOutputPort(b))
   //   CommandCall(add, Set(a, b))
   // ]
-  private def isSimpleCall(nodes: Seq[GraphNode], trivialExpressionsOnly: Boolean): Boolean = {
+  private def isSimpleCall(
+      nodes: Seq[GraphNode],
+      trivialExpressionsOnly: Boolean
+  ): Boolean = {
     // find the call
     val calls: Seq[CallNode] = nodes.collect {
       case cNode: CallNode => cNode
@@ -478,23 +490,32 @@ object Block {
   }
   case class AllExpressions(override val nodes: Vector[GraphNode]) extends Category
   case class CallDirect(override val nodes: Vector[GraphNode], value: CallNode) extends Category
-  case class CallWithSubexpressions(override val nodes: Vector[GraphNode], value: CallNode)
-      extends Category
-  case class CallFragment(override val nodes: Vector[GraphNode], value: CallNode) extends Category
+  case class CallWithSubexpressions(
+      override val nodes: Vector[GraphNode],
+      value: CallNode
+  ) extends Category
+  case class CallFragment(
+      override val nodes: Vector[GraphNode],
+      value: CallNode
+  ) extends Category
   case class CondOneCall(
       override val nodes: Vector[GraphNode],
       value: ConditionalNode,
       call: CallNode
   ) extends Category
-  case class CondFullBlock(override val nodes: Vector[GraphNode], value: ConditionalNode)
-      extends Category
+  case class CondFullBlock(
+      override val nodes: Vector[GraphNode],
+      value: ConditionalNode
+  ) extends Category
   case class ScatterOneCall(
       override val nodes: Vector[GraphNode],
       value: ScatterNode,
       call: CallNode
   ) extends Category
-  case class ScatterFullBlock(override val nodes: Vector[GraphNode], value: ScatterNode)
-      extends Category
+  case class ScatterFullBlock(
+      override val nodes: Vector[GraphNode],
+      value: ScatterNode
+  ) extends Category
 
   object Category {
     def getInnerGraph(catg: Category): Graph = {
@@ -552,7 +573,11 @@ object Block {
     }
   }
 
-  def getSubBlock(path: Vector[Int], graph: Graph, callsLoToHi: Vector[String]): Block = {
+  def getSubBlock(
+      path: Vector[Int],
+      graph: Graph,
+      callsLoToHi: Vector[String]
+  ): Block = {
     assert(path.size >= 1)
 
     val (_, _, blocks, _) = splitGraph(graph, callsLoToHi)
@@ -603,7 +628,9 @@ object Block {
       .toSet
 
     // Examine an input port, and keep it only if it points outside the block.
-    def keepOnlyOutsideRefs(inPort: GraphNodePort.InputPort): Option[(String, WomType)] = {
+    def keepOnlyOutsideRefs(
+        inPort: GraphNodePort.InputPort
+    ): Option[(String, WomType)] = {
       if (allBlockNodes contains inPort.upstream.graphNode) None
       else Some((inPort.name, inPort.womType))
     }
@@ -626,7 +653,8 @@ object Block {
         val scNodeInputs = scNode.inputPorts.flatMap(keepOnlyOutsideRefs(_))
         scNodeInputs ++ getInputsToGraph(scNode.innerGraph)
       case cnNode: ConditionalNode =>
-        val cnInputs = cnNode.conditionExpression.inputPorts.flatMap(keepOnlyOutsideRefs(_))
+        val cnInputs =
+          cnNode.conditionExpression.inputPorts.flatMap(keepOnlyOutsideRefs(_))
         cnInputs ++ getInputsToGraph(cnNode.innerGraph)
       case node: GraphNode =>
         node.inputPorts.flatMap(keepOnlyOutsideRefs(_))
@@ -748,7 +776,8 @@ object Block {
   ): Set[String] = {
     // Figure out all the variables needed to calculate the outputs
     val outputs: Set[String] = outputClosure(outputNodes)
-    val inputs: Set[String] = inputNodes.map(iNode => iNode.identifier.localName.value).toSet
+    val inputs: Set[String] =
+      inputNodes.map(iNode => iNode.identifier.localName.value).toSet
     //System.out.println(s"inputsUsedAsOutputs: ${outputs} ${inputs}")
     inputs.intersect(outputs)
   }

--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -47,7 +47,7 @@ case class DxPathFunctions(
     */
   override def relativeToHostCallRoot(path: String): String =
     throw new AppInternalException(
-      "relativeToHostCallRoot: not implemented in DxIoFunctions"
+        "relativeToHostCallRoot: not implemented in DxIoFunctions"
     )
 
   /**
@@ -135,7 +135,7 @@ case class DxIoFunctions(
         Future(WomSingleFile(localPath))
       case fdx: FurlDx =>
         throw new AppInternalException(
-          s"writeFile: not implemented in DxIoFunctions for cloud files (${fdx})"
+            s"writeFile: not implemented in DxIoFunctions for cloud files (${fdx})"
         )
     }
   }
@@ -146,7 +146,7 @@ case class DxIoFunctions(
     */
   override def createTemporaryDirectory(name: Option[String]): Future[String] =
     throw new AppInternalException(
-      "createTemporaryDirectory: not implemented in DxIoFunctions"
+        "createTemporaryDirectory: not implemented in DxIoFunctions"
     )
 
   /**
@@ -197,7 +197,7 @@ case class DxIoFunctions(
       dirPath: String
   ): Future[Seq[String]] =
     throw new AppInternalException(
-      "listAllFilesUnderDirectory: not implemented in DxIoFunctions"
+        "listAllFilesUnderDirectory: not implemented in DxIoFunctions"
     )
 
   /**
@@ -207,7 +207,7 @@ case class DxIoFunctions(
       path: String
   )(visited: Vector[String] = Vector.empty): Future[Iterator[IoElement]] =
     throw new AppInternalException(
-      "listDirectory: not implemented in DxIoFunctions"
+        "listDirectory: not implemented in DxIoFunctions"
     )
 
   /**
@@ -220,7 +220,7 @@ case class DxIoFunctions(
         Future(p.toFile.isDirectory)
       case fdx: FurlDx =>
         throw new AppInternalException(
-          s"isDirectory: cannot be applied to non local file (${path})"
+            s"isDirectory: cannot be applied to non local file (${path})"
         )
     }
   }

--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -11,208 +11,224 @@ import wom.values._
 import dxWDL.base.{AppInternalException, Utils}
 import dxWDL.dx.{DxFileDescribe, DxFile, DxUtils}
 
-case class DxPathFunctions(fileInfoDir : Map[String, (DxFile, DxFileDescribe)],
-                           config: DxPathConfig,
-                           runtimeDebugLevel: Int) extends PathFunctionSet {
+case class DxPathFunctions(
+    fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
+    config: DxPathConfig,
+    runtimeDebugLevel: Int
+) extends PathFunctionSet {
 
-    /**
-      * Similar to java.nio.Path.resolveSibling with
-      * of == a string representation of a java.nio.Path
-      */
-    override def sibling(of: String, other: String): String = ???
+  /**
+    * Similar to java.nio.Path.resolveSibling with
+    * of == a string representation of a java.nio.Path
+    */
+  override def sibling(of: String, other: String): String = ???
 
-    /**
-      * Similar to java.nio.Path.isAbsolute
-      */
-    override def isAbsolute(path: String): Boolean = {
-        Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                p.isAbsolute
-            case fdx : FurlDx =>
-                false
+  /**
+    * Similar to java.nio.Path.isAbsolute
+    */
+  override def isAbsolute(path: String): Boolean = {
+    Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        p.isAbsolute
+      case fdx: FurlDx =>
+        false
+    }
+  }
+
+  /**
+    * Similar to sibling only if "of" IS an absolute path and "other" IS NOT an absolute path, otherwise return other
+    */
+  override def absoluteSibling(of: String, other: String): String =
+    if (isAbsolute(of) && !isAbsolute(other)) sibling(of, other) else other
+
+  /**
+    * If path is relative, prefix it with the _host_ call root.
+    */
+  override def relativeToHostCallRoot(path: String): String =
+    throw new AppInternalException("relativeToHostCallRoot: not implemented in DxIoFunctions")
+
+  /**
+    * Similar to java.nio.Path.getFileName
+    */
+  override def name(path: String): String = {
+    Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        p.getFileName.toString
+      case fdx: FurlDx =>
+        fileInfoDir.get(fdx.dxFile.id) match {
+          case None =>
+            // perform an API call to get the file name
+            fdx.dxFile.describe().name
+          case Some((_, desc)) =>
+            desc.name
         }
     }
+  }
 
-    /**
-      * Similar to sibling only if "of" IS an absolute path and "other" IS NOT an absolute path, otherwise return other
-      */
-    override def absoluteSibling(of: String, other: String): String =
-        if (isAbsolute(of) && !isAbsolute(other)) sibling(of, other) else other
+  /**
+    * Path to stdout
+    */
+  override def stdout: String = config.stdout.toString
 
-    /**
-      * If path is relative, prefix it with the _host_ call root.
-      */
-    override def relativeToHostCallRoot(path: String): String =
-        throw new AppInternalException("relativeToHostCallRoot: not implemented in DxIoFunctions")
-
-    /**
-      * Similar to java.nio.Path.getFileName
-      */
-    override def name(path: String): String = {
-        Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                p.getFileName.toString
-            case fdx : FurlDx =>
-                fileInfoDir.get(fdx.dxFile.id) match {
-                    case None =>
-                        // perform an API call to get the file name
-                        fdx.dxFile.describe().name
-                    case Some((_,desc)) =>
-                        desc.name
-                }
-        }
-    }
-
-    /**
-      * Path to stdout
-      */
-    override def stdout: String = config.stdout.toString
-
-    /**
-      * Path to stderr
-      */
-    override def stderr: String = config.stderr.toString
+  /**
+    * Path to stderr
+    */
+  override def stderr: String = config.stderr.toString
 }
 
-case class DxIoFunctions(fileInfoDir : Map[String, (DxFile, DxFileDescribe)],
-                         config: DxPathConfig,
-                         runtimeDebugLevel: Int) extends IoFunctionSet {
-    private val verbose = runtimeDebugLevel >= 1
-    override def pathFunctions = new DxPathFunctions(fileInfoDir, config, runtimeDebugLevel)
+case class DxIoFunctions(
+    fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
+    config: DxPathConfig,
+    runtimeDebugLevel: Int
+) extends IoFunctionSet {
+  private val verbose        = runtimeDebugLevel >= 1
+  override def pathFunctions = new DxPathFunctions(fileInfoDir, config, runtimeDebugLevel)
 
-    // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
-    /**
-      * Read the content of a file
-      * @param path path of the file to read from
-      * @param maxBytes maximum number of bytes that can be read
-      * @param failOnOverflow if true, the Future will fail if the files has more than maxBytes
-      * @return the content of the file as a String
-      */
-    override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean): Future[String] = {
-        val content = Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                if (Files.exists(p)) {
-                    Utils.readFileContent(p)
-                } else {
-                    // stdout and stderr are "defined" as empty, even
-                    // if they have not been created.
-                    if (p == config.stdout || p == config.stderr)
-                        ""
-                    else
-                        throw new Exception(s"File ${p} does not exist")
-                }
-            case fdx : FurlDx =>
-                DxUtils.downloadString(fdx.dxFile, verbose)
+  // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
+  /**
+    * Read the content of a file
+    * @param path path of the file to read from
+    * @param maxBytes maximum number of bytes that can be read
+    * @param failOnOverflow if true, the Future will fail if the files has more than maxBytes
+    * @return the content of the file as a String
+    */
+  override def readFile(
+      path: String,
+      maxBytes: Option[Int],
+      failOnOverflow: Boolean
+  ): Future[String] = {
+    val content = Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        if (Files.exists(p)) {
+          Utils.readFileContent(p)
+        } else {
+          // stdout and stderr are "defined" as empty, even
+          // if they have not been created.
+          if (p == config.stdout || p == config.stderr)
+            ""
+          else
+            throw new Exception(s"File ${p} does not exist")
         }
-        Future(content)
+      case fdx: FurlDx =>
+        DxUtils.downloadString(fdx.dxFile, verbose)
     }
+    Future(content)
+  }
 
-    /**
-      * Write "content" to the specified "path" location
-      */
-    override def writeFile(path: String, content: String): Future[WomSingleFile] = {
-        Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                Utils.writeFileContent(p, content)
-                Future(WomSingleFile(localPath))
-            case fdx : FurlDx =>
-                throw new AppInternalException(s"writeFile: not implemented in DxIoFunctions for cloud files (${fdx})")
+  /**
+    * Write "content" to the specified "path" location
+    */
+  override def writeFile(path: String, content: String): Future[WomSingleFile] = {
+    Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        Utils.writeFileContent(p, content)
+        Future(WomSingleFile(localPath))
+      case fdx: FurlDx =>
+        throw new AppInternalException(
+          s"writeFile: not implemented in DxIoFunctions for cloud files (${fdx})"
+        )
+    }
+  }
+
+  /**
+    * Creates a temporary directory. This must be in a place accessible to the backend.
+    * In a world where then backend is not known at submission time this will not be sufficient.
+    */
+  override def createTemporaryDirectory(name: Option[String]): Future[String] =
+    throw new AppInternalException("createTemporaryDirectory: not implemented in DxIoFunctions")
+
+  /**
+    * Copy pathFrom to targetName
+    * @return destination as a WomSingleFile
+    */
+  override def copyFile(source: String, destination: String): Future[WomSingleFile] =
+    throw new AppInternalException("copyFile: not implemented in DxIoFunctions")
+
+  /**
+    * Glob files and directories using the provided pattern.
+    * @return the list of globbed paths
+    */
+  override def glob(pattern: String): Future[Seq[String]] = {
+    Utils.appletLog(config.verbose, s"glob(${pattern})")
+    val baseDir = config.homeDir
+    val matcher: PathMatcher = FileSystems
+      .getDefault()
+      .getPathMatcher(s"glob:${baseDir.toString}/${pattern}")
+    val retval =
+      if (!Files.exists(baseDir)) {
+        Seq.empty[String]
+      } else {
+        val files = Files
+          .walk(baseDir)
+          .iterator()
+          .asScala
+          .filter(Files.isRegularFile(_))
+          .filter(matcher.matches(_))
+          .map(_.toString)
+          .toSeq
+        files.sorted
+      }
+    Utils.appletLog(config.verbose, s"""glob results=${retval.mkString("\n")}""")
+    Future(retval)
+  }
+
+  /**
+    * Recursively list all files (and only files, not directories) under "dirPath"
+    * dirPath MUST BE a directory
+    * @return The list of all files under "dirPath"
+    */
+  override def listAllFilesUnderDirectory(dirPath: String): Future[Seq[String]] =
+    throw new AppInternalException("listAllFilesUnderDirectory: not implemented in DxIoFunctions")
+
+  /**
+    * List entries in a directory non recursively. Includes directories
+    */
+  override def listDirectory(
+      path: String
+  )(visited: Vector[String] = Vector.empty): Future[Iterator[IoElement]] =
+    throw new AppInternalException("listDirectory: not implemented in DxIoFunctions")
+
+  /**
+    * Return true if path points to a directory, false otherwise
+    */
+  override def isDirectory(path: String): Future[Boolean] = {
+    Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        Future(p.toFile.isDirectory)
+      case fdx: FurlDx =>
+        throw new AppInternalException(
+          s"isDirectory: cannot be applied to non local file (${path})"
+        )
+    }
+  }
+
+  /**
+    * Return the size of the file located at "path"
+    */
+  override def size(path: String): Future[Long] = {
+    Furl.parse(path) match {
+      case FurlLocal(localPath) =>
+        val p = Paths.get(localPath)
+        Future(p.toFile.length)
+      case fdx: FurlDx =>
+        val ssize: Long = pathFunctions.fileInfoDir.get(fdx.dxFile.id) match {
+          case None =>
+            // perform an API call to get the size
+            fdx.dxFile.describe().size
+          case Some((_, desc)) =>
+            desc.size
         }
+        Future(ssize)
     }
+  }
 
-
-    /**
-      * Creates a temporary directory. This must be in a place accessible to the backend.
-      * In a world where then backend is not known at submission time this will not be sufficient.
-      */
-    override def createTemporaryDirectory(name: Option[String]): Future[String] =
-        throw new AppInternalException("createTemporaryDirectory: not implemented in DxIoFunctions")
-
-    /**
-      * Copy pathFrom to targetName
-      * @return destination as a WomSingleFile
-      */
-    override def copyFile(source: String, destination: String): Future[WomSingleFile] =
-        throw new AppInternalException("copyFile: not implemented in DxIoFunctions")
-
-    /**
-      * Glob files and directories using the provided pattern.
-      * @return the list of globbed paths
-      */
-    override def glob(pattern: String): Future[Seq[String]] = {
-        Utils.appletLog(config.verbose, s"glob(${pattern})")
-        val baseDir = config.homeDir
-        val matcher:PathMatcher = FileSystems.getDefault()
-            .getPathMatcher(s"glob:${baseDir.toString}/${pattern}")
-        val retval =
-            if (!Files.exists(baseDir)) {
-                Seq.empty[String]
-            } else {
-                val files = Files.walk(baseDir).iterator().asScala
-                    .filter(Files.isRegularFile(_))
-                    .filter(matcher.matches(_))
-                    .map(_.toString)
-                    .toSeq
-                files.sorted
-            }
-        Utils.appletLog(config.verbose, s"""glob results=${retval.mkString("\n")}""")
-        Future(retval)
-    }
-
-    /**
-      * Recursively list all files (and only files, not directories) under "dirPath"
-      * dirPath MUST BE a directory
-      * @return The list of all files under "dirPath"
-      */
-    override def listAllFilesUnderDirectory(dirPath: String): Future[Seq[String]] =
-        throw new AppInternalException("listAllFilesUnderDirectory: not implemented in DxIoFunctions")
-
-    /**
-      * List entries in a directory non recursively. Includes directories
-      */
-    override def listDirectory(path: String)(visited: Vector[String] = Vector.empty)
-            : Future[Iterator[IoElement]] =
-        throw new AppInternalException("listDirectory: not implemented in DxIoFunctions")
-
-    /**
-      * Return true if path points to a directory, false otherwise
-      */
-    override def isDirectory(path: String): Future[Boolean] = {
-        Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                Future(p.toFile.isDirectory)
-            case fdx : FurlDx =>
-                throw new AppInternalException(s"isDirectory: cannot be applied to non local file (${path})")
-        }
-    }
-
-    /**
-      * Return the size of the file located at "path"
-      */
-    override def size(path: String): Future[Long] = {
-        Furl.parse(path) match {
-            case FurlLocal(localPath) =>
-                val p = Paths.get(localPath)
-                Future(p.toFile.length)
-            case fdx : FurlDx =>
-                val ssize : Long = pathFunctions.fileInfoDir.get(fdx.dxFile.id) match {
-                    case None =>
-                        // perform an API call to get the size
-                        fdx.dxFile.describe().size
-                    case Some((_, desc)) =>
-                        desc.size
-                }
-                Future(ssize)
-        }
-    }
-
-    /**
-      * To map/flatMap over IO results
-      */
-    override def ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+  /**
+    * To map/flatMap over IO results
+    */
+  override def ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 }

--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -46,7 +46,9 @@ case class DxPathFunctions(
     * If path is relative, prefix it with the _host_ call root.
     */
   override def relativeToHostCallRoot(path: String): String =
-    throw new AppInternalException("relativeToHostCallRoot: not implemented in DxIoFunctions")
+    throw new AppInternalException(
+      "relativeToHostCallRoot: not implemented in DxIoFunctions"
+    )
 
   /**
     * Similar to java.nio.Path.getFileName
@@ -84,7 +86,8 @@ case class DxIoFunctions(
     runtimeDebugLevel: Int
 ) extends IoFunctionSet {
   private val verbose = runtimeDebugLevel >= 1
-  override def pathFunctions = new DxPathFunctions(fileInfoDir, config, runtimeDebugLevel)
+  override def pathFunctions =
+    new DxPathFunctions(fileInfoDir, config, runtimeDebugLevel)
 
   // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
   /**
@@ -121,7 +124,10 @@ case class DxIoFunctions(
   /**
     * Write "content" to the specified "path" location
     */
-  override def writeFile(path: String, content: String): Future[WomSingleFile] = {
+  override def writeFile(
+      path: String,
+      content: String
+  ): Future[WomSingleFile] = {
     Furl.parse(path) match {
       case FurlLocal(localPath) =>
         val p = Paths.get(localPath)
@@ -139,13 +145,18 @@ case class DxIoFunctions(
     * In a world where then backend is not known at submission time this will not be sufficient.
     */
   override def createTemporaryDirectory(name: Option[String]): Future[String] =
-    throw new AppInternalException("createTemporaryDirectory: not implemented in DxIoFunctions")
+    throw new AppInternalException(
+      "createTemporaryDirectory: not implemented in DxIoFunctions"
+    )
 
   /**
     * Copy pathFrom to targetName
     * @return destination as a WomSingleFile
     */
-  override def copyFile(source: String, destination: String): Future[WomSingleFile] =
+  override def copyFile(
+      source: String,
+      destination: String
+  ): Future[WomSingleFile] =
     throw new AppInternalException("copyFile: not implemented in DxIoFunctions")
 
   /**
@@ -172,7 +183,8 @@ case class DxIoFunctions(
           .toSeq
         files.sorted
       }
-    Utils.appletLog(config.verbose, s"""glob results=${retval.mkString("\n")}""")
+    Utils.appletLog(config.verbose, s"""glob results=${retval
+      .mkString("\n")}""")
     Future(retval)
   }
 
@@ -181,8 +193,12 @@ case class DxIoFunctions(
     * dirPath MUST BE a directory
     * @return The list of all files under "dirPath"
     */
-  override def listAllFilesUnderDirectory(dirPath: String): Future[Seq[String]] =
-    throw new AppInternalException("listAllFilesUnderDirectory: not implemented in DxIoFunctions")
+  override def listAllFilesUnderDirectory(
+      dirPath: String
+  ): Future[Seq[String]] =
+    throw new AppInternalException(
+      "listAllFilesUnderDirectory: not implemented in DxIoFunctions"
+    )
 
   /**
     * List entries in a directory non recursively. Includes directories
@@ -190,7 +206,9 @@ case class DxIoFunctions(
   override def listDirectory(
       path: String
   )(visited: Vector[String] = Vector.empty): Future[Iterator[IoElement]] =
-    throw new AppInternalException("listDirectory: not implemented in DxIoFunctions")
+    throw new AppInternalException(
+      "listDirectory: not implemented in DxIoFunctions"
+    )
 
   /**
     * Return true if path points to a directory, false otherwise

--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -83,7 +83,7 @@ case class DxIoFunctions(
     config: DxPathConfig,
     runtimeDebugLevel: Int
 ) extends IoFunctionSet {
-  private val verbose        = runtimeDebugLevel >= 1
+  private val verbose = runtimeDebugLevel >= 1
   override def pathFunctions = new DxPathFunctions(fileInfoDir, config, runtimeDebugLevel)
 
   // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)

--- a/src/main/scala/dxWDL/util/DxPathConfig.scala
+++ b/src/main/scala/dxWDL/util/DxPathConfig.scala
@@ -71,25 +71,25 @@ case class DxPathConfig(
 
 object DxPathConfig {
   def apply(homeDir: Path, streamAllFiles: Boolean, verbose: Boolean): DxPathConfig = {
-    val metaDir: Path        = homeDir.resolve("meta")
-    val inputFilesDir: Path  = homeDir.resolve("inputs")
+    val metaDir: Path = homeDir.resolve("meta")
+    val inputFilesDir: Path = homeDir.resolve("inputs")
     val outputFilesDir: Path = homeDir.resolve("outputs")
-    val tmpDir: Path         = homeDir.resolve("job_scratch_space")
+    val tmpDir: Path = homeDir.resolve("job_scratch_space")
 
-    val instanceTypeDB       = homeDir.resolve("instance_type_db.json")
+    val instanceTypeDB = homeDir.resolve("instance_type_db.json")
     val womSourceCodeEncoded = homeDir.resolve("source.wdl.uu64")
 
-    val stdout             = metaDir.resolve("stdout")
-    val stderr             = metaDir.resolve("stderr")
-    val script             = metaDir.resolve("script")
+    val stdout = metaDir.resolve("stdout")
+    val stderr = metaDir.resolve("stderr")
+    val script = metaDir.resolve("script")
     val dockerSubmitScript = metaDir.resolve("docker.submit")
-    val setupStreams       = metaDir.resolve("setup_streams")
-    val dxdaManifest       = metaDir.resolve("dxdaManifest.json")
-    val dxfuseManifest     = metaDir.resolve("dxfuseManifest.json")
-    val dxfuseMountpoint   = homeDir.resolve("mnt")
-    val rcPath             = metaDir.resolve("rc")
-    val dockerCid          = metaDir.resolve("dockerCid")
-    val runnerTaskEnv      = metaDir.resolve("taskEnv.json")
+    val setupStreams = metaDir.resolve("setup_streams")
+    val dxdaManifest = metaDir.resolve("dxdaManifest.json")
+    val dxfuseManifest = metaDir.resolve("dxfuseManifest.json")
+    val dxfuseMountpoint = homeDir.resolve("mnt")
+    val rcPath = metaDir.resolve("rc")
+    val dockerCid = metaDir.resolve("dockerCid")
+    val runnerTaskEnv = metaDir.resolve("taskEnv.json")
 
     DxPathConfig(
       homeDir,

--- a/src/main/scala/dxWDL/util/DxPathConfig.scala
+++ b/src/main/scala/dxWDL/util/DxPathConfig.scala
@@ -70,7 +70,11 @@ case class DxPathConfig(
 }
 
 object DxPathConfig {
-  def apply(homeDir: Path, streamAllFiles: Boolean, verbose: Boolean): DxPathConfig = {
+  def apply(
+      homeDir: Path,
+      streamAllFiles: Boolean,
+      verbose: Boolean
+  ): DxPathConfig = {
     val metaDir: Path = homeDir.resolve("meta")
     val inputFilesDir: Path = homeDir.resolve("inputs")
     val outputFilesDir: Path = homeDir.resolve("outputs")

--- a/src/main/scala/dxWDL/util/DxPathConfig.scala
+++ b/src/main/scala/dxWDL/util/DxPathConfig.scala
@@ -96,26 +96,26 @@ object DxPathConfig {
     val runnerTaskEnv = metaDir.resolve("taskEnv.json")
 
     DxPathConfig(
-      homeDir,
-      metaDir,
-      inputFilesDir,
-      outputFilesDir,
-      tmpDir,
-      instanceTypeDB,
-      womSourceCodeEncoded,
-      stdout,
-      stderr,
-      dockerSubmitScript,
-      script,
-      rcPath,
-      dockerCid,
-      setupStreams,
-      dxdaManifest,
-      dxfuseManifest,
-      dxfuseMountpoint,
-      runnerTaskEnv,
-      streamAllFiles,
-      verbose
+        homeDir,
+        metaDir,
+        inputFilesDir,
+        outputFilesDir,
+        tmpDir,
+        instanceTypeDB,
+        womSourceCodeEncoded,
+        stdout,
+        stderr,
+        dockerSubmitScript,
+        script,
+        rcPath,
+        dockerCid,
+        setupStreams,
+        dxdaManifest,
+        dxfuseManifest,
+        dxfuseMountpoint,
+        runnerTaskEnv,
+        streamAllFiles,
+        verbose
     )
   }
 }

--- a/src/main/scala/dxWDL/util/DxPathConfig.scala
+++ b/src/main/scala/dxWDL/util/DxPathConfig.scala
@@ -18,114 +18,100 @@ import dxWDL.base.Utils
 //
 case class DxPathConfig(
     homeDir: Path,
-    metaDir : Path,
-
+    metaDir: Path,
     // Running applets download files from the platform to this location
-    inputFilesDir : Path,
-
+    inputFilesDir: Path,
     // Running applets place output files in this location
-    outputFilesDir : Path,
-
+    outputFilesDir: Path,
     // scratch space for WDL stdlib operations like "write_lines"
-    tmpDir : Path,
-
+    tmpDir: Path,
     // Where a JSON representation of the instance data base is stored
     instanceTypeDB: Path,
-
     // Source WOM code. We could get it from the details field, but that
     // would require an additional API call. This is a private copy.
     womSourceCodeEncoded: Path,
-
     stdout: Path,
     stderr: Path,
-
     // bash script for running the docker image the user specified
     // is deposited here.
     dockerSubmitScript: Path,
-
     // bash script is written to this location
-    script : Path,
-
+    script: Path,
     // Status code returned from the shell command is written
     // to this file
-    rcPath : Path,
-
+    rcPath: Path,
     // file where the docker container name is stored.
-    dockerCid : Path,
-
+    dockerCid: Path,
     // bash commands for streaming files with 'dx cat' are located here
-    setupStreams : Path,
-
+    setupStreams: Path,
     // Location of dx download agent (dxda) manifest. It will download all these
     // files, if the file is non empty.
-    dxdaManifest : Path,
-
+    dxdaManifest: Path,
     // Location of dxfuse manifest. It will mount all these
     // files, if the file is non empty.
-    dxfuseManifest : Path,
-    dxfuseMountpoint : Path,
-
+    dxfuseManifest: Path,
+    dxfuseMountpoint: Path,
     // file for storing the state between prolog and epilog of the task runner
     runnerTaskEnv: Path,
-
     // should we stream all files?
     streamAllFiles: Boolean,
-    verbose: Boolean) {
+    verbose: Boolean
+) {
 
-    // create all the directory paths, so we can start using them.
-    // This is used when running tasks, but NOT when compiling.
-    def createCleanDirs() : Unit = {
-        Utils.safeMkdir(metaDir)
-        Utils.safeMkdir(inputFilesDir)
-        Utils.safeMkdir(outputFilesDir)
-        Utils.safeMkdir(tmpDir)
-        Utils.safeMkdir(dxfuseMountpoint)
-    }
+  // create all the directory paths, so we can start using them.
+  // This is used when running tasks, but NOT when compiling.
+  def createCleanDirs(): Unit = {
+    Utils.safeMkdir(metaDir)
+    Utils.safeMkdir(inputFilesDir)
+    Utils.safeMkdir(outputFilesDir)
+    Utils.safeMkdir(tmpDir)
+    Utils.safeMkdir(dxfuseMountpoint)
+  }
 }
 
 object DxPathConfig {
-    def apply(homeDir: Path,
-              streamAllFiles : Boolean,
-              verbose: Boolean) : DxPathConfig = {
-        val metaDir: Path = homeDir.resolve("meta")
-        val inputFilesDir: Path = homeDir.resolve("inputs")
-        val outputFilesDir: Path = homeDir.resolve("outputs")
-        val tmpDir : Path = homeDir.resolve("job_scratch_space")
+  def apply(homeDir: Path, streamAllFiles: Boolean, verbose: Boolean): DxPathConfig = {
+    val metaDir: Path        = homeDir.resolve("meta")
+    val inputFilesDir: Path  = homeDir.resolve("inputs")
+    val outputFilesDir: Path = homeDir.resolve("outputs")
+    val tmpDir: Path         = homeDir.resolve("job_scratch_space")
 
-        val instanceTypeDB = homeDir.resolve("instance_type_db.json")
-        val womSourceCodeEncoded = homeDir.resolve("source.wdl.uu64")
+    val instanceTypeDB       = homeDir.resolve("instance_type_db.json")
+    val womSourceCodeEncoded = homeDir.resolve("source.wdl.uu64")
 
-        val stdout = metaDir.resolve("stdout")
-        val stderr = metaDir.resolve("stderr")
-        val script = metaDir.resolve("script")
-        val dockerSubmitScript = metaDir.resolve("docker.submit")
-        val setupStreams = metaDir.resolve("setup_streams")
-        val dxdaManifest = metaDir.resolve("dxdaManifest.json")
-        val dxfuseManifest = metaDir.resolve("dxfuseManifest.json")
-        val dxfuseMountpoint = homeDir.resolve("mnt")
-        val rcPath = metaDir.resolve("rc")
-        val dockerCid = metaDir.resolve("dockerCid")
-        val runnerTaskEnv = metaDir.resolve("taskEnv.json")
+    val stdout             = metaDir.resolve("stdout")
+    val stderr             = metaDir.resolve("stderr")
+    val script             = metaDir.resolve("script")
+    val dockerSubmitScript = metaDir.resolve("docker.submit")
+    val setupStreams       = metaDir.resolve("setup_streams")
+    val dxdaManifest       = metaDir.resolve("dxdaManifest.json")
+    val dxfuseManifest     = metaDir.resolve("dxfuseManifest.json")
+    val dxfuseMountpoint   = homeDir.resolve("mnt")
+    val rcPath             = metaDir.resolve("rc")
+    val dockerCid          = metaDir.resolve("dockerCid")
+    val runnerTaskEnv      = metaDir.resolve("taskEnv.json")
 
-        DxPathConfig(homeDir,
-                     metaDir,
-                     inputFilesDir,
-                     outputFilesDir,
-                     tmpDir,
-                     instanceTypeDB,
-                     womSourceCodeEncoded,
-                     stdout,
-                     stderr,
-                     dockerSubmitScript,
-                     script,
-                     rcPath,
-                     dockerCid,
-                     setupStreams,
-                     dxdaManifest,
-                     dxfuseManifest,
-                     dxfuseMountpoint,
-                     runnerTaskEnv,
-                     streamAllFiles,
-                     verbose)
-    }
+    DxPathConfig(
+      homeDir,
+      metaDir,
+      inputFilesDir,
+      outputFilesDir,
+      tmpDir,
+      instanceTypeDB,
+      womSourceCodeEncoded,
+      stdout,
+      stderr,
+      dockerSubmitScript,
+      script,
+      rcPath,
+      dockerCid,
+      setupStreams,
+      dxdaManifest,
+      dxfuseManifest,
+      dxfuseMountpoint,
+      runnerTaskEnv,
+      streamAllFiles,
+      verbose
+    )
+  }
 }

--- a/src/main/scala/dxWDL/util/Furl.scala
+++ b/src/main/scala/dxWDL/util/Furl.scala
@@ -73,7 +73,10 @@ object Furl {
   // We need to change the standard so that the conversion from file to
   // string is well defined, and requires an explicit conversion function.
   //
-  def dxFileToFurl(dxFile: DxFile, fileInfoDir: Map[String, (DxFile, DxFileDescribe)]): FurlDx = {
+  def dxFileToFurl(
+      dxFile: DxFile,
+      fileInfoDir: Map[String, (DxFile, DxFileDescribe)]
+  ): FurlDx = {
     // Try the cache first; if the file isn't there, submit an API call.
     val (folder, name) = fileInfoDir.get(dxFile.id) match {
       case None =>

--- a/src/main/scala/dxWDL/util/Furl.scala
+++ b/src/main/scala/dxWDL/util/Furl.scala
@@ -93,9 +93,9 @@ object Furl {
       case Some(proj) =>
         val projId = proj.getId
         FurlDx(
-          s"${DX_URL_PREFIX}${projId}:${fid}::${logicalName}",
-          Some(DxProject.getInstance(projId)),
-          dxFile
+            s"${DX_URL_PREFIX}${projId}:${fid}::${logicalName}",
+            Some(DxProject.getInstance(projId)),
+            dxFile
         )
     }
   }

--- a/src/main/scala/dxWDL/util/Furl.scala
+++ b/src/main/scala/dxWDL/util/Furl.scala
@@ -21,7 +21,7 @@ import dxWDL.dx._
 
 sealed trait Furl
 
-case class FurlLocal(path: String)                                          extends Furl
+case class FurlLocal(path: String) extends Furl
 case class FurlDx(value: String, dxProj: Option[DxProject], dxFile: DxFile) extends Furl
 
 object Furl {
@@ -31,9 +31,9 @@ object Furl {
   //
   // Get the project and file.
   private def parseDxFurl(buf: String): FurlDx = {
-    val s         = buf.substring(DX_URL_PREFIX.length)
+    val s = buf.substring(DX_URL_PREFIX.length)
     val proj_file = s.split("::")(0)
-    val dxFile    = DxPath.resolveDxURLFile(DX_URL_PREFIX + proj_file)
+    val dxFile = DxPath.resolveDxURLFile(DX_URL_PREFIX + proj_file)
     dxFile.project match {
       case None =>
         FurlDx(buf, None, dxFile)
@@ -83,7 +83,7 @@ object Furl {
         (miniDesc.folder, miniDesc.name)
     }
     val logicalName = s"${folder}/${name}"
-    val fid         = dxFile.getId
+    val fid = dxFile.getId
     dxFile.project match {
       case None =>
         FurlDx(s"${DX_URL_PREFIX}${fid}::${logicalName}", None, dxFile)

--- a/src/main/scala/dxWDL/util/Furl.scala
+++ b/src/main/scala/dxWDL/util/Furl.scala
@@ -21,82 +21,79 @@ import dxWDL.dx._
 
 sealed trait Furl
 
-case class FurlLocal(path : String) extends Furl
-case class FurlDx(value : String,
-                  dxProj : Option[DxProject],
-                  dxFile: DxFile) extends Furl
+case class FurlLocal(path: String)                                          extends Furl
+case class FurlDx(value: String, dxProj: Option[DxProject], dxFile: DxFile) extends Furl
 
 object Furl {
-    // From a string such as:
-    //    dx://proj-xxxx:file-yyyy::/A/B/C.txt
-    //    dx://proj-xxxx:file-yyyy
-    //
-    // Get the project and file.
-    private def parseDxFurl(buf: String) : FurlDx = {
-        val s = buf.substring(DX_URL_PREFIX.length)
-        val proj_file = s.split("::")(0)
-        val dxFile = DxPath.resolveDxURLFile(DX_URL_PREFIX + proj_file)
-        dxFile.project match {
-            case None =>
-                FurlDx(buf, None, dxFile)
-            case Some(DxProject(proj)) if proj.startsWith("project-") =>
-                FurlDx(buf, Some(DxProject(proj)), dxFile)
-            case Some(DxProject(proj)) if proj.startsWith("container-") =>
-                FurlDx(buf, None, dxFile)
-            case _ =>
-                throw new Exception(s"Invalid path ${buf}")
-        }
+  // From a string such as:
+  //    dx://proj-xxxx:file-yyyy::/A/B/C.txt
+  //    dx://proj-xxxx:file-yyyy
+  //
+  // Get the project and file.
+  private def parseDxFurl(buf: String): FurlDx = {
+    val s         = buf.substring(DX_URL_PREFIX.length)
+    val proj_file = s.split("::")(0)
+    val dxFile    = DxPath.resolveDxURLFile(DX_URL_PREFIX + proj_file)
+    dxFile.project match {
+      case None =>
+        FurlDx(buf, None, dxFile)
+      case Some(DxProject(proj)) if proj.startsWith("project-") =>
+        FurlDx(buf, Some(DxProject(proj)), dxFile)
+      case Some(DxProject(proj)) if proj.startsWith("container-") =>
+        FurlDx(buf, None, dxFile)
+      case _ =>
+        throw new Exception(s"Invalid path ${buf}")
     }
+  }
 
-    def parse(path: String) : Furl = {
-        path match {
-            case _ if path.startsWith(Utils.DX_URL_PREFIX) =>
-                parseDxFurl(path)
-            case _ if path contains "://" =>
-                throw new Exception(s"protocol not supported, cannot access ${path}")
-            case _ =>
-                // A local file
-                FurlLocal(path)
-        }
+  def parse(path: String): Furl = {
+    path match {
+      case _ if path.startsWith(Utils.DX_URL_PREFIX) =>
+        parseDxFurl(path)
+      case _ if path contains "://" =>
+        throw new Exception(s"protocol not supported, cannot access ${path}")
+      case _ =>
+        // A local file
+        FurlLocal(path)
     }
+  }
 
-    // Convert a dx-file to a string with the format:
-    //   dx://proj-xxxx:file-yyyy::/A/B/C.txt
-    //
-    // This is needed for operations like:
-    //     File filename
-    //     String  = sub(filename, ".txt", "") + ".md"
-    // The standard library functions requires the file name to
-    // end with a posix-like name. It can't just be:
-    // "dx://file-xxxx", or "dx://proj-xxxx:file-yyyy". It needs
-    // to be something like:  dx://xxxx:yyyy:genome.txt, so that
-    // we can change the suffix.
-    //
-    // We need to change the standard so that the conversion from file to
-    // string is well defined, and requires an explicit conversion function.
-    //
-    def dxFileToFurl(dxFile: DxFile,
-                     fileInfoDir: Map[String, (DxFile, DxFileDescribe)]) : FurlDx = {
-        // Try the cache first; if the file isn't there, submit an API call.
-        val (folder, name) = fileInfoDir.get(dxFile.id) match {
-            case None =>
-                val desc = dxFile.describe()
-                (desc.folder, desc.name)
-            case Some((_,miniDesc)) =>
-                (miniDesc.folder, miniDesc.name)
-        }
-        val logicalName = s"${folder}/${name}"
-        val fid = dxFile.getId
-        dxFile.project match {
-            case None =>
-                FurlDx(s"${DX_URL_PREFIX}${fid}::${logicalName}",
-                       None,
-                       dxFile)
-            case Some(proj) =>
-                val projId = proj.getId
-                FurlDx(s"${DX_URL_PREFIX}${projId}:${fid}::${logicalName}",
-                       Some(DxProject.getInstance(projId)),
-                       dxFile)
-        }
+  // Convert a dx-file to a string with the format:
+  //   dx://proj-xxxx:file-yyyy::/A/B/C.txt
+  //
+  // This is needed for operations like:
+  //     File filename
+  //     String  = sub(filename, ".txt", "") + ".md"
+  // The standard library functions requires the file name to
+  // end with a posix-like name. It can't just be:
+  // "dx://file-xxxx", or "dx://proj-xxxx:file-yyyy". It needs
+  // to be something like:  dx://xxxx:yyyy:genome.txt, so that
+  // we can change the suffix.
+  //
+  // We need to change the standard so that the conversion from file to
+  // string is well defined, and requires an explicit conversion function.
+  //
+  def dxFileToFurl(dxFile: DxFile, fileInfoDir: Map[String, (DxFile, DxFileDescribe)]): FurlDx = {
+    // Try the cache first; if the file isn't there, submit an API call.
+    val (folder, name) = fileInfoDir.get(dxFile.id) match {
+      case None =>
+        val desc = dxFile.describe()
+        (desc.folder, desc.name)
+      case Some((_, miniDesc)) =>
+        (miniDesc.folder, miniDesc.name)
     }
+    val logicalName = s"${folder}/${name}"
+    val fid         = dxFile.getId
+    dxFile.project match {
+      case None =>
+        FurlDx(s"${DX_URL_PREFIX}${fid}::${logicalName}", None, dxFile)
+      case Some(proj) =>
+        val projId = proj.getId
+        FurlDx(
+          s"${DX_URL_PREFIX}${projId}:${fid}::${logicalName}",
+          Some(DxProject.getInstance(projId)),
+          dxFile
+        )
+    }
+  }
 }

--- a/src/main/scala/dxWDL/util/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/util/InstanceTypeDB.scala
@@ -104,9 +104,9 @@ case class DxInstanceType(
   // types don't have the exact memory and disk space that you would
   // expect. For example, mem1_ssd1_x2 has less disk space than mem2_ssd1_x2.
   def compareByResources(that: DxInstanceType): Int = {
-    val memDelta  = (this.memoryMB / 1024) - (that.memoryMB / 1024)
+    val memDelta = (this.memoryMB / 1024) - (that.memoryMB / 1024)
     val diskDelta = (this.diskGB / 16) - (that.diskGB / 16)
-    val cpuDelta  = this.cpu - that.cpu
+    val cpuDelta = this.cpu - that.cpu
 
     val retval =
       if (memDelta == 0 && diskDelta == 0 && cpuDelta == 0)
@@ -259,7 +259,7 @@ case class InstanceTypeDB(pricingAvailable: Boolean, instances: Vector[DxInstanc
 
   // sort the instances, and print them out
   def prettyPrint(): String = {
-    var remain: Set[DxInstanceType]          = instances.toSet
+    var remain: Set[DxInstanceType] = instances.toSet
     var sortediTypes: Vector[DxInstanceType] = Vector()
     while (!remain.isEmpty) {
       val smallest = calcMinimalInstanceType(remain)
@@ -300,7 +300,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
       case None                 => None
       case Some(WomString(buf)) =>
         // extract number
-        val numRex  = """(\d+\.?\d*)""".r
+        val numRex = """(\d+\.?\d*)""".r
         val numbers = numRex.findAllIn(buf).toList
         if (numbers.length != 1)
           throw new Exception(s"Can not parse memory specification ${buf}")
@@ -315,7 +315,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
 
         // extract memory units
         val memUnitRex = """([a-zA-Z]+)""".r
-        val memUnits   = memUnitRex.findAllIn(buf).toList
+        val memUnits = memUnitRex.findAllIn(buf).toList
         if (memUnits.length > 1)
           throw new Exception(s"Can not parse memory specification ${buf}")
         val memBytes: Double =
@@ -349,9 +349,9 @@ object InstanceTypeDB extends DefaultJsonProtocol {
     val diskGB: Option[Int] = wdlDiskGB match {
       case None => None
       case Some(WomString(buf)) =>
-        val components  = buf.split("\\s+")
+        val components = buf.split("\\s+")
         val ignoreWords = Set("local-disk", "hdd", "sdd", "ssd")
-        val l           = components.filter(x => !(ignoreWords contains x.toLowerCase))
+        val l = components.filter(x => !(ignoreWords contains x.toLowerCase))
         if (l.length != 1)
           throw new Exception(s"Can't parse disk space specification ${buf}")
         val i =
@@ -427,7 +427,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
       }
       osSupported.map { elem =>
         val distribution = getJsStringField(elem, "distribution")
-        val release      = getJsStringField(elem, "release")
+        val release = getJsStringField(elem, "release")
         distribution -> release
       }.toVector
     }
@@ -443,7 +443,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
           .build()
       )
       .build()
-    val rep            = DXAPI.projectDescribe(dxProject.id, req, classOf[JsonNode])
+    val rep = DXAPI.projectDescribe(dxProject.id, req, classOf[JsonNode])
     val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
     val availableInstanceTypes: JsValue =
       repJs.asJsObject.fields.get(availableField) match {
@@ -454,11 +454,11 @@ object InstanceTypeDB extends DefaultJsonProtocol {
     // convert to a list of DxInstanceTypes, with prices set to zero
     availableInstanceTypes.asJsObject.fields.map {
       case (iName, jsValue) =>
-        val numCores       = getJsIntField(jsValue, "numCores")
-        val memoryMB       = getJsIntField(jsValue, "totalMemoryMB")
-        val diskSpaceGB    = getJsIntField(jsValue, "ephemeralStorageGB")
-        val os             = getSupportedOSes(jsValue)
-        val gpu            = iName contains "_gpu"
+        val numCores = getJsIntField(jsValue, "numCores")
+        val memoryMB = getJsIntField(jsValue, "totalMemoryMB")
+        val diskSpaceGB = getJsIntField(jsValue, "ephemeralStorageGB")
+        val os = getSupportedOSes(jsValue)
+        val gpu = iName contains "_gpu"
         val dxInstanceType = DxInstanceType(iName, memoryMB, diskSpaceGB, numCores, 0, os, gpu)
         iName -> dxInstanceType
     }.toMap
@@ -488,10 +488,10 @@ object InstanceTypeDB extends DefaultJsonProtocol {
           throw new Exception("Insufficient permissions")
       }
 
-    val js: JsValue           = DxUtils.jsValueOfJsonNode(rep)
+    val js: JsValue = DxUtils.jsValueOfJsonNode(rep)
     val pricingModelsByRegion = getJsField(js, "pricingModelsByRegion")
-    val pricingModel          = getJsField(pricingModelsByRegion, region)
-    val computeRatesPerHour   = getJsField(pricingModel, "computeRatesPerHour")
+    val pricingModel = getJsField(pricingModelsByRegion, region)
+    val computeRatesPerHour = getJsField(pricingModel, "computeRatesPerHour")
 
     // convert from JsValue to a Map
     computeRatesPerHour.asJsObject.fields.map {
@@ -622,7 +622,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
 
     // sort the prices from low to high, and then replace
     // with rank.
-    var crnt_price      = 0
+    var crnt_price = 0
     val sortedInstances = db.instances.sortWith(_.price < _.price)
     val opaque = sortedInstances.map { it =>
       crnt_price += 1

--- a/src/main/scala/dxWDL/util/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/util/InstanceTypeDB.scala
@@ -24,7 +24,6 @@ cpu         1 per core
 price       comparative price
 
   */
-
 package dxWDL.util
 
 import com.dnanexus.{DXAPI, DXJSON}
@@ -37,11 +36,13 @@ import dxWDL.base.{Utils, Verbose}
 import dxWDL.dx._
 
 // Request for an instance type
-case class InstanceTypeReq(dxInstanceType: Option[String],
-                           memoryMB: Option[Int],
-                           diskGB: Option[Int],
-                           cpu: Option[Int],
-                           gpu: Option[Boolean])
+case class InstanceTypeReq(
+    dxInstanceType: Option[String],
+    memoryMB: Option[Int],
+    diskGB: Option[Int],
+    cpu: Option[Int],
+    gpu: Option[Boolean]
+)
 
 // Instance Type on the platform. For example:
 // name:   mem1_ssd1_x4
@@ -49,538 +50,584 @@ case class InstanceTypeReq(dxInstanceType: Option[String],
 // disk:   80 GB
 // price:  0.5 dollar per hour
 // os:     [(Ubuntu, 12.04), (Ubuntu, 14.04)}
-case class DxInstanceType(name: String,
-                          memoryMB: Int,
-                          diskGB: Int,
-                          cpu: Int,
-                          price: Float,
-                          os: Vector[(String, String)],
-                          gpu : Boolean) {
-    // Does this instance satisfy the requirements?
-    def satisfies(memReq: Option[Int],
-                  diskReq: Option[Int],
-                  cpuReq: Option[Int],
-                  gpuReq: Option[Boolean]) : Boolean = {
-        memReq match {
-            case Some(x) => if (memoryMB < x) return false
-            case None => ()
-        }
-        diskReq match {
-            case Some(x) => if (diskGB < x) return false
-            case None => ()
-        }
-        cpuReq match {
-            case Some(x) => if (cpu < x) return false
-            case None => ()
-        }
-        gpuReq match {
-            case Some(flag) => if (flag != gpu) return false
-            case None => ()
-        }
-        return true
+case class DxInstanceType(
+    name: String,
+    memoryMB: Int,
+    diskGB: Int,
+    cpu: Int,
+    price: Float,
+    os: Vector[(String, String)],
+    gpu: Boolean
+) {
+  // Does this instance satisfy the requirements?
+  def satisfies(
+      memReq: Option[Int],
+      diskReq: Option[Int],
+      cpuReq: Option[Int],
+      gpuReq: Option[Boolean]
+  ): Boolean = {
+    memReq match {
+      case Some(x) => if (memoryMB < x) return false
+      case None    => ()
     }
-
-    def compareByPrice(that: DxInstanceType) : Int = {
-        // compare by price
-        if (this.price < that.price)
-            return -1
-        if (this.price > that.price)
-            return 1
-        return 0
+    diskReq match {
+      case Some(x) => if (diskGB < x) return false
+      case None    => ()
     }
-
-    // Compare based on resource sizes. This is a partial ordering.
-    //
-    // For example, if A has more memory, disk space, and cores than
-    // B, then B < A. We round down memory and disk sizes, to make the
-    // comparison insensitive to minor differences.
-    //
-    // We add some fuzziness to the comparison, because the instance
-    // types don't have the exact memory and disk space that you would
-    // expect. For example, mem1_ssd1_x2 has less disk space than mem2_ssd1_x2.
-    def compareByResources(that : DxInstanceType) : Int = {
-        val memDelta = (this.memoryMB/1024) - (that.memoryMB/1024)
-        val diskDelta = (this.diskGB/16) - (that.diskGB/16)
-        val cpuDelta = this.cpu - that.cpu
-
-        val retval =
-            if (memDelta == 0 && diskDelta == 0 && cpuDelta == 0)
-                0
-            else if (memDelta <= 0 && diskDelta <= 0 && cpuDelta <= 0)
-                -1
-            else if (memDelta >= 0 &&  diskDelta >= 0 && cpuDelta >= 0)
-                1
-            else
-                // instances cannot be directly compared.
-                0
-        //System.out.println(s"compareByResource ${this.name} ${that.name} retval=${retval}")
-        retval
+    cpuReq match {
+      case Some(x) => if (cpu < x) return false
+      case None    => ()
     }
-
-    // v2 instances are always better than v1 instances
-    def compareByType(that: DxInstanceType) : Int = {
-        //System.out.println(s"compareByType ${this.name} ${that.name}")
-        def typeVersion(name: String) =
-            if (name contains "_v2") "v2"
-            else "v1"
-
-        (typeVersion(this.name), typeVersion(that.name)) match {
-            case ("v1", "v2") => -1
-            case ("v2", "v1") => 1
-            case (_, _) => 0
-        }
+    gpuReq match {
+      case Some(flag) => if (flag != gpu) return false
+      case None       => ()
     }
+    return true
+  }
+
+  def compareByPrice(that: DxInstanceType): Int = {
+    // compare by price
+    if (this.price < that.price)
+      return -1
+    if (this.price > that.price)
+      return 1
+    return 0
+  }
+
+  // Compare based on resource sizes. This is a partial ordering.
+  //
+  // For example, if A has more memory, disk space, and cores than
+  // B, then B < A. We round down memory and disk sizes, to make the
+  // comparison insensitive to minor differences.
+  //
+  // We add some fuzziness to the comparison, because the instance
+  // types don't have the exact memory and disk space that you would
+  // expect. For example, mem1_ssd1_x2 has less disk space than mem2_ssd1_x2.
+  def compareByResources(that: DxInstanceType): Int = {
+    val memDelta  = (this.memoryMB / 1024) - (that.memoryMB / 1024)
+    val diskDelta = (this.diskGB / 16) - (that.diskGB / 16)
+    val cpuDelta  = this.cpu - that.cpu
+
+    val retval =
+      if (memDelta == 0 && diskDelta == 0 && cpuDelta == 0)
+        0
+      else if (memDelta <= 0 && diskDelta <= 0 && cpuDelta <= 0)
+        -1
+      else if (memDelta >= 0 && diskDelta >= 0 && cpuDelta >= 0)
+        1
+      else
+        // instances cannot be directly compared.
+        0
+    //System.out.println(s"compareByResource ${this.name} ${that.name} retval=${retval}")
+    retval
+  }
+
+  // v2 instances are always better than v1 instances
+  def compareByType(that: DxInstanceType): Int = {
+    //System.out.println(s"compareByType ${this.name} ${that.name}")
+    def typeVersion(name: String) =
+      if (name contains "_v2") "v2"
+      else "v1"
+
+    (typeVersion(this.name), typeVersion(that.name)) match {
+      case ("v1", "v2") => -1
+      case ("v2", "v1") => 1
+      case (_, _)       => 0
+    }
+  }
 }
 
 // support automatic conversion to/from JsValue
 object DxInstanceType extends DefaultJsonProtocol {
-    implicit val dxInstanceTypeFormat = jsonFormat7(DxInstanceType.apply)
+  implicit val dxInstanceTypeFormat = jsonFormat7(DxInstanceType.apply)
 }
 
+case class InstanceTypeDB(pricingAvailable: Boolean, instances: Vector[DxInstanceType]) {
 
-case class InstanceTypeDB(pricingAvailable : Boolean,
-                          instances: Vector[DxInstanceType]) {
+  // if prices are available, choose the cheapest instance. Otherwise,
+  // choose one with minimal resources.
+  private def lteq(x: DxInstanceType, y: DxInstanceType): Boolean = {
+    val costDiff =
+      if (pricingAvailable) {
+        x.compareByPrice(y)
+      } else {
+        x.compareByResources(y)
+      }
+    if (costDiff != 0)
+      return costDiff <= 0
 
-    // if prices are available, choose the cheapest instance. Otherwise,
-    // choose one with minimal resources.
-    private def lteq(x : DxInstanceType, y : DxInstanceType) : Boolean = {
-        val costDiff =
-            if (pricingAvailable) {
-                x.compareByPrice(y)
-            } else {
-                x.compareByResources(y)
-            }
-        if (costDiff != 0)
-            return costDiff <= 0
+    // cost is the same, compare by instance type. Better is HIGHER
+    x.compareByType(y) >= 0
+  }
 
-        // cost is the same, compare by instance type. Better is HIGHER
-        x.compareByType(y) >= 0
+  // Calculate the dx instance type that fits best, based on
+  // runtime specifications.
+  //
+  // memory:    minimal amount of RAM, specified in MB
+  // diskSpace: minimal amount of disk space, specified in GB
+  // numCores:  minimal number of cores
+  //
+  // Solving this in an optimal way is a hard problem. The approximation
+  // we use here is:
+  // 1) discard all instances that do not have enough resources
+  // 2) choose the cheapest instance
+  def chooseAttrs(
+      memoryMB: Option[Int],
+      diskGB: Option[Int],
+      cpu: Option[Int],
+      gpu: Option[Boolean]
+  ): String = {
+    // discard all instances that are too weak
+    val sufficient: Vector[DxInstanceType] =
+      instances.filter(x => x.satisfies(memoryMB, diskGB, cpu, gpu))
+    if (sufficient.length == 0)
+      throw new Exception(
+        s"""|No instances found that match the requirements
+                                    |memory=$memoryMB, diskGB=$diskGB, cpu=$cpu""".stripMargin
+          .replaceAll("\n", " ")
+      )
+    val initialGuess = sufficient.head
+    val bestInstance = sufficient.tail.foldLeft(initialGuess) {
+      case (bestSoFar, x) =>
+        if (lteq(x, bestSoFar)) x
+        else bestSoFar
     }
+    bestInstance.name
+  }
 
-    // Calculate the dx instance type that fits best, based on
-    // runtime specifications.
-    //
-    // memory:    minimal amount of RAM, specified in MB
-    // diskSpace: minimal amount of disk space, specified in GB
-    // numCores:  minimal number of cores
-    //
-    // Solving this in an optimal way is a hard problem. The approximation
-    // we use here is:
-    // 1) discard all instances that do not have enough resources
-    // 2) choose the cheapest instance
-    def chooseAttrs(memoryMB: Option[Int],
-                    diskGB: Option[Int],
-                    cpu: Option[Int],
-                    gpu: Option[Boolean]) : String = {
-        // discard all instances that are too weak
-        val sufficient: Vector[DxInstanceType] =
-            instances.filter(x => x.satisfies(memoryMB, diskGB, cpu, gpu))
-        if (sufficient.length == 0)
-            throw new Exception(s"""|No instances found that match the requirements
-                                    |memory=$memoryMB, diskGB=$diskGB, cpu=$cpu"""
-                                    .stripMargin.replaceAll("\n", " "))
-        val initialGuess = sufficient.head
-        val bestInstance = sufficient.tail.foldLeft(initialGuess){ case (bestSoFar,x) =>
-            if (lteq(x, bestSoFar)) x
-            else bestSoFar
-        }
-        bestInstance.name
+  def chooseShortcut(iType: String): String = {
+    // Short circut the calculation, and just choose this instance.
+    // Make sure it is available.
+    instances.find(x => x.name == iType) match {
+      case Some(x) =>
+        // instance exists, and can be used
+        iType
+      case None =>
+        // Probably a bad instance name
+        throw new Exception(s"""|Instance type ${iType} is unavailable
+                                        |or badly named""".stripMargin.replaceAll("\n", " "))
     }
+  }
 
-    def chooseShortcut(iType: String) : String = {
-        // Short circut the calculation, and just choose this instance.
-        // Make sure it is available.
-        instances.find(x => x.name == iType) match {
-            case Some(x) =>
-                // instance exists, and can be used
-                iType
-            case None =>
-                // Probably a bad instance name
-                throw new Exception(s"""|Instance type ${iType} is unavailable
-                                        |or badly named"""
-                                        .stripMargin.replaceAll("\n", " "))
-        }
+  // The cheapest available instance, this is normally also the smallest.
+  private def calcMinimalInstanceType(iTypes: Set[DxInstanceType]): DxInstanceType = {
+    if (iTypes.isEmpty)
+      throw new Exception("empty list")
+    iTypes.tail.foldLeft(iTypes.head) {
+      case (best, elem) =>
+        if (lteq(elem, best)) elem
+        else best
     }
+  }
 
-    // The cheapest available instance, this is normally also the smallest.
-    private def calcMinimalInstanceType(iTypes: Set[DxInstanceType]) : DxInstanceType = {
-        if (iTypes.isEmpty)
-            throw new Exception("empty list")
-        iTypes.tail.foldLeft(iTypes.head) {
-            case (best, elem) =>
-                if (lteq(elem, best)) elem
-                else best
-        }
-    }
-
-    // A fast but cheap instance type.
-    //
-    def defaultInstanceType : String = {
-        val iType = calcMinimalInstanceType(instances.toSet)
-        iType.name
-    }
+  // A fast but cheap instance type.
+  //
+  def defaultInstanceType: String = {
+    val iType = calcMinimalInstanceType(instances.toSet)
+    iType.name
+  }
 
   // check if instance type A is smaller or equal in requirements to
-    // instance type B
-    def lteqByResources(iTypeA: String,
-                        iTypeB: String) : Boolean = {
-        val ax = instances.find(_.name == iTypeA)
-        val bx = instances.find(_.name == iTypeB)
+  // instance type B
+  def lteqByResources(iTypeA: String, iTypeB: String): Boolean = {
+    val ax = instances.find(_.name == iTypeA)
+    val bx = instances.find(_.name == iTypeB)
 
-        (ax,bx) match {
-            case (Some(a), Some(b)) =>
-                // All the resources for instance A should be less than or equal
-                // to the resoruces for B.
-                (a.memoryMB <= b.memoryMB &&
-                     a.diskGB <= b.diskGB &&
-                     a.cpu <= b.cpu)
-            case (_,_) =>
-                // At least one of the instances is not in the database.
-                // We can't compare them.
-                false
-        }
+    (ax, bx) match {
+      case (Some(a), Some(b)) =>
+        // All the resources for instance A should be less than or equal
+        // to the resoruces for B.
+        (a.memoryMB <= b.memoryMB &&
+          a.diskGB <= b.diskGB &&
+          a.cpu <= b.cpu)
+      case (_, _) =>
+        // At least one of the instances is not in the database.
+        // We can't compare them.
+        false
     }
+  }
 
-    def apply(iType: InstanceTypeReq) : String = {
-        iType.dxInstanceType match {
-            case None =>
-                chooseAttrs(iType.memoryMB, iType.diskGB, iType.cpu, iType.gpu)
-            case Some(dxIType) =>
-                // Shortcut the entire calculation, and provide the dx instance type directly
-                chooseShortcut(dxIType)
-        }
+  def apply(iType: InstanceTypeReq): String = {
+    iType.dxInstanceType match {
+      case None =>
+        chooseAttrs(iType.memoryMB, iType.diskGB, iType.cpu, iType.gpu)
+      case Some(dxIType) =>
+        // Shortcut the entire calculation, and provide the dx instance type directly
+        chooseShortcut(dxIType)
     }
+  }
 
-    // sort the instances, and print them out
-    def prettyPrint() : String = {
-        var remain : Set[DxInstanceType] = instances.toSet
-        var sortediTypes : Vector[DxInstanceType] = Vector()
-        while (!remain.isEmpty) {
-            val smallest = calcMinimalInstanceType(remain)
-            sortediTypes = sortediTypes :+ smallest
-            remain = remain - smallest
-        }
-        sortediTypes.toJson.prettyPrint
+  // sort the instances, and print them out
+  def prettyPrint(): String = {
+    var remain: Set[DxInstanceType]          = instances.toSet
+    var sortediTypes: Vector[DxInstanceType] = Vector()
+    while (!remain.isEmpty) {
+      val smallest = calcMinimalInstanceType(remain)
+      sortediTypes = sortediTypes :+ smallest
+      remain = remain - smallest
     }
+    sortediTypes.toJson.prettyPrint
+  }
 }
 
 object InstanceTypeDB extends DefaultJsonProtocol {
-    // support automatic conversion to/from JsValue
-    implicit val instanceTypeDBFormat = jsonFormat2(InstanceTypeDB.apply)
+  // support automatic conversion to/from JsValue
+  implicit val instanceTypeDBFormat = jsonFormat2(InstanceTypeDB.apply)
 
-    // Currently, we support only constants.
-    def parse(dxInstanceType: Option[WomValue],
-              wdlMemoryMB: Option[WomValue],
-              wdlDiskGB: Option[WomValue],
-              wdlCpu: Option[WomValue],
-              wdlGpu: Option[WomValue]) : InstanceTypeReq = {
-        // Shortcut the entire calculation, and provide the dx instance type directly
-        dxInstanceType match {
-            case None => None
-            case Some(WomString(iType)) =>
-                return InstanceTypeReq(Some(iType), None, None, None, None)
-            case Some(x) =>
-                throw new Exception(s"""|dxInstaceType has to evaluate to a
-                                        |WomString type ${x.toWomString}"""
-                                        .stripMargin.replaceAll("\n", " "))
-        }
-
-        // Examples for memory specification: "4000 MB", "1 GB"
-        val memoryMB: Option[Int] = wdlMemoryMB match {
-            case None => None
-            case Some(WomString(buf)) =>
-                // extract number
-                val numRex = """(\d+\.?\d*)""".r
-                val numbers = numRex.findAllIn(buf).toList
-                if (numbers.length != 1)
-                    throw new Exception(s"Can not parse memory specification ${buf}")
-                val number:String = numbers(0)
-                val x:Double = try { number.toDouble } catch {
-                    case e: Throwable =>
-                        throw new Exception(s"Unrecognized number ${number}")
-                }
-
-                // extract memory units
-                val memUnitRex = """([a-zA-Z]+)""".r
-                val memUnits = memUnitRex.findAllIn(buf).toList
-                if (memUnits.length > 1)
-                    throw new Exception(s"Can not parse memory specification ${buf}")
-                val memBytes : Double =
-                    if (memUnits.isEmpty) {
-                    // specification is in bytes, convert to megabytes
-                        x.toInt
-                    } else {
-                        // Units were specified
-                        val memUnit:String = memUnits(0).toLowerCase
-                        val nBytes: Double = memUnit match {
-                            case "b" => x
-                            case "kb" => x * 1000d
-                            case "mb" => x * 1000d * 1000d
-                            case "gb" => x * 1000d * 1000d * 1000d
-                            case "tb" => x * 1000d * 1000d * 1000d * 1000d
-                            case "kib" => x * 1024d
-                            case "mib" => x * 1024d * 1024d
-                            case "gib" => x * 1024d * 1024d * 1024d
-                            case "tib" => x * 1024d * 1024d * 1024d * 1024d
-                            case _ => throw new Exception(s"Unknown memory unit ${memUnit}")
-                        }
-                        nBytes.toDouble
-                    }
-                val memMib : Double = memBytes / (1024 * 1024).toDouble
-                Some(memMib.toInt)
-            case Some(x) =>
-                throw new Exception(s"Memory has to evaluate to a WomString type ${x.toWomString}")
-        }
-
-        // Examples: "local-disk 1024 HDD"
-        val diskGB: Option[Int] = wdlDiskGB match {
-            case None => None
-            case Some(WomString(buf)) =>
-                val components = buf.split("\\s+")
-                val ignoreWords = Set("local-disk", "hdd", "sdd", "ssd")
-                val l = components.filter(x => !(ignoreWords contains x.toLowerCase))
-                if (l.length != 1)
-                    throw new Exception(s"Can't parse disk space specification ${buf}")
-                val i = try { l(0).toInt } catch {
-                    case e: Throwable =>
-                        throw new Exception(s"Parse error for diskSpace attribute ${buf}")
-                }
-                Some(i)
-            case Some(x) =>
-                throw new Exception(s"Disk space has to evaluate to a WomString type ${x.toWomString}")
-        }
-
-        // Examples: "1", "12"
-        val cpu: Option[Int] = wdlCpu match {
-            case None => None
-            case Some(WomString(buf)) =>
-                val i:Int = try { buf.toInt } catch {
-                    case e: Throwable =>
-                        throw new Exception(s"Parse error for cpu specification ${buf}")
-                }
-                Some(i)
-            case Some(WomInteger(i)) => Some(i)
-            case Some(WomFloat(x)) => Some(x.toInt)
-            case Some(x) => throw new Exception(s"Cpu has to evaluate to a numeric value ${x}")
-        }
-
-        val gpu : Option[Boolean] = wdlGpu match {
-            case None => None
-            case Some(WomBoolean(flag)) => Some(flag)
-            case Some(x) => throw new Exception(s"Gpu has to be a boolean ${x}")
-        }
-
-        return InstanceTypeReq(None, memoryMB, diskGB, cpu, gpu)
+  // Currently, we support only constants.
+  def parse(
+      dxInstanceType: Option[WomValue],
+      wdlMemoryMB: Option[WomValue],
+      wdlDiskGB: Option[WomValue],
+      wdlCpu: Option[WomValue],
+      wdlGpu: Option[WomValue]
+  ): InstanceTypeReq = {
+    // Shortcut the entire calculation, and provide the dx instance type directly
+    dxInstanceType match {
+      case None => None
+      case Some(WomString(iType)) =>
+        return InstanceTypeReq(Some(iType), None, None, None, None)
+      case Some(x) =>
+        throw new Exception(
+          s"""|dxInstaceType has to evaluate to a
+                                        |WomString type ${x.toWomString}""".stripMargin
+            .replaceAll("\n", " ")
+        )
     }
 
-    // Extract an integer fields from a JsObject
-    private def getJsIntField(js: JsValue, fieldName:String) : Int = {
-        js.asJsObject.fields.get(fieldName) match {
-            case Some(JsNumber(x)) => x.toInt
-            case Some(JsString(x)) => x.toInt
-            case _ => throw new Exception(s"Missing field ${fieldName} in JSON ${js.prettyPrint}}")
-        }
-    }
-
-    private def getJsStringField(js: JsValue, fieldName:String) : String = {
-        js.asJsObject.fields.get(fieldName) match {
-            case Some(JsNumber(x)) => x.toString
-            case Some(JsString(x)) => x
-            case _ => throw new Exception(s"Missing field ${fieldName} in JSON ${js.prettyPrint}}")
-        }
-    }
-
-    private def getJsField(js: JsValue, fieldName: String) : JsValue = {
-        js.asJsObject.fields.get(fieldName) match {
-            case Some(x:JsValue) => x
-            case None => throw new Exception(s"Missing field ${fieldName} in ${js.prettyPrint}")
-        }
-    }
-
-    // Query the platform for the available instance types in
-    // this project.
-    private def queryAvailableInstanceTypes(dxProject: DxProject) : Map[String, DxInstanceType] = {
-        // get List of supported OSes
-        def getSupportedOSes(js: JsValue) : Vector[(String, String)]= {
-            val osSupported:Vector[JsValue] = js.asJsObject.fields.get("os") match {
-                case Some(JsArray(x)) => x
-                case _ => throw new Exception(s"Missing field os in JSON ${js.prettyPrint}")
-            }
-            osSupported.map{ elem =>
-                val distribution = getJsStringField(elem, "distribution")
-                val release = getJsStringField(elem, "release")
-                distribution -> release
-            }.toVector
-        }
-
-        val availableField = "availableInstanceTypes"
-        val req: ObjectNode = DXJSON.getObjectBuilder()
-            .put("fields",
-                 DXJSON.getObjectBuilder().put(availableField, true)
-                     .build())
-            .build()
-        val rep = DXAPI.projectDescribe(dxProject.id, req, classOf[JsonNode])
-        val repJs:JsValue = DxUtils.jsValueOfJsonNode(rep)
-        val availableInstanceTypes:JsValue =
-            repJs.asJsObject.fields.get(availableField) match {
-                case Some(x) => x
-                case None => throw new Exception(
-                    s"Field ${availableField} is missing ${repJs.prettyPrint}")
-            }
-
-        // convert to a list of DxInstanceTypes, with prices set to zero
-        availableInstanceTypes.asJsObject.fields.map{ case (iName, jsValue) =>
-            val numCores = getJsIntField(jsValue, "numCores")
-            val memoryMB = getJsIntField(jsValue, "totalMemoryMB")
-            val diskSpaceGB = getJsIntField(jsValue, "ephemeralStorageGB")
-            val os = getSupportedOSes(jsValue)
-            val gpu = iName contains "_gpu"
-            val dxInstanceType = DxInstanceType(iName, memoryMB, diskSpaceGB, numCores, 0, os, gpu)
-            iName -> dxInstanceType
-        }.toMap
-    }
-
-    // Get the mapping from instance type to price, limited to the
-    // project we are in. Describing a user requires permission to
-    // view the user account. The compiler may not have these
-    // permissions, causing this method to throw an exception.
-    private def getPricingModel(billTo:String,
-                                region:String) : Map[String, Float] = {
-        val req: ObjectNode = DXJSON.getObjectBuilder()
-            .put("fields",
-                 DXJSON.getObjectBuilder().put("pricingModelsByRegion", true)
-                     .build())
-            .build()
-
-        val rep = try {
-            DXAPI.userDescribe(billTo, req, classOf[JsonNode])
-        } catch {
+    // Examples for memory specification: "4000 MB", "1 GB"
+    val memoryMB: Option[Int] = wdlMemoryMB match {
+      case None                 => None
+      case Some(WomString(buf)) =>
+        // extract number
+        val numRex  = """(\d+\.?\d*)""".r
+        val numbers = numRex.findAllIn(buf).toList
+        if (numbers.length != 1)
+          throw new Exception(s"Can not parse memory specification ${buf}")
+        val number: String = numbers(0)
+        val x: Double =
+          try {
+            number.toDouble
+          } catch {
             case e: Throwable =>
-                throw new Exception("Insufficient permissions")
-        }
+              throw new Exception(s"Unrecognized number ${number}")
+          }
 
-        val js: JsValue = DxUtils.jsValueOfJsonNode(rep)
-        val pricingModelsByRegion = getJsField(js, "pricingModelsByRegion")
-        val pricingModel = getJsField(pricingModelsByRegion, region)
-        val computeRatesPerHour = getJsField(pricingModel, "computeRatesPerHour")
-
-        // convert from JsValue to a Map
-        computeRatesPerHour.asJsObject.fields.map{ case (key, jsValue) =>
-            val hourlyRate:Float = jsValue match {
-                case JsNumber(x) => x.toFloat
-                case JsString(x) => x.toFloat
-                case _ => throw new Exception(s"compute rate is not a number ${jsValue.prettyPrint}")
+        // extract memory units
+        val memUnitRex = """([a-zA-Z]+)""".r
+        val memUnits   = memUnitRex.findAllIn(buf).toList
+        if (memUnits.length > 1)
+          throw new Exception(s"Can not parse memory specification ${buf}")
+        val memBytes: Double =
+          if (memUnits.isEmpty) {
+            // specification is in bytes, convert to megabytes
+            x.toInt
+          } else {
+            // Units were specified
+            val memUnit: String = memUnits(0).toLowerCase
+            val nBytes: Double = memUnit match {
+              case "b"   => x
+              case "kb"  => x * 1000d
+              case "mb"  => x * 1000d * 1000d
+              case "gb"  => x * 1000d * 1000d * 1000d
+              case "tb"  => x * 1000d * 1000d * 1000d * 1000d
+              case "kib" => x * 1024d
+              case "mib" => x * 1024d * 1024d
+              case "gib" => x * 1024d * 1024d * 1024d
+              case "tib" => x * 1024d * 1024d * 1024d * 1024d
+              case _     => throw new Exception(s"Unknown memory unit ${memUnit}")
             }
-            key -> hourlyRate
-        }.toMap
+            nBytes.toDouble
+          }
+        val memMib: Double = memBytes / (1024 * 1024).toDouble
+        Some(memMib.toInt)
+      case Some(x) =>
+        throw new Exception(s"Memory has to evaluate to a WomString type ${x.toWomString}")
     }
 
-    private def crossTables(availableIT: Map[String, DxInstanceType],
-                            pm: Map[String, Float]): Vector[DxInstanceType] = {
-        pm.map{ case (iName, hourlyRate) =>
-            availableIT.get(iName) match {
-                case None => None
-                case Some(iType) =>
-                    Some(DxInstanceType(iName, iType.memoryMB, iType.diskGB,
-                                        iType.cpu, hourlyRate, iType.os, iType.gpu))
-            }
-        }.flatten.toVector
-    }
-
-    // Check if an instance type passes some basic criteria:
-    // - Instance must support Ubuntu 16.04.
-    // - Instance is not an FPGA instance.
-    // - Instance does not have local HDD storage, this
-    //   means it is really old hardware.
-    private def instanceCriteria(iType: DxInstanceType) : Boolean = {
-        val osSupported = iType.os.foldLeft(false) {
-            case (accu, (distribution, release)) =>
-                if (release == "16.04")
-                    true
-                else
-                    accu
-        }
-        if (!osSupported)
-            return false
-        if (iType.name contains "fpga")
-            return false
-        if (iType.name contains "hdd")
-            return false
-        return true
-    }
-
-    private def queryNoPrices(dxProject: DxProject) : InstanceTypeDB = {
-        // Figure out the available instances by describing the project
-        val allAvailableIT = queryAvailableInstanceTypes(dxProject)
-
-        // filter out instances that we cannot use
-        val iTypes: Vector[DxInstanceType] = allAvailableIT
-            .filter{ case (iName,traits) => instanceCriteria(traits) }
-            .map{ case (_,traits) => traits}
-            .toVector
-        InstanceTypeDB(false, iTypes)
-    }
-
-    private def queryWithPrices(dxProject: DxProject) : InstanceTypeDB = {
-        // Figure out the available instances by describing the project
-        val allAvailableIT = queryAvailableInstanceTypes(dxProject)
-
-        // get billTo and region from the project
-        val (billTo, region) = DxUtils.projectDescribeExtraInfo(dxProject)
-
-        // get the pricing model
-        val pm = getPricingModel(billTo, region)
-
-        // Create fully formed instance types by crossing the tables
-        val availableInstanceTypes: Vector[DxInstanceType] = crossTables(allAvailableIT, pm)
-
-        // filter out instances that we cannot use
-        val iTypes: Vector[DxInstanceType] = availableInstanceTypes.filter(instanceCriteria)
-        InstanceTypeDB(true, iTypes)
-    }
-
-    def query(dxProject: DxProject, verbose:Verbose) : InstanceTypeDB = {
-        try {
-            queryWithPrices(dxProject)
-        } catch {
-            // Insufficient permissions to describe the user, we cannot get the price list.
+    // Examples: "local-disk 1024 HDD"
+    val diskGB: Option[Int] = wdlDiskGB match {
+      case None => None
+      case Some(WomString(buf)) =>
+        val components  = buf.split("\\s+")
+        val ignoreWords = Set("local-disk", "hdd", "sdd", "ssd")
+        val l           = components.filter(x => !(ignoreWords contains x.toLowerCase))
+        if (l.length != 1)
+          throw new Exception(s"Can't parse disk space specification ${buf}")
+        val i =
+          try {
+            l(0).toInt
+          } catch {
             case e: Throwable =>
-                Utils.warning(verbose, """|Warning: insufficient permissions to retrieve the
+              throw new Exception(s"Parse error for diskSpace attribute ${buf}")
+          }
+        Some(i)
+      case Some(x) =>
+        throw new Exception(s"Disk space has to evaluate to a WomString type ${x.toWomString}")
+    }
+
+    // Examples: "1", "12"
+    val cpu: Option[Int] = wdlCpu match {
+      case None => None
+      case Some(WomString(buf)) =>
+        val i: Int =
+          try {
+            buf.toInt
+          } catch {
+            case e: Throwable =>
+              throw new Exception(s"Parse error for cpu specification ${buf}")
+          }
+        Some(i)
+      case Some(WomInteger(i)) => Some(i)
+      case Some(WomFloat(x))   => Some(x.toInt)
+      case Some(x)             => throw new Exception(s"Cpu has to evaluate to a numeric value ${x}")
+    }
+
+    val gpu: Option[Boolean] = wdlGpu match {
+      case None                   => None
+      case Some(WomBoolean(flag)) => Some(flag)
+      case Some(x)                => throw new Exception(s"Gpu has to be a boolean ${x}")
+    }
+
+    return InstanceTypeReq(None, memoryMB, diskGB, cpu, gpu)
+  }
+
+  // Extract an integer fields from a JsObject
+  private def getJsIntField(js: JsValue, fieldName: String): Int = {
+    js.asJsObject.fields.get(fieldName) match {
+      case Some(JsNumber(x)) => x.toInt
+      case Some(JsString(x)) => x.toInt
+      case _                 => throw new Exception(s"Missing field ${fieldName} in JSON ${js.prettyPrint}}")
+    }
+  }
+
+  private def getJsStringField(js: JsValue, fieldName: String): String = {
+    js.asJsObject.fields.get(fieldName) match {
+      case Some(JsNumber(x)) => x.toString
+      case Some(JsString(x)) => x
+      case _                 => throw new Exception(s"Missing field ${fieldName} in JSON ${js.prettyPrint}}")
+    }
+  }
+
+  private def getJsField(js: JsValue, fieldName: String): JsValue = {
+    js.asJsObject.fields.get(fieldName) match {
+      case Some(x: JsValue) => x
+      case None             => throw new Exception(s"Missing field ${fieldName} in ${js.prettyPrint}")
+    }
+  }
+
+  // Query the platform for the available instance types in
+  // this project.
+  private def queryAvailableInstanceTypes(dxProject: DxProject): Map[String, DxInstanceType] = {
+    // get List of supported OSes
+    def getSupportedOSes(js: JsValue): Vector[(String, String)] = {
+      val osSupported: Vector[JsValue] = js.asJsObject.fields.get("os") match {
+        case Some(JsArray(x)) => x
+        case _                => throw new Exception(s"Missing field os in JSON ${js.prettyPrint}")
+      }
+      osSupported.map { elem =>
+        val distribution = getJsStringField(elem, "distribution")
+        val release      = getJsStringField(elem, "release")
+        distribution -> release
+      }.toVector
+    }
+
+    val availableField = "availableInstanceTypes"
+    val req: ObjectNode = DXJSON
+      .getObjectBuilder()
+      .put(
+        "fields",
+        DXJSON
+          .getObjectBuilder()
+          .put(availableField, true)
+          .build()
+      )
+      .build()
+    val rep            = DXAPI.projectDescribe(dxProject.id, req, classOf[JsonNode])
+    val repJs: JsValue = DxUtils.jsValueOfJsonNode(rep)
+    val availableInstanceTypes: JsValue =
+      repJs.asJsObject.fields.get(availableField) match {
+        case Some(x) => x
+        case None    => throw new Exception(s"Field ${availableField} is missing ${repJs.prettyPrint}")
+      }
+
+    // convert to a list of DxInstanceTypes, with prices set to zero
+    availableInstanceTypes.asJsObject.fields.map {
+      case (iName, jsValue) =>
+        val numCores       = getJsIntField(jsValue, "numCores")
+        val memoryMB       = getJsIntField(jsValue, "totalMemoryMB")
+        val diskSpaceGB    = getJsIntField(jsValue, "ephemeralStorageGB")
+        val os             = getSupportedOSes(jsValue)
+        val gpu            = iName contains "_gpu"
+        val dxInstanceType = DxInstanceType(iName, memoryMB, diskSpaceGB, numCores, 0, os, gpu)
+        iName -> dxInstanceType
+    }.toMap
+  }
+
+  // Get the mapping from instance type to price, limited to the
+  // project we are in. Describing a user requires permission to
+  // view the user account. The compiler may not have these
+  // permissions, causing this method to throw an exception.
+  private def getPricingModel(billTo: String, region: String): Map[String, Float] = {
+    val req: ObjectNode = DXJSON
+      .getObjectBuilder()
+      .put(
+        "fields",
+        DXJSON
+          .getObjectBuilder()
+          .put("pricingModelsByRegion", true)
+          .build()
+      )
+      .build()
+
+    val rep =
+      try {
+        DXAPI.userDescribe(billTo, req, classOf[JsonNode])
+      } catch {
+        case e: Throwable =>
+          throw new Exception("Insufficient permissions")
+      }
+
+    val js: JsValue           = DxUtils.jsValueOfJsonNode(rep)
+    val pricingModelsByRegion = getJsField(js, "pricingModelsByRegion")
+    val pricingModel          = getJsField(pricingModelsByRegion, region)
+    val computeRatesPerHour   = getJsField(pricingModel, "computeRatesPerHour")
+
+    // convert from JsValue to a Map
+    computeRatesPerHour.asJsObject.fields.map {
+      case (key, jsValue) =>
+        val hourlyRate: Float = jsValue match {
+          case JsNumber(x) => x.toFloat
+          case JsString(x) => x.toFloat
+          case _           => throw new Exception(s"compute rate is not a number ${jsValue.prettyPrint}")
+        }
+        key -> hourlyRate
+    }.toMap
+  }
+
+  private def crossTables(
+      availableIT: Map[String, DxInstanceType],
+      pm: Map[String, Float]
+  ): Vector[DxInstanceType] = {
+    pm.map {
+        case (iName, hourlyRate) =>
+          availableIT.get(iName) match {
+            case None => None
+            case Some(iType) =>
+              Some(
+                DxInstanceType(
+                  iName,
+                  iType.memoryMB,
+                  iType.diskGB,
+                  iType.cpu,
+                  hourlyRate,
+                  iType.os,
+                  iType.gpu
+                )
+              )
+          }
+      }
+      .flatten
+      .toVector
+  }
+
+  // Check if an instance type passes some basic criteria:
+  // - Instance must support Ubuntu 16.04.
+  // - Instance is not an FPGA instance.
+  // - Instance does not have local HDD storage, this
+  //   means it is really old hardware.
+  private def instanceCriteria(iType: DxInstanceType): Boolean = {
+    val osSupported = iType.os.foldLeft(false) {
+      case (accu, (distribution, release)) =>
+        if (release == "16.04")
+          true
+        else
+          accu
+    }
+    if (!osSupported)
+      return false
+    if (iType.name contains "fpga")
+      return false
+    if (iType.name contains "hdd")
+      return false
+    return true
+  }
+
+  private def queryNoPrices(dxProject: DxProject): InstanceTypeDB = {
+    // Figure out the available instances by describing the project
+    val allAvailableIT = queryAvailableInstanceTypes(dxProject)
+
+    // filter out instances that we cannot use
+    val iTypes: Vector[DxInstanceType] = allAvailableIT
+      .filter { case (iName, traits) => instanceCriteria(traits) }
+      .map { case (_, traits) => traits }
+      .toVector
+    InstanceTypeDB(false, iTypes)
+  }
+
+  private def queryWithPrices(dxProject: DxProject): InstanceTypeDB = {
+    // Figure out the available instances by describing the project
+    val allAvailableIT = queryAvailableInstanceTypes(dxProject)
+
+    // get billTo and region from the project
+    val (billTo, region) = DxUtils.projectDescribeExtraInfo(dxProject)
+
+    // get the pricing model
+    val pm = getPricingModel(billTo, region)
+
+    // Create fully formed instance types by crossing the tables
+    val availableInstanceTypes: Vector[DxInstanceType] = crossTables(allAvailableIT, pm)
+
+    // filter out instances that we cannot use
+    val iTypes: Vector[DxInstanceType] = availableInstanceTypes.filter(instanceCriteria)
+    InstanceTypeDB(true, iTypes)
+  }
+
+  def query(dxProject: DxProject, verbose: Verbose): InstanceTypeDB = {
+    try {
+      queryWithPrices(dxProject)
+    } catch {
+      // Insufficient permissions to describe the user, we cannot get the price list.
+      case e: Throwable =>
+        Utils.warning(
+          verbose,
+          """|Warning: insufficient permissions to retrieve the
                                           |instance price list. This will result in suboptimal machine choices,
                                           |incurring higher costs when running workflows.
-                                          |""".stripMargin.replaceAll("\n", " "))
-                queryNoPrices(dxProject)
-        }
+                                          |""".stripMargin.replaceAll("\n", " ")
+        )
+        queryNoPrices(dxProject)
     }
+  }
 
-    // Remove exact price information. For example,
-    // if the price list is:
-    //   mem1_ssd1_x2:  0.04$
-    //   mem1_ssd1_x4:  0.08$
-    //   mem3_ssd1_x8:  1.05$
-    // convert it into:
-    //   mem1_ssd1_x2:  1$
-    //   mem1_ssd1_x4:  2$
-    //   mem3_ssd1_x8:  3$
-    //
-    // This is useful when exporting the price list to an applet, which can be reverse
-    // engineered. We do not want to risk disclosing the real price list. Leaking the
-    // relative ordering of instances, but not actual prices, is considered ok.
-    def opaquePrices(db: InstanceTypeDB) : InstanceTypeDB = {
-        if (db.instances.isEmpty)
-            return db
-        // check if there is no pricing information
-        if (!db.pricingAvailable)
-            return db
+  // Remove exact price information. For example,
+  // if the price list is:
+  //   mem1_ssd1_x2:  0.04$
+  //   mem1_ssd1_x4:  0.08$
+  //   mem3_ssd1_x8:  1.05$
+  // convert it into:
+  //   mem1_ssd1_x2:  1$
+  //   mem1_ssd1_x4:  2$
+  //   mem3_ssd1_x8:  3$
+  //
+  // This is useful when exporting the price list to an applet, which can be reverse
+  // engineered. We do not want to risk disclosing the real price list. Leaking the
+  // relative ordering of instances, but not actual prices, is considered ok.
+  def opaquePrices(db: InstanceTypeDB): InstanceTypeDB = {
+    if (db.instances.isEmpty)
+      return db
+    // check if there is no pricing information
+    if (!db.pricingAvailable)
+      return db
 
-        // sort the prices from low to high, and then replace
-        // with rank.
-        var crnt_price = 0
-        val sortedInstances = db.instances.sortWith(_.price < _.price)
-        val opaque = sortedInstances.map{ it =>
-            crnt_price += 1
-            it.copy(price = crnt_price)
-        }
-        InstanceTypeDB(true, opaque)
+    // sort the prices from low to high, and then replace
+    // with rank.
+    var crnt_price      = 0
+    val sortedInstances = db.instances.sortWith(_.price < _.price)
+    val opaque = sortedInstances.map { it =>
+      crnt_price += 1
+      it.copy(price = crnt_price)
     }
+    InstanceTypeDB(true, opaque)
+  }
 }

--- a/src/main/scala/dxWDL/util/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/util/InstanceTypeDB.scala
@@ -185,9 +185,9 @@ case class InstanceTypeDB(
       instances.filter(x => x.satisfies(memoryMB, diskGB, cpu, gpu))
     if (sufficient.length == 0)
       throw new Exception(
-        s"""|No instances found that match the requirements
+          s"""|No instances found that match the requirements
                                     |memory=$memoryMB, diskGB=$diskGB, cpu=$cpu""".stripMargin
-          .replaceAll("\n", " ")
+            .replaceAll("\n", " ")
       )
     val initialGuess = sufficient.head
     val bestInstance = sufficient.tail.foldLeft(initialGuess) {
@@ -208,9 +208,9 @@ case class InstanceTypeDB(
       case None =>
         // Probably a bad instance name
         throw new Exception(
-          s"""|Instance type ${iType} is unavailable
+            s"""|Instance type ${iType} is unavailable
                                         |or badly named""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
   }
@@ -297,9 +297,9 @@ object InstanceTypeDB extends DefaultJsonProtocol {
         return InstanceTypeReq(Some(iType), None, None, None, None)
       case Some(x) =>
         throw new Exception(
-          s"""|dxInstaceType has to evaluate to a
+            s"""|dxInstaceType has to evaluate to a
                                         |WomString type ${x.toWomString}""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
 
@@ -351,7 +351,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
         Some(memMib.toInt)
       case Some(x) =>
         throw new Exception(
-          s"Memory has to evaluate to a WomString type ${x.toWomString}"
+            s"Memory has to evaluate to a WomString type ${x.toWomString}"
         )
     }
 
@@ -374,7 +374,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
         Some(i)
       case Some(x) =>
         throw new Exception(
-          s"Disk space has to evaluate to a WomString type ${x.toWomString}"
+            s"Disk space has to evaluate to a WomString type ${x.toWomString}"
         )
     }
 
@@ -412,7 +412,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
       case Some(JsString(x)) => x.toInt
       case _ =>
         throw new Exception(
-          s"Missing field ${fieldName} in JSON ${js.prettyPrint}}"
+            s"Missing field ${fieldName} in JSON ${js.prettyPrint}}"
         )
     }
   }
@@ -423,7 +423,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
       case Some(JsString(x)) => x
       case _ =>
         throw new Exception(
-          s"Missing field ${fieldName} in JSON ${js.prettyPrint}}"
+            s"Missing field ${fieldName} in JSON ${js.prettyPrint}}"
         )
     }
   }
@@ -459,11 +459,11 @@ object InstanceTypeDB extends DefaultJsonProtocol {
     val req: ObjectNode = DXJSON
       .getObjectBuilder()
       .put(
-        "fields",
-        DXJSON
-          .getObjectBuilder()
-          .put(availableField, true)
-          .build()
+          "fields",
+          DXJSON
+            .getObjectBuilder()
+            .put(availableField, true)
+            .build()
       )
       .build()
     val rep = DXAPI.projectDescribe(dxProject.id, req, classOf[JsonNode])
@@ -473,7 +473,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
         case Some(x) => x
         case None =>
           throw new Exception(
-            s"Field ${availableField} is missing ${repJs.prettyPrint}"
+              s"Field ${availableField} is missing ${repJs.prettyPrint}"
           )
       }
 
@@ -502,11 +502,11 @@ object InstanceTypeDB extends DefaultJsonProtocol {
     val req: ObjectNode = DXJSON
       .getObjectBuilder()
       .put(
-        "fields",
-        DXJSON
-          .getObjectBuilder()
-          .put("pricingModelsByRegion", true)
-          .build()
+          "fields",
+          DXJSON
+            .getObjectBuilder()
+            .put("pricingModelsByRegion", true)
+            .build()
       )
       .build()
 
@@ -531,7 +531,7 @@ object InstanceTypeDB extends DefaultJsonProtocol {
           case JsString(x) => x.toFloat
           case _ =>
             throw new Exception(
-              s"compute rate is not a number ${jsValue.prettyPrint}"
+                s"compute rate is not a number ${jsValue.prettyPrint}"
             )
         }
         key -> hourlyRate
@@ -548,15 +548,15 @@ object InstanceTypeDB extends DefaultJsonProtocol {
             case None => None
             case Some(iType) =>
               Some(
-                DxInstanceType(
-                  iName,
-                  iType.memoryMB,
-                  iType.diskGB,
-                  iType.cpu,
-                  hourlyRate,
-                  iType.os,
-                  iType.gpu
-                )
+                  DxInstanceType(
+                      iName,
+                      iType.memoryMB,
+                      iType.diskGB,
+                      iType.cpu,
+                      hourlyRate,
+                      iType.os,
+                      iType.gpu
+                  )
               )
           }
       }
@@ -625,8 +625,8 @@ object InstanceTypeDB extends DefaultJsonProtocol {
       // Insufficient permissions to describe the user, we cannot get the price list.
       case e: Throwable =>
         Utils.warning(
-          verbose,
-          """|Warning: insufficient permissions to retrieve the
+            verbose,
+            """|Warning: insufficient permissions to retrieve the
                                           |instance price list. This will result in suboptimal machine choices,
                                           |incurring higher costs when running workflows.
                                           |""".stripMargin.replaceAll("\n", " ")

--- a/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
+++ b/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
@@ -1,6 +1,5 @@
 package dxWDL.util
 
-
 import cats.data.Validated.{Invalid, Valid}
 import common.Checked
 import common.transforms.CheckedAtoB
@@ -30,431 +29,441 @@ import dxWDL.base.{Language, Utils}
 // Read, parse, and typecheck a WDL/CWL source file. This includes loading all imported files.
 case class ParseWomSourceFile(verbose: Boolean) {
 
-    // allSources: A mapping from file URL to file source.
-    //
-    // Record all files accessed while traversing imports. We wrap
-    // the Cromwell importers, and write down every new file.
-    //
-    case class FileRecorderResolver(
-        allSources: HashMap[String, WorkflowSource],
-        lower: ImportResolver) extends ImportResolver {
+  // allSources: A mapping from file URL to file source.
+  //
+  // Record all files accessed while traversing imports. We wrap
+  // the Cromwell importers, and write down every new file.
+  //
+  case class FileRecorderResolver(
+      allSources: HashMap[String, WorkflowSource],
+      lower: ImportResolver
+  ) extends ImportResolver {
 
-        def name = lower.name
+    def name = lower.name
 
-        protected def innerResolver(path: String,
-                                    currentResolvers: List[ImportResolver])
-                : Checked[ResolvedImportBundle] = ???
+    protected def innerResolver(
+        path: String,
+        currentResolvers: List[ImportResolver]
+    ): Checked[ResolvedImportBundle] = ???
 
-        override def resolver: CheckedAtoB[ImportResolutionRequest, ResolvedImportBundle] = {
-            CheckedAtoB.fromErrorOr {
-                case request : ImportResolutionRequest =>
-                    val path = request.toResolve
-                    val bundleChk: Checked[ResolvedImportBundle] = lower.resolver(request)
-                    bundleChk match {
-                        case Left(errors) =>
-                            Invalid(errors)
-                        case Right(bundle) =>
-                            val fileContent = bundle.source
-                            // convert an 'EitherOr' to 'Validated'
-                            allSources.get(path) match {
-                                case None =>
-                                    allSources(path) = fileContent
-                                case Some(oldContent) if oldContent != fileContent =>
-                                    Invalid(s"${path} has been imported twice, with different content")
-                                case _ => ()
-                            }
-                            Valid(bundle)
-                    }
-            }
-        }
-
-        override def cleanupIfNecessary(): ErrorOr[Unit] = ???
-
-        override def hashKey: ErrorOr[String] = ???
-    }
-
-    private def fileRecorder(allSources: HashMap[String, WorkflowSource],
-                             resolver: ImportResolver) : ImportResolver =
-        new FileRecorderResolver(allSources, resolver)
-
-    // Figure out which language variant is used in the source code. WDL/CWL, and
-    // which version.
-    private def getLanguageFactory(wfSource : String) : LanguageFactory = {
-        val langPossibilties = List(
-            new WdlDraft3LanguageFactory(ConfigFactory.empty()),
-            new WdlBiscayneLanguageFactory(ConfigFactory.empty()),
-            new CwlV1_0LanguageFactory(ConfigFactory.empty()))
-
-        langPossibilties
-            .find(_.looksParsable(wfSource))
-            .getOrElse(new WdlDraft2LanguageFactory(ConfigFactory.empty()))
-    }
-
-    private def getBundle(mainFile: Path,
-                          imports: List[Path]): (Language.Value,
-                                                 WomBundle,
-                                                 Map[String, WorkflowSource],
-                                                 Vector[WomBundle]) = {
-        // Resolves for:
-        // - Where we run from
-        // - Where the file is
-        val allSources =  HashMap.empty[String, WorkflowSource]
-
-        val absPath = Paths.get(mainFile.toAbsolutePath.toString)
-        val mainFileContents = Files.readAllLines(absPath).asScala.mkString(System.lineSeparator())
-
-        // We need to get all the WDL sources, so we could analyze them
-        val mainFileResolvers =
-            DirectoryResolver.localFilesystemResolvers(Some(DefaultPathBuilder.build(mainFile)))
-
-        // look for source files in each of the import directories
-        val fileImportResolvers : List[ImportResolver] = imports.map{ p =>
-            val p2 : cromwell.core.path.Path = DefaultPathBuilder.build(p.toAbsolutePath)
-            DirectoryResolver(p2,
-                              customName = None,
-                              deleteOnClose = false,
-                              directoryHash = None)
-        }
-        val importResolvers: List[ImportResolver] =
-            mainFileResolvers ++ fileImportResolvers :+ HttpResolver(relativeTo = None)
-
-        // Allow http addresses when importing
-        val importResolversRecorded: List[ImportResolver] =
-            importResolvers.map{ impr => fileRecorder(allSources, impr) }
-
-        val languageFactory = getLanguageFactory(mainFileContents)
-        val bundleChk: Checked[WomBundle] =
-            languageFactory.getWomBundle(mainFileContents,
-                                         None,
-                                         "{}",
-                                         importResolversRecorded,
-                                         List(languageFactory),
-                                         convertNestedScatterToSubworkflow = false)
-
-        val bundle = bundleChk match {
+    override def resolver: CheckedAtoB[ImportResolutionRequest, ResolvedImportBundle] = {
+      CheckedAtoB.fromErrorOr {
+        case request: ImportResolutionRequest =>
+          val path                                     = request.toResolve
+          val bundleChk: Checked[ResolvedImportBundle] = lower.resolver(request)
+          bundleChk match {
             case Left(errors) =>
-                System.out.println("=== WOM file =====")
-                System.out.println(mainFileContents)
-                throw new Exception(s"""|WOM validation errors:
+              Invalid(errors)
+            case Right(bundle) =>
+              val fileContent = bundle.source
+              // convert an 'EitherOr' to 'Validated'
+              allSources.get(path) match {
+                case None =>
+                  allSources(path) = fileContent
+                case Some(oldContent) if oldContent != fileContent =>
+                  Invalid(s"${path} has been imported twice, with different content")
+                case _ => ()
+              }
+              Valid(bundle)
+          }
+      }
+    }
+
+    override def cleanupIfNecessary(): ErrorOr[Unit] = ???
+
+    override def hashKey: ErrorOr[String] = ???
+  }
+
+  private def fileRecorder(
+      allSources: HashMap[String, WorkflowSource],
+      resolver: ImportResolver
+  ): ImportResolver =
+    new FileRecorderResolver(allSources, resolver)
+
+  // Figure out which language variant is used in the source code. WDL/CWL, and
+  // which version.
+  private def getLanguageFactory(wfSource: String): LanguageFactory = {
+    val langPossibilties = List(
+      new WdlDraft3LanguageFactory(ConfigFactory.empty()),
+      new WdlBiscayneLanguageFactory(ConfigFactory.empty()),
+      new CwlV1_0LanguageFactory(ConfigFactory.empty())
+    )
+
+    langPossibilties
+      .find(_.looksParsable(wfSource))
+      .getOrElse(new WdlDraft2LanguageFactory(ConfigFactory.empty()))
+  }
+
+  private def getBundle(
+      mainFile: Path,
+      imports: List[Path]
+  ): (Language.Value, WomBundle, Map[String, WorkflowSource], Vector[WomBundle]) = {
+    // Resolves for:
+    // - Where we run from
+    // - Where the file is
+    val allSources = HashMap.empty[String, WorkflowSource]
+
+    val absPath          = Paths.get(mainFile.toAbsolutePath.toString)
+    val mainFileContents = Files.readAllLines(absPath).asScala.mkString(System.lineSeparator())
+
+    // We need to get all the WDL sources, so we could analyze them
+    val mainFileResolvers =
+      DirectoryResolver.localFilesystemResolvers(Some(DefaultPathBuilder.build(mainFile)))
+
+    // look for source files in each of the import directories
+    val fileImportResolvers: List[ImportResolver] = imports.map { p =>
+      val p2: cromwell.core.path.Path = DefaultPathBuilder.build(p.toAbsolutePath)
+      DirectoryResolver(p2, customName = None, deleteOnClose = false, directoryHash = None)
+    }
+    val importResolvers: List[ImportResolver] =
+      mainFileResolvers ++ fileImportResolvers :+ HttpResolver(relativeTo = None)
+
+    // Allow http addresses when importing
+    val importResolversRecorded: List[ImportResolver] =
+      importResolvers.map { impr =>
+        fileRecorder(allSources, impr)
+      }
+
+    val languageFactory = getLanguageFactory(mainFileContents)
+    val bundleChk: Checked[WomBundle] =
+      languageFactory.getWomBundle(
+        mainFileContents,
+        None,
+        "{}",
+        importResolversRecorded,
+        List(languageFactory),
+        convertNestedScatterToSubworkflow = false
+      )
+
+    val bundle = bundleChk match {
+      case Left(errors) =>
+        System.out.println("=== WOM file =====")
+        System.out.println(mainFileContents)
+        throw new Exception(s"""|WOM validation errors:
                                         | ${errors}
                                         |""".stripMargin)
-            case Right(bundle) => bundle
-        }
-        val lang = (languageFactory.languageName.toLowerCase,
-                    languageFactory.languageVersionName) match {
-            case ("wdl", "draft-2") => Language.WDLvDraft2
-            case ("wdl", "draft-3") => Language.WDLv1_0
-            case ("wdl", "1.0") => Language.WDLv1_0
-            case ("wdl", "development") => Language.WDLv2_0
-            case ("wdl", "Biscayne") => Language.WDLv2_0
-            case ("cwl", "1.0") => Language.CWLv1_0
-            case (l,v) => throw new Exception(s"Unsupported language (${l}) version (${v})")
-        }
+      case Right(bundle) => bundle
+    }
+    val lang =
+      (languageFactory.languageName.toLowerCase, languageFactory.languageVersionName) match {
+        case ("wdl", "draft-2")     => Language.WDLvDraft2
+        case ("wdl", "draft-3")     => Language.WDLv1_0
+        case ("wdl", "1.0")         => Language.WDLv1_0
+        case ("wdl", "development") => Language.WDLv2_0
+        case ("wdl", "Biscayne")    => Language.WDLv2_0
+        case ("cwl", "1.0")         => Language.CWLv1_0
+        case (l, v)                 => throw new Exception(s"Unsupported language (${l}) version (${v})")
+      }
 
-        // build wom bundles for all the referenced files
-        //
-        // We need to do this iteratively, because we may discover new
-        // imports every time we access a WDL file.
-        var subBundles = Map.empty[String, WomBundle]
-        var discoveredNewSources = true
-        while (discoveredNewSources)  {
-            val newSubBundles = allSources.flatMap{
-                case (path, wfSource) if subBundles contains path =>
-                    // we already parsed the wom code in this path
-                    None
-                case (path, wfSource) if !(subBundles contains path) =>
-                    // A new path, not seen before
-                    val bundle =
-                        languageFactory.getWomBundle(wfSource,
-                                                     None,
-                                                     "{}",
-                                                     importResolversRecorded,
-                                                     List(languageFactory),
-                                                     convertNestedScatterToSubworkflow = false) match {
-                            case Left(errors) => throw new Exception(s"""|WOM validation errors:
+    // build wom bundles for all the referenced files
+    //
+    // We need to do this iteratively, because we may discover new
+    // imports every time we access a WDL file.
+    var subBundles           = Map.empty[String, WomBundle]
+    var discoveredNewSources = true
+    while (discoveredNewSources) {
+      val newSubBundles = allSources.flatMap {
+        case (path, wfSource) if subBundles contains path =>
+          // we already parsed the wom code in this path
+          None
+        case (path, wfSource) if !(subBundles contains path) =>
+          // A new path, not seen before
+          val bundle =
+            languageFactory.getWomBundle(
+              wfSource,
+              None,
+              "{}",
+              importResolversRecorded,
+              List(languageFactory),
+              convertNestedScatterToSubworkflow = false
+            ) match {
+              case Left(errors)  => throw new Exception(s"""|WOM validation errors:
                                                                          | ${errors}
                                                                          |""".stripMargin)
-                            case Right(bundle) => bundle
-                        }
-                    Some(path -> bundle)
-            }.toMap
-            subBundles = subBundles ++ newSubBundles
+              case Right(bundle) => bundle
+            }
+          Some(path -> bundle)
+      }.toMap
+      subBundles = subBundles ++ newSubBundles
 
-            // have we discovered new WDL files?
-            val delta = newSubBundles.size
-            discoveredNewSources = !newSubBundles.isEmpty
-            if (delta > 0)
-                Utils.trace(verbose, s"found ${delta} new WDL source files")
-        }
-
-        allSources(mainFile.toString) = mainFileContents
-        (lang, bundle, allSources.toMap, subBundles.values.toVector)
+      // have we discovered new WDL files?
+      val delta = newSubBundles.size
+      discoveredNewSources = !newSubBundles.isEmpty
+      if (delta > 0)
+        Utils.trace(verbose, s"found ${delta} new WDL source files")
     }
 
-    def apply(sourcePath: Path,
-              imports: List[Path]) : (Language.Value,
-                                      WomBundle,
-                                      Map[String, WorkflowSource],
-                                      Vector[WomBundle]) = {
-        val (lang, bundle, allSources, subBundles) = getBundle(sourcePath, imports)
-        lang match {
-            case Language.CWLv1_0 =>
-                throw new Exception("CWL is not handled at the moment, only WDL is supported")
-            case _ => ()
-        }
-        (lang, bundle, allSources, subBundles)
+    allSources(mainFile.toString) = mainFileContents
+    (lang, bundle, allSources.toMap, subBundles.values.toVector)
+  }
+
+  def apply(
+      sourcePath: Path,
+      imports: List[Path]
+  ): (Language.Value, WomBundle, Map[String, WorkflowSource], Vector[WomBundle]) = {
+    val (lang, bundle, allSources, subBundles) = getBundle(sourcePath, imports)
+    lang match {
+      case Language.CWLv1_0 =>
+        throw new Exception("CWL is not handled at the moment, only WDL is supported")
+      case _ => ()
     }
+    (lang, bundle, allSources, subBundles)
+  }
 
+  // Look for the first task in the sequence of lines. If not found, return None.
+  // If found, return the remaining lines, the name of the task, and the WDL source lines.
+  //
+  // Go through the lines, until you find a match for a start-line.
+  // Look for expression that looks like this:
+  //
+  // task NAME {
+  //  ...
+  // }
+  //
+  // A complication is that the inner string could include curly bracket symbols
+  // as well. There needs to be balanced number of left and right brackets. We ignore
+  // this situation, and assume the end task marker is a closed curly bracket at
+  // the beginning of the line. Note that this algorithm will make a mistake in this
+  // case:
+  //
+  // task  NAME {
+  //   Int a
+  // command {
+  //    ls -lR
+  // }
+  // }
+  private def findWdlElement(
+      lines: List[String],
+      elemStartLine: Regex,
+      elemEndLine: Regex
+  ): Option[(List[String], String, String)] = {
+    var remaining: List[String]   = lines
+    var taskLines: Vector[String] = Vector.empty[String]
+    var taskName: Option[String]  = None
 
-    // Look for the first task in the sequence of lines. If not found, return None.
-    // If found, return the remaining lines, the name of the task, and the WDL source lines.
-    //
-    // Go through the lines, until you find a match for a start-line.
-    // Look for expression that looks like this:
-    //
-    // task NAME {
-    //  ...
-    // }
-    //
-    // A complication is that the inner string could include curly bracket symbols
-    // as well. There needs to be balanced number of left and right brackets. We ignore
-    // this situation, and assume the end task marker is a closed curly bracket at
-    // the beginning of the line. Note that this algorithm will make a mistake in this
-    // case:
-    //
-    // task  NAME {
-    //   Int a
-    // command {
-    //    ls -lR
-    // }
-   // }
-    private def findWdlElement(lines: List[String],
-                               elemStartLine : Regex,
-                               elemEndLine : Regex) : Option[(List[String], String, String)] = {
-        var remaining: List[String] = lines
-        var taskLines : Vector[String] = Vector.empty[String]
-        var taskName : Option[String] = None
+    while (!remaining.isEmpty) {
+      // pop the first line
+      val line = remaining.head
+      remaining = remaining.tail
 
-        while (!remaining.isEmpty) {
-            // pop the first line
-            val line = remaining.head
-            remaining = remaining.tail
+      taskName match {
+        case None if (elemStartLine.pattern.matcher(line).matches) =>
+          // hit the beginning of a task
+          taskLines = Vector(line)
 
-            taskName match {
-                case None if (elemStartLine.pattern.matcher(line).matches) =>
-                    // hit the beginning of a task
-                    taskLines = Vector(line)
-
-                    // extract the task name
-                    val allMatches = elemStartLine.findAllMatchIn(line).toList
-                    if (allMatches.size != 1)
-                        throw new Exception(s"""|task definition appears twice in one line
+          // extract the task name
+          val allMatches = elemStartLine.findAllMatchIn(line).toList
+          if (allMatches.size != 1)
+            throw new Exception(s"""|task definition appears twice in one line
                                                 |
                                                 |${line}
                                                 |""".stripMargin)
-                    taskName = Some(allMatches(0).group(3))
-                case None =>
-                    // lines before the task
-                    ()
-                case Some(tn) if (elemEndLine.pattern.matcher(line).matches) =>
-                    // hit the end of the task
-                    taskLines :+= line
-                    return Some((remaining, tn, taskLines.mkString("\n")))
-                case Some(_) =>
-                    // in the middle of a task
-                    taskLines :+= line
-            }
+          taskName = Some(allMatches(0).group(3))
+        case None =>
+          // lines before the task
+          ()
+        case Some(tn) if (elemEndLine.pattern.matcher(line).matches) =>
+          // hit the end of the task
+          taskLines :+= line
+          return Some((remaining, tn, taskLines.mkString("\n")))
+        case Some(_) =>
+          // in the middle of a task
+          taskLines :+= line
+      }
+    }
+    return None
+  }
+
+  private def findNextTask(lines: List[String]): Option[(List[String], String, String)] = {
+    val taskStartLine: Regex = "^(\\s*)task(\\s+)(\\w+)(\\s*)\\{".r
+    val taskEndLine: Regex   = "^}(\\s)*$".r
+    findWdlElement(lines, taskStartLine, taskEndLine)
+  }
+
+  private def findNextWorkflow(lines: List[String]): Option[(List[String], String, String)] = {
+    val workflowStartLine: Regex = "^(\\s*)workflow(\\s+)(\\w+)(\\s*)\\{".r
+    val workflowEndLine: Regex   = "^}(\\s)*$".r
+    findWdlElement(lines, workflowStartLine, workflowEndLine)
+  }
+
+  // Go through one WDL source file, and return a map from task name
+  // to its source code. Return an empty map if there are no tasks
+  // in this file.
+  def scanForTasks(sourceCode: String): Map[String, String] = {
+    var lines   = sourceCode.split("\n").toList
+    val taskDir = HashMap.empty[String, String]
+
+    while (!lines.isEmpty) {
+      val retval = findNextTask(lines)
+
+      // TODO: add a WOM syntax check that this is indeed a task.
+      retval match {
+        case None => return taskDir.toMap
+        case Some((remainingLines, taskName, taskLines)) =>
+          taskDir(taskName) = taskLines
+          lines = remainingLines
+      }
+    }
+    return taskDir.toMap
+  }
+
+  // Go through one WDL source file, and return a map from task name
+  // to its source code. Return an empty map if there are no tasks
+  // in this file.
+  def scanForWorkflow(sourceCode: String): Option[(String, String)] = {
+    val lines = sourceCode.split("\n").toList
+    findNextWorkflow(lines) match {
+      case None =>
+        None
+      case Some((remainingLines, wfName, wfLines)) =>
+        Some((wfName, wfLines))
+    }
+  }
+
+  // Scan the workflow for calls, and return a mapping from call name
+  // to source line number.
+  //
+  // For example, scanning workflow foo
+  //
+  // workflow foo {
+  //   Float x
+  //   call A
+  //   call A as A2
+  // }
+  //
+  // would return : Map(A -> 3, A2 -> 4)
+  //
+  // When a workflow imports other namespaces, the syntax for calls
+  // is NAMESPACE.CALL_NAME. For example:
+  //
+  // import "library.wdl" as lib
+  // workflow foo {
+  //   call lib.Multiply as mul { ... }
+  // }
+  //
+  private def allNodesDoNotDescendIntoSubWorkflows(graph: Graph): Set[GraphNode] = {
+    graph.nodes ++
+      graph.scatters.flatMap(x => allNodesDoNotDescendIntoSubWorkflows(x.innerGraph)) ++
+      graph.conditionals.flatMap(x => allNodesDoNotDescendIntoSubWorkflows(x.innerGraph)) ++
+      graph.workflowCalls
+  }
+
+  def scanForCalls(graph: Graph, wfSource: String): Vector[String] = {
+    val nodes = allNodesDoNotDescendIntoSubWorkflows(graph)
+    val callToSrcLine: Map[String, Int] = nodes.collect {
+      case cNode: CallNode =>
+        val callUnqualifiedName = Utils.getUnqualifiedName(cNode.localName)
+        val lineNum = cNode.sourceLocation match {
+          case None                        => throw new Exception("No source line for call ${cNode}")
+          case Some(SourceFileLocation(x)) => x
         }
-        return None
+        callUnqualifiedName -> lineNum
+    }.toMap
+
+    // sort from low to high according to the source lines.
+    val callsLoToHi: Vector[(String, Int)] = callToSrcLine.toVector.sortBy(_._2)
+    callsLoToHi.map { case (x, _) => x }
+  }
+
+  // throw an exception if the workflow source is not valid WDL 1.0
+  def validateWdlCode(wdlWfSource: String, language: Language.Value): Unit = {
+    val languageFactory = language match {
+      case Language.WDLv2_0 =>
+        new WdlBiscayneLanguageFactory(ConfigFactory.empty())
+      case Language.WDLv1_0 =>
+        new WdlDraft3LanguageFactory(ConfigFactory.empty())
+      case Language.WDLvDraft2 =>
+        new WdlDraft2LanguageFactory(ConfigFactory.empty())
+      case other =>
+        throw new Exception(s"Unsupported language ${other}")
     }
 
-
-    private def findNextTask(lines: List[String]) : Option[(List[String], String, String)] = {
-        val taskStartLine: Regex = "^(\\s*)task(\\s+)(\\w+)(\\s*)\\{".r
-        val taskEndLine: Regex = "^}(\\s)*$".r
-        findWdlElement(lines, taskStartLine, taskEndLine)
-    }
-
-    private def findNextWorkflow(lines: List[String]) : Option[(List[String], String, String)] = {
-        val workflowStartLine: Regex = "^(\\s*)workflow(\\s+)(\\w+)(\\s*)\\{".r
-        val workflowEndLine: Regex = "^}(\\s)*$".r
-        findWdlElement(lines, workflowStartLine, workflowEndLine)
-    }
-
-    // Go through one WDL source file, and return a map from task name
-    // to its source code. Return an empty map if there are no tasks
-    // in this file.
-    def scanForTasks(sourceCode: String) : Map[String, String] = {
-        var lines = sourceCode.split("\n").toList
-        val taskDir = HashMap.empty[String, String]
-
-        while (!lines.isEmpty) {
-            val retval = findNextTask(lines)
-
-            // TODO: add a WOM syntax check that this is indeed a task.
-            retval match {
-                case None => return taskDir.toMap
-                case Some((remainingLines, taskName, taskLines)) =>
-                    taskDir(taskName) = taskLines
-                    lines = remainingLines
-            }
-        }
-        return taskDir.toMap
-    }
-
-    // Go through one WDL source file, and return a map from task name
-    // to its source code. Return an empty map if there are no tasks
-    // in this file.
-    def scanForWorkflow(sourceCode: String) : Option[(String, String)] = {
-        val lines = sourceCode.split("\n").toList
-        findNextWorkflow(lines) match {
-            case None =>
-                None
-            case Some((remainingLines, wfName, wfLines)) =>
-                Some((wfName, wfLines))
-        }
-    }
-
-    // Scan the workflow for calls, and return a mapping from call name
-    // to source line number.
-    //
-    // For example, scanning workflow foo
-    //
-    // workflow foo {
-    //   Float x
-    //   call A
-    //   call A as A2
-    // }
-    //
-    // would return : Map(A -> 3, A2 -> 4)
-    //
-    // When a workflow imports other namespaces, the syntax for calls
-    // is NAMESPACE.CALL_NAME. For example:
-    //
-    // import "library.wdl" as lib
-    // workflow foo {
-    //   call lib.Multiply as mul { ... }
-    // }
-    //
-    private def allNodesDoNotDescendIntoSubWorkflows(graph: Graph): Set[GraphNode] = {
-        graph.nodes ++
-        graph.scatters.flatMap(x => allNodesDoNotDescendIntoSubWorkflows(x.innerGraph)) ++
-        graph.conditionals.flatMap(x => allNodesDoNotDescendIntoSubWorkflows(x.innerGraph)) ++
-        graph.workflowCalls
-    }
-
-    def scanForCalls(graph: Graph,
-                     wfSource: String) : Vector[String] = {
-        val nodes = allNodesDoNotDescendIntoSubWorkflows(graph)
-        val callToSrcLine : Map[String, Int]  = nodes.collect{
-            case cNode : CallNode =>
-                val callUnqualifiedName = Utils.getUnqualifiedName(cNode.localName)
-                val lineNum = cNode.sourceLocation match {
-                    case None => throw new Exception("No source line for call ${cNode}")
-                    case Some(SourceFileLocation(x)) => x
-                }
-                callUnqualifiedName -> lineNum
-        }.toMap
-
-        // sort from low to high according to the source lines.
-        val callsLoToHi : Vector[(String, Int)] = callToSrcLine.toVector.sortBy(_._2)
-        callsLoToHi.map{ case (x,_) => x }
-    }
-
-    // throw an exception if the workflow source is not valid WDL 1.0
-    def validateWdlCode(wdlWfSource: String,
-                        language: Language.Value) : Unit = {
-        val languageFactory = language match {
-            case Language.WDLv2_0 =>
-                new WdlBiscayneLanguageFactory(ConfigFactory.empty())
-            case Language.WDLv1_0 =>
-                new WdlDraft3LanguageFactory(ConfigFactory.empty())
-            case Language.WDLvDraft2 =>
-                new WdlDraft2LanguageFactory(ConfigFactory.empty())
-            case other =>
-                throw new Exception(s"Unsupported language ${other}")
-        }
-
-        val bundleChk: Checked[WomBundle] =
-            languageFactory.getWomBundle(wdlWfSource, None, "{}", List.empty, List.empty, false)
-        bundleChk match {
-            case Left(errors) =>
-                Utils.error("Found Errors in generated WDL source")
-                Utils.error(wdlWfSource + "\n")
-                throw new Exception(s"""|WOM validation errors:
+    val bundleChk: Checked[WomBundle] =
+      languageFactory.getWomBundle(wdlWfSource, None, "{}", List.empty, List.empty, false)
+    bundleChk match {
+      case Left(errors) =>
+        Utils.error("Found Errors in generated WDL source")
+        Utils.error(wdlWfSource + "\n")
+        throw new Exception(s"""|WOM validation errors:
                                         | ${errors}
                                         |""".stripMargin)
-            case Right(bundle) =>
-                // Passed WOM validation
-                ()
-        }
+      case Right(bundle) =>
+        // Passed WOM validation
+        ()
     }
+  }
 
-    // Parse a Workflow source file. Return the:
-    //  * workflow definition
-    //  * directory of tasks
-    //  * directory of type aliases
-    def parseWdlWorkflow(wfSource: String) : (WorkflowDefinition,
-                                              Map[String, CallableTaskDefinition],
-                                              Map[String, WomType])= {
-        val languageFactory = getLanguageFactory(wfSource)
-        val bundleChk: Checked[WomBundle] =
-            languageFactory.getWomBundle(wfSource, None, "{}", List.empty, List(languageFactory),
-                                         convertNestedScatterToSubworkflow = false)
-        val womBundle = bundleChk match {
-            case Left(errors) => throw new Exception(s"""|WOM validation errors:
+  // Parse a Workflow source file. Return the:
+  //  * workflow definition
+  //  * directory of tasks
+  //  * directory of type aliases
+  def parseWdlWorkflow(
+      wfSource: String
+  ): (WorkflowDefinition, Map[String, CallableTaskDefinition], Map[String, WomType]) = {
+    val languageFactory = getLanguageFactory(wfSource)
+    val bundleChk: Checked[WomBundle] =
+      languageFactory.getWomBundle(
+        wfSource,
+        None,
+        "{}",
+        List.empty,
+        List(languageFactory),
+        convertNestedScatterToSubworkflow = false
+      )
+    val womBundle = bundleChk match {
+      case Left(errors)  => throw new Exception(s"""|WOM validation errors:
                                                          | ${errors}
                                                          |""".stripMargin)
-            case Right(bundle) => bundle
-        }
-        val wf = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("Could not find the workflow in the source")
-        }
-        val taskDir = womBundle.allCallables.flatMap{
-            case (name, callable) =>
-                callable match {
-                    case task : CallableTaskDefinition => Some(name -> task)
-                    case exec : ExecutableTaskDefinition => Some(name -> exec.callableTaskDefinition)
-                    case _ => None
-                }
-        }.toMap
-        (wf, taskDir, womBundle.typeAliases)
+      case Right(bundle) => bundle
     }
-
-    // Extract the only task from a namespace
-    def getMainTask(bundle: WomBundle) : CallableTaskDefinition = {
-        // check if the primary is nonempty
-        val task: Option[CallableTaskDefinition] = bundle.primaryCallable match  {
-            case Some(task : CallableTaskDefinition) => Some(task)
-            case Some(exec : ExecutableTaskDefinition) => Some(exec.callableTaskDefinition)
-            case _ => None
+    val wf = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("Could not find the workflow in the source")
+    }
+    val taskDir = womBundle.allCallables.flatMap {
+      case (name, callable) =>
+        callable match {
+          case task: CallableTaskDefinition   => Some(name -> task)
+          case exec: ExecutableTaskDefinition => Some(name -> exec.callableTaskDefinition)
+          case _                              => None
         }
+    }.toMap
+    (wf, taskDir, womBundle.typeAliases)
+  }
+
+  // Extract the only task from a namespace
+  def getMainTask(bundle: WomBundle): CallableTaskDefinition = {
+    // check if the primary is nonempty
+    val task: Option[CallableTaskDefinition] = bundle.primaryCallable match {
+      case Some(task: CallableTaskDefinition)   => Some(task)
+      case Some(exec: ExecutableTaskDefinition) => Some(exec.callableTaskDefinition)
+      case _                                    => None
+    }
+    task match {
+      case Some(x) => x
+      case None    =>
+        // primary is empty, check the allCallables map
+        if (bundle.allCallables.size != 1)
+          throw new Exception("WDL file must contains exactly one task")
+        val (_, task) = bundle.allCallables.head
         task match {
-            case Some(x) => x
-            case None =>
-                // primary is empty, check the allCallables map
-                if (bundle.allCallables.size != 1)
-                    throw new Exception("WDL file must contains exactly one task")
-                val (_, task) = bundle.allCallables.head
-                task match {
-                    case task : CallableTaskDefinition => task
-                    case exec : ExecutableTaskDefinition => exec.callableTaskDefinition
-                    case _ => throw new Exception("Cannot find task inside WDL file")
-                }
+          case task: CallableTaskDefinition   => task
+          case exec: ExecutableTaskDefinition => exec.callableTaskDefinition
+          case _                              => throw new Exception("Cannot find task inside WDL file")
         }
     }
+  }
 
-    def parseWdlTask(wfSource: String) : (CallableTaskDefinition, Map[String, WomType]) = {
-        val languageFactory = getLanguageFactory(wfSource)
-        val bundleChk: Checked[WomBundle] =
-            languageFactory.getWomBundle(wfSource, None, "{}", List.empty, List(languageFactory), false)
-        val womBundle = bundleChk match {
-            case Left(errors) => throw new Exception(s"""|WOM validation errors:
+  def parseWdlTask(wfSource: String): (CallableTaskDefinition, Map[String, WomType]) = {
+    val languageFactory = getLanguageFactory(wfSource)
+    val bundleChk: Checked[WomBundle] =
+      languageFactory.getWomBundle(wfSource, None, "{}", List.empty, List(languageFactory), false)
+    val womBundle = bundleChk match {
+      case Left(errors)  => throw new Exception(s"""|WOM validation errors:
                                                          | ${errors}
                                                          |""".stripMargin)
-            case Right(bundle) => bundle
-        }
-        (getMainTask(womBundle), womBundle.typeAliases)
+      case Right(bundle) => bundle
     }
+    (getMainTask(womBundle), womBundle.typeAliases)
+  }
 }

--- a/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
+++ b/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
@@ -49,7 +49,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     override def resolver: CheckedAtoB[ImportResolutionRequest, ResolvedImportBundle] = {
       CheckedAtoB.fromErrorOr {
         case request: ImportResolutionRequest =>
-          val path                                     = request.toResolve
+          val path = request.toResolve
           val bundleChk: Checked[ResolvedImportBundle] = lower.resolver(request)
           bundleChk match {
             case Left(errors) =>
@@ -103,7 +103,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     // - Where the file is
     val allSources = HashMap.empty[String, WorkflowSource]
 
-    val absPath          = Paths.get(mainFile.toAbsolutePath.toString)
+    val absPath = Paths.get(mainFile.toAbsolutePath.toString)
     val mainFileContents = Files.readAllLines(absPath).asScala.mkString(System.lineSeparator())
 
     // We need to get all the WDL sources, so we could analyze them
@@ -159,7 +159,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     //
     // We need to do this iteratively, because we may discover new
     // imports every time we access a WDL file.
-    var subBundles           = Map.empty[String, WomBundle]
+    var subBundles = Map.empty[String, WomBundle]
     var discoveredNewSources = true
     while (discoveredNewSources) {
       val newSubBundles = allSources.flatMap {
@@ -237,9 +237,9 @@ case class ParseWomSourceFile(verbose: Boolean) {
       elemStartLine: Regex,
       elemEndLine: Regex
   ): Option[(List[String], String, String)] = {
-    var remaining: List[String]   = lines
+    var remaining: List[String] = lines
     var taskLines: Vector[String] = Vector.empty[String]
-    var taskName: Option[String]  = None
+    var taskName: Option[String] = None
 
     while (!remaining.isEmpty) {
       // pop the first line
@@ -276,13 +276,13 @@ case class ParseWomSourceFile(verbose: Boolean) {
 
   private def findNextTask(lines: List[String]): Option[(List[String], String, String)] = {
     val taskStartLine: Regex = "^(\\s*)task(\\s+)(\\w+)(\\s*)\\{".r
-    val taskEndLine: Regex   = "^}(\\s)*$".r
+    val taskEndLine: Regex = "^}(\\s)*$".r
     findWdlElement(lines, taskStartLine, taskEndLine)
   }
 
   private def findNextWorkflow(lines: List[String]): Option[(List[String], String, String)] = {
     val workflowStartLine: Regex = "^(\\s*)workflow(\\s+)(\\w+)(\\s*)\\{".r
-    val workflowEndLine: Regex   = "^}(\\s)*$".r
+    val workflowEndLine: Regex = "^}(\\s)*$".r
     findWdlElement(lines, workflowStartLine, workflowEndLine)
   }
 
@@ -290,7 +290,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
   // to its source code. Return an empty map if there are no tasks
   // in this file.
   def scanForTasks(sourceCode: String): Map[String, String] = {
-    var lines   = sourceCode.split("\n").toList
+    var lines = sourceCode.split("\n").toList
     val taskDir = HashMap.empty[String, String]
 
     while (!lines.isEmpty) {

--- a/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
+++ b/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
@@ -62,7 +62,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
                   allSources(path) = fileContent
                 case Some(oldContent) if oldContent != fileContent =>
                   Invalid(
-                    s"${path} has been imported twice, with different content"
+                      s"${path} has been imported twice, with different content"
                   )
                 case _ => ()
               }
@@ -86,9 +86,9 @@ case class ParseWomSourceFile(verbose: Boolean) {
   // which version.
   private def getLanguageFactory(wfSource: String): LanguageFactory = {
     val langPossibilties = List(
-      new WdlDraft3LanguageFactory(ConfigFactory.empty()),
-      new WdlBiscayneLanguageFactory(ConfigFactory.empty()),
-      new CwlV1_0LanguageFactory(ConfigFactory.empty())
+        new WdlDraft3LanguageFactory(ConfigFactory.empty()),
+        new WdlBiscayneLanguageFactory(ConfigFactory.empty()),
+        new CwlV1_0LanguageFactory(ConfigFactory.empty())
     )
 
     langPossibilties
@@ -117,7 +117,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     // We need to get all the WDL sources, so we could analyze them
     val mainFileResolvers =
       DirectoryResolver.localFilesystemResolvers(
-        Some(DefaultPathBuilder.build(mainFile))
+          Some(DefaultPathBuilder.build(mainFile))
       )
 
     // look for source files in each of the import directories
@@ -125,10 +125,10 @@ case class ParseWomSourceFile(verbose: Boolean) {
       val p2: cromwell.core.path.Path =
         DefaultPathBuilder.build(p.toAbsolutePath)
       DirectoryResolver(
-        p2,
-        customName = None,
-        deleteOnClose = false,
-        directoryHash = None
+          p2,
+          customName = None,
+          deleteOnClose = false,
+          directoryHash = None
       )
     }
     val importResolvers: List[ImportResolver] =
@@ -143,12 +143,12 @@ case class ParseWomSourceFile(verbose: Boolean) {
     val languageFactory = getLanguageFactory(mainFileContents)
     val bundleChk: Checked[WomBundle] =
       languageFactory.getWomBundle(
-        mainFileContents,
-        None,
-        "{}",
-        importResolversRecorded,
-        List(languageFactory),
-        convertNestedScatterToSubworkflow = false
+          mainFileContents,
+          None,
+          "{}",
+          importResolversRecorded,
+          List(languageFactory),
+          convertNestedScatterToSubworkflow = false
       )
 
     val bundle = bundleChk match {
@@ -162,8 +162,8 @@ case class ParseWomSourceFile(verbose: Boolean) {
     }
     val lang =
       (
-        languageFactory.languageName.toLowerCase,
-        languageFactory.languageVersionName
+          languageFactory.languageName.toLowerCase,
+          languageFactory.languageVersionName
       ) match {
         case ("wdl", "draft-2")     => Language.WDLvDraft2
         case ("wdl", "draft-3")     => Language.WDLv1_0
@@ -190,16 +190,16 @@ case class ParseWomSourceFile(verbose: Boolean) {
           // A new path, not seen before
           val bundle =
             languageFactory.getWomBundle(
-              wfSource,
-              None,
-              "{}",
-              importResolversRecorded,
-              List(languageFactory),
-              convertNestedScatterToSubworkflow = false
+                wfSource,
+                None,
+                "{}",
+                importResolversRecorded,
+                List(languageFactory),
+                convertNestedScatterToSubworkflow = false
             ) match {
               case Left(errors) =>
                 throw new Exception(
-                  s"""|WOM validation errors:
+                    s"""|WOM validation errors:
                                                                          | ${errors}
                                                                          |""".stripMargin
                 )
@@ -233,7 +233,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     lang match {
       case Language.CWLv1_0 =>
         throw new Exception(
-          "CWL is not handled at the moment, only WDL is supported"
+            "CWL is not handled at the moment, only WDL is supported"
         )
       case _ => ()
     }
@@ -416,12 +416,12 @@ case class ParseWomSourceFile(verbose: Boolean) {
 
     val bundleChk: Checked[WomBundle] =
       languageFactory.getWomBundle(
-        wdlWfSource,
-        None,
-        "{}",
-        List.empty,
-        List.empty,
-        false
+          wdlWfSource,
+          None,
+          "{}",
+          List.empty,
+          List.empty,
+          false
       )
     bundleChk match {
       case Left(errors) =>
@@ -450,12 +450,12 @@ case class ParseWomSourceFile(verbose: Boolean) {
     val languageFactory = getLanguageFactory(wfSource)
     val bundleChk: Checked[WomBundle] =
       languageFactory.getWomBundle(
-        wfSource,
-        None,
-        "{}",
-        List.empty,
-        List(languageFactory),
-        convertNestedScatterToSubworkflow = false
+          wfSource,
+          None,
+          "{}",
+          List.empty,
+          List(languageFactory),
+          convertNestedScatterToSubworkflow = false
       )
     val womBundle = bundleChk match {
       case Left(errors)  => throw new Exception(s"""|WOM validation errors:
@@ -509,12 +509,12 @@ case class ParseWomSourceFile(verbose: Boolean) {
     val languageFactory = getLanguageFactory(wfSource)
     val bundleChk: Checked[WomBundle] =
       languageFactory.getWomBundle(
-        wfSource,
-        None,
-        "{}",
-        List.empty,
-        List(languageFactory),
-        false
+          wfSource,
+          None,
+          "{}",
+          List.empty,
+          List(languageFactory),
+          false
       )
     val womBundle = bundleChk match {
       case Left(errors)  => throw new Exception(s"""|WOM validation errors:

--- a/src/main/scala/dxWDL/util/WdlVarLinks.scala
+++ b/src/main/scala/dxWDL/util/WdlVarLinks.scala
@@ -26,343 +26,347 @@ import dxWDL.dx._
 // A complex value is implemented as a json structure, and an array of
 // all the files it references.
 sealed trait DxLink
-case class DxlValue(jsn: JsValue) extends DxLink  // This may contain dx-files
+case class DxlValue(jsn: JsValue)                                                  extends DxLink // This may contain dx-files
 case class DxlStage(dxStage: DxWorkflowStage, ioRef: IORef.Value, varName: String) extends DxLink
-case class DxlWorkflowInput(varName: String) extends DxLink
-case class DxlExec(dxExec: DxExecution, varName: String) extends DxLink
+case class DxlWorkflowInput(varName: String)                                       extends DxLink
+case class DxlExec(dxExec: DxExecution, varName: String)                           extends DxLink
 
 case class WdlVarLinks(womType: WomType, dxlink: DxLink)
 
-case class WdlVarLinksConverter(verbose: Verbose,
-                                fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
-                                typeAliases: Map[String, WomType]) {
-    val womTypeSerializer = WomTypeSerialization(typeAliases)
+case class WdlVarLinksConverter(
+    verbose: Verbose,
+    fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
+    typeAliases: Map[String, WomType]
+) {
+  val womTypeSerializer = WomTypeSerialization(typeAliases)
 
-    private def isDoubleOptional(t: WomType) : Boolean = {
-        t match {
-            case WomOptionalType(WomOptionalType(_)) => true
-            case _ => false
-        }
+  private def isDoubleOptional(t: WomType): Boolean = {
+    t match {
+      case WomOptionalType(WomOptionalType(_)) => true
+      case _                                   => false
     }
+  }
 
-    // Serialize a complex WDL value into a JSON value. The value could potentially point
-    // to many files. The assumption is that files are already in the format of dxWDLs,
-    // requiring not upload/download or any special conversion.
-    private def jsFromWomValue(womType: WomType, womValue: WomValue) : JsValue = {
-        if (isDoubleOptional(womType) ||
-                isDoubleOptional(womValue.womType)) {
-            System.err.println(s"""|jsFromWomValue
+  // Serialize a complex WDL value into a JSON value. The value could potentially point
+  // to many files. The assumption is that files are already in the format of dxWDLs,
+  // requiring not upload/download or any special conversion.
+  private def jsFromWomValue(womType: WomType, womValue: WomValue): JsValue = {
+    if (isDoubleOptional(womType) ||
+        isDoubleOptional(womValue.womType)) {
+      System.err.println(s"""|jsFromWomValue
                                    |    type=${womType}
                                    |    val=${womValue.toWomString}
                                    |    val.type=${womValue.womType}
                                    |""".stripMargin)
-            throw new Exception("a double optional type")
+      throw new Exception("a double optional type")
+    }
+    def handleFile(path: String): JsValue = {
+      Furl.parse(path) match {
+        case FurlDx(path, _, dxFile) =>
+          DxUtils.dxFileToJsValue(dxFile)
+        case FurlLocal(path) =>
+          // A local file.
+          JsString(path)
+      }
+    }
+    (womType, womValue) match {
+      // Base case: primitive types
+      case (WomSingleFileType, WomString(path))     => handleFile(path)
+      case (WomSingleFileType, WomSingleFile(path)) => handleFile(path)
+      case (WomStringType, WomSingleFile(path))     => JsString(path)
+      case (WomStringType, WomString(buf)) =>
+        if (buf.length > Utils.MAX_STRING_LEN)
+          throw new AppInternalException(s"string is longer than ${Utils.MAX_STRING_LEN}")
+        JsString(buf)
+      case (WomBooleanType, WomBoolean(b))      => JsBoolean(b)
+      case (WomBooleanType, WomString("true"))  => JsBoolean(true)
+      case (WomBooleanType, WomString("false")) => JsBoolean(false)
+
+      // Integer conversions
+      case (WomIntegerType, WomInteger(n)) => JsNumber(n)
+      case (WomIntegerType, WomString(s))  => JsNumber(s.toInt)
+      case (WomIntegerType, WomFloat(x))   => JsNumber(x.toInt)
+
+      // Float conversions
+      case (WomFloatType, WomFloat(x))   => JsNumber(x)
+      case (WomFloatType, WomInteger(n)) => JsNumber(n.toFloat)
+      case (WomFloatType, WomString(s))  => JsNumber(s.toFloat)
+
+      case (WomPairType(lType, rType), WomPair(l, r)) =>
+        val lJs = jsFromWomValue(lType, l)
+        val rJs = jsFromWomValue(rType, r)
+        JsObject("left" -> lJs, "right" -> rJs)
+
+      // Maps. These are projections from a key to value, where
+      // the key and value types are statically known. We
+      // represent them in JSON as an array of keys, followed by
+      // an array of values.
+      case (WomMapType(keyType, valueType), WomMap(_, m)) =>
+        // general case
+        val keys: WomValue   = WomArray(WomArrayType(keyType), m.keys.toVector)
+        val kJs              = jsFromWomValue(keys.womType, keys)
+        val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
+        val vJs              = jsFromWomValue(values.womType, values)
+        JsObject("keys" -> kJs, "values" -> vJs)
+
+      // Arrays: these come after maps, because there is an automatic coercion from
+      // a map to an array.
+      //
+      // Base case: empty array
+      case (_, WomArray(_, ar)) if ar.length == 0 =>
+        JsArray(Vector.empty)
+      case (WomArrayType(t), null) =>
+        JsArray(Vector.empty)
+
+      // Non empty array
+      case (WomArrayType(t), WomArray(_, elems)) =>
+        val jsVals = elems.map { x =>
+          jsFromWomValue(t, x)
         }
-        def handleFile(path:String) : JsValue =  {
-            Furl.parse(path) match {
-                case FurlDx(path, _, dxFile) =>
-                    DxUtils.dxFileToJsValue(dxFile)
-                case FurlLocal(path) =>
-                    // A local file.
-                    JsString(path)
-            }
-        }
-        (womType, womValue) match {
-            // Base case: primitive types
-            case (WomSingleFileType, WomString(path)) => handleFile(path)
-            case (WomSingleFileType, WomSingleFile(path)) => handleFile(path)
-            case (WomStringType, WomSingleFile(path)) => JsString(path)
-            case (WomStringType, WomString(buf)) =>
-                if (buf.length > Utils.MAX_STRING_LEN)
-                    throw new AppInternalException(s"string is longer than ${Utils.MAX_STRING_LEN}")
-                JsString(buf)
-            case (WomBooleanType,WomBoolean(b)) => JsBoolean(b)
-            case (WomBooleanType,WomString("true")) => JsBoolean(true)
-            case (WomBooleanType,WomString("false")) => JsBoolean(false)
+        JsArray(jsVals.toVector)
 
-            // Integer conversions
-            case (WomIntegerType,WomInteger(n)) => JsNumber(n)
-            case (WomIntegerType,WomString(s)) => JsNumber(s.toInt)
-            case (WomIntegerType,WomFloat(x)) => JsNumber(x.toInt)
+      // Strip optional type
+      case (WomOptionalType(t), WomOptionalValue(_, Some(w))) =>
+        jsFromWomValue(t, w)
+      case (WomOptionalType(t), WomOptionalValue(_, None)) =>
+        JsNull
+      case (WomOptionalType(t), w) =>
+        jsFromWomValue(t, w)
+      case (t, WomOptionalValue(_, Some(w))) =>
+        jsFromWomValue(t, w)
 
-            // Float conversions
-            case (WomFloatType, WomFloat(x)) => JsNumber(x)
-            case (WomFloatType, WomInteger(n)) => JsNumber(n.toFloat)
-            case (WomFloatType, WomString(s)) => JsNumber(s.toFloat)
+      // structs
+      case (WomCompositeType(typeMap, None), _) =>
+        throw new Exception("struct without a name")
 
-            case (WomPairType(lType, rType), WomPair(l,r)) =>
-                val lJs = jsFromWomValue(lType, l)
-                val rJs = jsFromWomValue(rType, r)
-                JsObject("left" -> lJs, "right" -> rJs)
-
-            // Maps. These are projections from a key to value, where
-            // the key and value types are statically known. We
-            // represent them in JSON as an array of keys, followed by
-            // an array of values.
-            case (WomMapType(keyType, valueType), WomMap(_, m)) =>
-                // general case
-                val keys:WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
-                val kJs = jsFromWomValue(keys.womType, keys)
-                val values:WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
-                val vJs = jsFromWomValue(values.womType, values)
-                JsObject("keys" -> kJs, "values" -> vJs)
-
-            // Arrays: these come after maps, because there is an automatic coercion from
-            // a map to an array.
-            //
-            // Base case: empty array
-            case (_, WomArray(_, ar)) if ar.length == 0 =>
-                JsArray(Vector.empty)
-            case (WomArrayType(t), null) =>
-                JsArray(Vector.empty)
-
-            // Non empty array
-            case (WomArrayType(t), WomArray(_, elems)) =>
-                val jsVals = elems.map{ x => jsFromWomValue(t, x) }
-                JsArray(jsVals.toVector)
-
-            // Strip optional type
-            case (WomOptionalType(t), WomOptionalValue(_,Some(w))) =>
-                jsFromWomValue(t, w)
-            case (WomOptionalType(t), WomOptionalValue(_,None)) =>
-                JsNull
-            case (WomOptionalType(t), w) =>
-                jsFromWomValue(t, w)
-            case (t, WomOptionalValue(_,Some(w))) =>
-                jsFromWomValue(t, w)
-
-            // structs
-            case (WomCompositeType(typeMap, None), _) =>
-                throw new Exception("struct without a name")
-
-            case (WomCompositeType(typeMap, Some(structName)),
-                  WomObject(m: Map[String, WomValue], _)) =>
-                // Convert each of the elements
-                val mJs = m.map{ case (key, womValue) =>
-                    val elemType = typeMap.get(key) match {
-                        case None =>
-                            throw new Exception(s"""|ERROR
+      case (WomCompositeType(typeMap, Some(structName)), WomObject(m: Map[String, WomValue], _)) =>
+        // Convert each of the elements
+        val mJs = m.map {
+          case (key, womValue) =>
+            val elemType = typeMap.get(key) match {
+              case None =>
+                throw new Exception(s"""|ERROR
                                                     |WomCompositeType
                                                     |  structName=${structName}
                                                     |  typeMap=${typeMap}
                                                     |  wom-object=${m}
                                                     |typeMap is missing key=${key}
                                                     |""".stripMargin)
-                        case Some(t) => t
-                    }
-                    key -> jsFromWomValue(elemType, womValue)
-                }.toMap
-                JsObject(mJs)
+              case Some(t) => t
+            }
+            key -> jsFromWomValue(elemType, womValue)
+        }.toMap
+        JsObject(mJs)
 
-            case (_,_) =>
-                val womTypeStr =
-                    if (womType == null)
-                        "null"
-                    else
-                        WomTypeSerialization.typeName(womType)
-                val womValueStr =
-                    if (womValue == null)
-                        "null"
-                    else
-                        s"(${womValue.toWomString}, ${womValue.womType})"
-                throw new Exception(s"""|Unsupported combination:
+      case (_, _) =>
+        val womTypeStr =
+          if (womType == null)
+            "null"
+          else
+            WomTypeSerialization.typeName(womType)
+        val womValueStr =
+          if (womValue == null)
+            "null"
+          else
+            s"(${womValue.toWomString}, ${womValue.womType})"
+        throw new Exception(s"""|Unsupported combination:
                                         |    womType:  ${womTypeStr}
                                         |    womValue: ${womValueStr}""".stripMargin)
-        }
     }
+  }
 
-    // import a WDL value
-    def importFromWDL(womType: WomType,
-                      womValue: WomValue) : WdlVarLinks = {
-        val jsValue = jsFromWomValue(womType, womValue)
-        WdlVarLinks(womType, DxlValue(jsValue))
-    }
+  // import a WDL value
+  def importFromWDL(womType: WomType, womValue: WomValue): WdlVarLinks = {
+    val jsValue = jsFromWomValue(womType, womValue)
+    WdlVarLinks(womType, DxlValue(jsValue))
+  }
 
-    // Convert a job input to a WomValue. Do not download any files, convert them
-    // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
-    //
-    private def jobInputToWomValue(name: String,
-                                   womType: WomType,
-                                   jsValue: JsValue) : WomValue = {
-        (womType, jsValue)  match {
-            // base case: primitive types
-            case (WomBooleanType, JsBoolean(b)) => WomBoolean(b.booleanValue)
-            case (WomIntegerType, JsNumber(bnm)) => WomInteger(bnm.intValue)
-            case (WomFloatType, JsNumber(bnm)) => WomFloat(bnm.doubleValue)
-            case (WomStringType, JsString(s)) => WomString(s)
-            case (WomSingleFileType, JsString(s)) => WomSingleFile(s)
-            case (WomSingleFileType, JsObject(_)) =>
-                // Convert the path in DNAx to a string. We can later
-                // decide if we want to download it or not
-                val dxFile = DxUtils.dxFileFromJsValue(jsValue)
-                val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
-                WomSingleFile(s)
+  // Convert a job input to a WomValue. Do not download any files, convert them
+  // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
+  //
+  private def jobInputToWomValue(name: String, womType: WomType, jsValue: JsValue): WomValue = {
+    (womType, jsValue) match {
+      // base case: primitive types
+      case (WomBooleanType, JsBoolean(b))   => WomBoolean(b.booleanValue)
+      case (WomIntegerType, JsNumber(bnm))  => WomInteger(bnm.intValue)
+      case (WomFloatType, JsNumber(bnm))    => WomFloat(bnm.doubleValue)
+      case (WomStringType, JsString(s))     => WomString(s)
+      case (WomSingleFileType, JsString(s)) => WomSingleFile(s)
+      case (WomSingleFileType, JsObject(_)) =>
+        // Convert the path in DNAx to a string. We can later
+        // decide if we want to download it or not
+        val dxFile          = DxUtils.dxFileFromJsValue(jsValue)
+        val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
+        WomSingleFile(s)
 
-            // Maps. These are serialized as an object with a keys array and
-            // a values array.
-            case (WomMapType(keyType, valueType), _) =>
-                val fields = jsValue.asJsObject.fields
-                // [mJs] is a map from json key to json value
-                val mJs: Map[JsValue, JsValue] =
-                    (fields("keys"), fields("values")) match {
-                        case (JsArray(x), JsArray(y)) =>
-                            if (x.length != y.length)
-                                throw new Exception(s"""|len(keys) != len(values)
+      // Maps. These are serialized as an object with a keys array and
+      // a values array.
+      case (WomMapType(keyType, valueType), _) =>
+        val fields = jsValue.asJsObject.fields
+        // [mJs] is a map from json key to json value
+        val mJs: Map[JsValue, JsValue] =
+          (fields("keys"), fields("values")) match {
+            case (JsArray(x), JsArray(y)) =>
+              if (x.length != y.length)
+                throw new Exception(s"""|len(keys) != len(values)
                                                         |fields: ${fields}
                                                         |""".stripMargin)
-                            (x zip y).toMap
-                        case _ =>
-                            throw new Exception(s"Malformed JSON ${fields}")
-                    }
-                val m: Map[WomValue, WomValue] = mJs.map {
-                    case (k:JsValue, v:JsValue) =>
-                        val kWom = jobInputToWomValue(name, keyType, k)
-                        val vWom = jobInputToWomValue(name, valueType, v)
-                        kWom -> vWom
-                }.toMap
-                WomMap(WomMapType(keyType, valueType), m)
+              (x zip y).toMap
+            case _ =>
+              throw new Exception(s"Malformed JSON ${fields}")
+          }
+        val m: Map[WomValue, WomValue] = mJs.map {
+          case (k: JsValue, v: JsValue) =>
+            val kWom = jobInputToWomValue(name, keyType, k)
+            val vWom = jobInputToWomValue(name, valueType, v)
+            kWom -> vWom
+        }.toMap
+        WomMap(WomMapType(keyType, valueType), m)
 
-            case (WomPairType(lType, rType), JsObject(fields))
-                    if (List("left", "right").forall(fields contains _)) =>
-                val left = jobInputToWomValue(name, lType, fields("left"))
-                val right = jobInputToWomValue(name, rType, fields("right"))
-                WomPair(left, right)
+      case (WomPairType(lType, rType), JsObject(fields))
+          if (List("left", "right").forall(fields contains _)) =>
+        val left  = jobInputToWomValue(name, lType, fields("left"))
+        val right = jobInputToWomValue(name, rType, fields("right"))
+        WomPair(left, right)
 
-            // empty array
-            case (WomArrayType(t), JsNull) =>
-                WomArray(WomArrayType(t), List.empty[WomValue])
+      // empty array
+      case (WomArrayType(t), JsNull) =>
+        WomArray(WomArrayType(t), List.empty[WomValue])
 
-            // array
-            case (WomArrayType(t), JsArray(vec)) =>
-                val wVec: Seq[WomValue] = vec.map{
-                    elem:JsValue => jobInputToWomValue(name, t, elem)
-                }
-                WomArray(WomArrayType(t), wVec)
+      // array
+      case (WomArrayType(t), JsArray(vec)) =>
+        val wVec: Seq[WomValue] = vec.map { elem: JsValue =>
+          jobInputToWomValue(name, t, elem)
+        }
+        WomArray(WomArrayType(t), wVec)
 
-            case (WomOptionalType(t), JsNull) =>
-                WomOptionalValue(t, None)
-            case (WomOptionalType(t), jsv) =>
-                val value = jobInputToWomValue(name, t, jsv)
-                WomOptionalValue(t, Some(value))
+      case (WomOptionalType(t), JsNull) =>
+        WomOptionalValue(t, None)
+      case (WomOptionalType(t), jsv) =>
+        val value = jobInputToWomValue(name, t, jsv)
+        WomOptionalValue(t, Some(value))
 
-            // structs
-            case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
-                val m : Map[String, WomValue] = fields.map{
-                    case (key, jsValue) =>
-                        val t = typeMap.get(key) match {
-                            case None =>
-                                throw new Exception(s"""|ERROR
+      // structs
+      case (WomCompositeType(typeMap, Some(structName)), JsObject(fields)) =>
+        val m: Map[String, WomValue] = fields.map {
+          case (key, jsValue) =>
+            val t = typeMap.get(key) match {
+              case None =>
+                throw new Exception(s"""|ERROR
                                                         |WomCompositeType
                                                         |  structName=${structName}
                                                         |  typeMap=${typeMap}
                                                         |  fields=${fields}
                                                         |typeMap is missing key=${key}
                                                         |""".stripMargin)
-                            case Some(t) => t
-                        }
-                        key -> jobInputToWomValue(key, t, jsValue)
-                }.toMap
-                WomObject(m, WomCompositeType(typeMap, Some(structName)))
+              case Some(t) => t
+            }
+            key -> jobInputToWomValue(key, t, jsValue)
+        }.toMap
+        WomObject(m, WomCompositeType(typeMap, Some(structName)))
 
-            case _ =>
-                throw new AppInternalException(
-                    s"""|Unsupported combination
+      case _ =>
+        throw new AppInternalException(s"""|Unsupported combination
                         |  name:    ${name}
                         |  womType: ${womType}
                         |  JSON:    ${jsValue.prettyPrint}
                         |""".stripMargin)
-        }
+    }
+  }
+
+  def unpackJobInput(name: String, womType: WomType, jsv: JsValue): (WomValue, Vector[DxFile]) = {
+    val jsv1 =
+      jsv match {
+        case JsObject(fields) if fields contains "___" =>
+          // unpack the hash with which complex JSON values are
+          // wrapped in dnanexus.
+          fields("___")
+        case _ => jsv
+      }
+    val womValue = jobInputToWomValue(name, womType, jsv1)
+    val dxFiles  = DxUtils.findDxFiles(jsv)
+    (womValue, dxFiles)
+  }
+
+  // create input/output fields that bind the variable name [bindName] to
+  // this WdlVar
+  def genFields(
+      wvl: WdlVarLinks,
+      bindName: String,
+      encodeDots: Boolean = true
+  ): List[(String, JsValue)] = {
+    def nodots(s: String): String =
+      Utils.encodeAppletVarName(Utils.transformVarName(s))
+    val bindEncName =
+      if (encodeDots) nodots(bindName)
+      else bindName
+    def mkSimple(): (String, JsValue) = {
+      val jsv: JsValue = wvl.dxlink match {
+        case DxlValue(jsn) => jsn
+        case DxlStage(dxStage, ioRef, varEncName) =>
+          ioRef match {
+            case IORef.Input  => dxStage.getInputReference(nodots(varEncName))
+            case IORef.Output => dxStage.getOutputReference(nodots(varEncName))
+          }
+        case DxlWorkflowInput(varEncName) =>
+          JsObject(
+            "$dnanexus_link" -> JsObject("workflowInputField" -> JsString(nodots(varEncName)))
+          )
+        case DxlExec(dxJob, varEncName) =>
+          DxUtils.makeEBOR(dxJob, nodots(varEncName))
+      }
+      (bindEncName, jsv)
+    }
+    def mkComplex(womType: WomType): Map[String, JsValue] = {
+      val bindEncName_F = bindEncName + Utils.FLAT_FILES_SUFFIX
+      wvl.dxlink match {
+        case DxlValue(jsn) =>
+          // files that are embedded in the structure
+          val dxFiles = DxUtils.findDxFiles(jsn)
+          val jsFiles = dxFiles.map(_.getLinkAsJson)
+          // Dx allows hashes as an input/output type. If the JSON value is
+          // not a hash (js-object), we need to add an outer layer to it.
+          val jsn1 = JsObject("___" -> jsn)
+          Map(bindEncName -> jsn1, bindEncName_F -> JsArray(jsFiles))
+        case DxlStage(dxStage, ioRef, varEncName) =>
+          val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
+          ioRef match {
+            case IORef.Input =>
+              Map(
+                bindEncName   -> dxStage.getInputReference(varEncName),
+                bindEncName_F -> dxStage.getInputReference(varEncName_F)
+              )
+            case IORef.Output =>
+              Map(
+                bindEncName   -> dxStage.getOutputReference(varEncName),
+                bindEncName_F -> dxStage.getOutputReference(varEncName_F)
+              )
+          }
+        case DxlWorkflowInput(varEncName) =>
+          val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
+          Map(
+            bindEncName ->
+              JsObject("$dnanexus_link" -> JsObject("workflowInputField" -> JsString(varEncName))),
+            bindEncName_F ->
+              JsObject("$dnanexus_link" -> JsObject("workflowInputField" -> JsString(varEncName_F)))
+          )
+        case DxlExec(dxJob, varEncName) =>
+          val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
+          Map(
+            bindEncName   -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
+            bindEncName_F -> DxUtils.makeEBOR(dxJob, nodots(varEncName_F))
+          )
+      }
     }
 
-    def unpackJobInput(name: String, womType: WomType, jsv: JsValue) : (WomValue,
-                                                                        Vector[DxFile]) = {
-        val jsv1 =
-            jsv match {
-                case JsObject(fields) if fields contains "___" =>
-                    // unpack the hash with which complex JSON values are
-                    // wrapped in dnanexus.
-                    fields("___")
-                case _ => jsv
-            }
-        val womValue = jobInputToWomValue(name, womType, jsv1)
-        val dxFiles = DxUtils.findDxFiles(jsv)
-        (womValue, dxFiles)
+    val womType = Utils.stripOptional(wvl.womType)
+    if (DxUtils.isNativeDxType(womType)) {
+      // Types that are supported natively in DX
+      List(mkSimple())
+    } else {
+      // General complex type requiring two fields: a JSON
+      // structure, and a flat array of files.
+      mkComplex(womType).toList
     }
-
-    // create input/output fields that bind the variable name [bindName] to
-    // this WdlVar
-    def genFields(wvl : WdlVarLinks,
-                  bindName: String,
-                  encodeDots: Boolean = true) : List[(String, JsValue)] = {
-        def nodots(s: String) : String =
-            Utils.encodeAppletVarName(Utils.transformVarName(s))
-        val bindEncName =
-            if (encodeDots) nodots(bindName)
-            else bindName
-        def mkSimple() : (String, JsValue) = {
-            val jsv : JsValue = wvl.dxlink match {
-                case DxlValue(jsn) => jsn
-                case DxlStage(dxStage, ioRef, varEncName) =>
-                    ioRef match {
-                        case IORef.Input => dxStage.getInputReference(nodots(varEncName))
-                        case IORef.Output => dxStage.getOutputReference(nodots(varEncName))
-                    }
-                case DxlWorkflowInput(varEncName) =>
-                    JsObject("$dnanexus_link" -> JsObject(
-                                 "workflowInputField" -> JsString(nodots(varEncName))))
-                case DxlExec(dxJob, varEncName) =>
-                    DxUtils.makeEBOR(dxJob, nodots(varEncName))
-            }
-            (bindEncName, jsv)
-        }
-        def mkComplex(womType: WomType) : Map[String, JsValue] = {
-            val bindEncName_F = bindEncName + Utils.FLAT_FILES_SUFFIX
-            wvl.dxlink match {
-                case DxlValue(jsn) =>
-                    // files that are embedded in the structure
-                    val dxFiles = DxUtils.findDxFiles(jsn)
-                    val jsFiles = dxFiles.map(_.getLinkAsJson)
-                    // Dx allows hashes as an input/output type. If the JSON value is
-                    // not a hash (js-object), we need to add an outer layer to it.
-                    val jsn1 = JsObject("___" -> jsn)
-                    Map(bindEncName -> jsn1,
-                        bindEncName_F -> JsArray(jsFiles))
-                case DxlStage(dxStage, ioRef, varEncName) =>
-                    val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
-                    ioRef match {
-                        case IORef.Input => Map(
-                            bindEncName -> dxStage.getInputReference(varEncName),
-                            bindEncName_F -> dxStage.getInputReference(varEncName_F)
-                        )
-                        case IORef.Output => Map(
-                            bindEncName -> dxStage.getOutputReference(varEncName),
-                            bindEncName_F -> dxStage.getOutputReference(varEncName_F)
-                        )
-                    }
-                case DxlWorkflowInput(varEncName) =>
-                    val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
-                    Map( bindEncName ->
-                            JsObject("$dnanexus_link" -> JsObject(
-                                         "workflowInputField" -> JsString(varEncName))),
-                         bindEncName_F ->
-                            JsObject("$dnanexus_link" -> JsObject(
-                                         "workflowInputField" -> JsString(varEncName_F)))
-                    )
-                case DxlExec(dxJob, varEncName) =>
-                    val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
-                    Map(bindEncName -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
-                        bindEncName_F -> DxUtils.makeEBOR(dxJob, nodots(varEncName_F)))
-            }
-        }
-
-        val womType = Utils.stripOptional(wvl.womType)
-        if (DxUtils.isNativeDxType(womType)) {
-            // Types that are supported natively in DX
-            List(mkSimple())
-        } else {
-            // General complex type requiring two fields: a JSON
-            // structure, and a flat array of files.
-            mkComplex(womType).toList
-        }
-    }
+  }
 }

--- a/src/main/scala/dxWDL/util/WdlVarLinks.scala
+++ b/src/main/scala/dxWDL/util/WdlVarLinks.scala
@@ -26,10 +26,10 @@ import dxWDL.dx._
 // A complex value is implemented as a json structure, and an array of
 // all the files it references.
 sealed trait DxLink
-case class DxlValue(jsn: JsValue)                                                  extends DxLink // This may contain dx-files
+case class DxlValue(jsn: JsValue) extends DxLink // This may contain dx-files
 case class DxlStage(dxStage: DxWorkflowStage, ioRef: IORef.Value, varName: String) extends DxLink
-case class DxlWorkflowInput(varName: String)                                       extends DxLink
-case class DxlExec(dxExec: DxExecution, varName: String)                           extends DxLink
+case class DxlWorkflowInput(varName: String) extends DxLink
+case class DxlExec(dxExec: DxExecution, varName: String) extends DxLink
 
 case class WdlVarLinks(womType: WomType, dxlink: DxLink)
 
@@ -103,10 +103,10 @@ case class WdlVarLinksConverter(
       // an array of values.
       case (WomMapType(keyType, valueType), WomMap(_, m)) =>
         // general case
-        val keys: WomValue   = WomArray(WomArrayType(keyType), m.keys.toVector)
-        val kJs              = jsFromWomValue(keys.womType, keys)
+        val keys: WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
+        val kJs = jsFromWomValue(keys.womType, keys)
         val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
-        val vJs              = jsFromWomValue(values.womType, values)
+        val vJs = jsFromWomValue(values.womType, values)
         JsObject("keys" -> kJs, "values" -> vJs)
 
       // Arrays: these come after maps, because there is an automatic coercion from
@@ -195,7 +195,7 @@ case class WdlVarLinksConverter(
       case (WomSingleFileType, JsObject(_)) =>
         // Convert the path in DNAx to a string. We can later
         // decide if we want to download it or not
-        val dxFile          = DxUtils.dxFileFromJsValue(jsValue)
+        val dxFile = DxUtils.dxFileFromJsValue(jsValue)
         val FurlDx(s, _, _) = Furl.dxFileToFurl(dxFile, fileInfoDir)
         WomSingleFile(s)
 
@@ -225,7 +225,7 @@ case class WdlVarLinksConverter(
 
       case (WomPairType(lType, rType), JsObject(fields))
           if (List("left", "right").forall(fields contains _)) =>
-        val left  = jobInputToWomValue(name, lType, fields("left"))
+        val left = jobInputToWomValue(name, lType, fields("left"))
         val right = jobInputToWomValue(name, rType, fields("right"))
         WomPair(left, right)
 
@@ -284,7 +284,7 @@ case class WdlVarLinksConverter(
         case _ => jsv
       }
     val womValue = jobInputToWomValue(name, womType, jsv1)
-    val dxFiles  = DxUtils.findDxFiles(jsv)
+    val dxFiles = DxUtils.findDxFiles(jsv)
     (womValue, dxFiles)
   }
 
@@ -333,12 +333,12 @@ case class WdlVarLinksConverter(
           ioRef match {
             case IORef.Input =>
               Map(
-                bindEncName   -> dxStage.getInputReference(varEncName),
+                bindEncName -> dxStage.getInputReference(varEncName),
                 bindEncName_F -> dxStage.getInputReference(varEncName_F)
               )
             case IORef.Output =>
               Map(
-                bindEncName   -> dxStage.getOutputReference(varEncName),
+                bindEncName -> dxStage.getOutputReference(varEncName),
                 bindEncName_F -> dxStage.getOutputReference(varEncName_F)
               )
           }
@@ -353,7 +353,7 @@ case class WdlVarLinksConverter(
         case DxlExec(dxJob, varEncName) =>
           val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
           Map(
-            bindEncName   -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
+            bindEncName -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
             bindEncName_F -> DxUtils.makeEBOR(dxJob, nodots(varEncName_F))
           )
       }

--- a/src/main/scala/dxWDL/util/WdlVarLinks.scala
+++ b/src/main/scala/dxWDL/util/WdlVarLinks.scala
@@ -81,7 +81,7 @@ case class WdlVarLinksConverter(
       case (WomStringType, WomString(buf)) =>
         if (buf.length > Utils.MAX_STRING_LEN)
           throw new AppInternalException(
-            s"string is longer than ${Utils.MAX_STRING_LEN}"
+              s"string is longer than ${Utils.MAX_STRING_LEN}"
           )
         JsString(buf)
       case (WomBooleanType, WomBoolean(b))      => JsBoolean(b)
@@ -180,7 +180,7 @@ case class WdlVarLinksConverter(
           else
             s"(${womValue.toWomString}, ${womValue.womType})"
         throw new Exception(
-          s"""|Unsupported combination:
+            s"""|Unsupported combination:
                                         |    womType:  ${womTypeStr}
                                         |    womValue: ${womValueStr}""".stripMargin
         )
@@ -330,9 +330,9 @@ case class WdlVarLinksConverter(
           }
         case DxlWorkflowInput(varEncName) =>
           JsObject(
-            "$dnanexus_link" -> JsObject(
-              "workflowInputField" -> JsString(nodots(varEncName))
-            )
+              "$dnanexus_link" -> JsObject(
+                  "workflowInputField" -> JsString(nodots(varEncName))
+              )
           )
         case DxlExec(dxJob, varEncName) =>
           DxUtils.makeEBOR(dxJob, nodots(varEncName))
@@ -355,36 +355,36 @@ case class WdlVarLinksConverter(
           ioRef match {
             case IORef.Input =>
               Map(
-                bindEncName -> dxStage.getInputReference(varEncName),
-                bindEncName_F -> dxStage.getInputReference(varEncName_F)
+                  bindEncName -> dxStage.getInputReference(varEncName),
+                  bindEncName_F -> dxStage.getInputReference(varEncName_F)
               )
             case IORef.Output =>
               Map(
-                bindEncName -> dxStage.getOutputReference(varEncName),
-                bindEncName_F -> dxStage.getOutputReference(varEncName_F)
+                  bindEncName -> dxStage.getOutputReference(varEncName),
+                  bindEncName_F -> dxStage.getOutputReference(varEncName_F)
               )
           }
         case DxlWorkflowInput(varEncName) =>
           val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
           Map(
-            bindEncName ->
-              JsObject(
-                "$dnanexus_link" -> JsObject(
-                  "workflowInputField" -> JsString(varEncName)
+              bindEncName ->
+                JsObject(
+                    "$dnanexus_link" -> JsObject(
+                        "workflowInputField" -> JsString(varEncName)
+                    )
+                ),
+              bindEncName_F ->
+                JsObject(
+                    "$dnanexus_link" -> JsObject(
+                        "workflowInputField" -> JsString(varEncName_F)
+                    )
                 )
-              ),
-            bindEncName_F ->
-              JsObject(
-                "$dnanexus_link" -> JsObject(
-                  "workflowInputField" -> JsString(varEncName_F)
-                )
-              )
           )
         case DxlExec(dxJob, varEncName) =>
           val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
           Map(
-            bindEncName -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
-            bindEncName_F -> DxUtils.makeEBOR(dxJob, nodots(varEncName_F))
+              bindEncName -> DxUtils.makeEBOR(dxJob, nodots(varEncName)),
+              bindEncName_F -> DxUtils.makeEBOR(dxJob, nodots(varEncName_F))
           )
       }
     }

--- a/src/main/scala/dxWDL/util/WdlVarLinks.scala
+++ b/src/main/scala/dxWDL/util/WdlVarLinks.scala
@@ -27,7 +27,11 @@ import dxWDL.dx._
 // all the files it references.
 sealed trait DxLink
 case class DxlValue(jsn: JsValue) extends DxLink // This may contain dx-files
-case class DxlStage(dxStage: DxWorkflowStage, ioRef: IORef.Value, varName: String) extends DxLink
+case class DxlStage(
+    dxStage: DxWorkflowStage,
+    ioRef: IORef.Value,
+    varName: String
+) extends DxLink
 case class DxlWorkflowInput(varName: String) extends DxLink
 case class DxlExec(dxExec: DxExecution, varName: String) extends DxLink
 
@@ -76,7 +80,9 @@ case class WdlVarLinksConverter(
       case (WomStringType, WomSingleFile(path))     => JsString(path)
       case (WomStringType, WomString(buf)) =>
         if (buf.length > Utils.MAX_STRING_LEN)
-          throw new AppInternalException(s"string is longer than ${Utils.MAX_STRING_LEN}")
+          throw new AppInternalException(
+            s"string is longer than ${Utils.MAX_STRING_LEN}"
+          )
         JsString(buf)
       case (WomBooleanType, WomBoolean(b))      => JsBoolean(b)
       case (WomBooleanType, WomString("true"))  => JsBoolean(true)
@@ -105,7 +111,8 @@ case class WdlVarLinksConverter(
         // general case
         val keys: WomValue = WomArray(WomArrayType(keyType), m.keys.toVector)
         val kJs = jsFromWomValue(keys.womType, keys)
-        val values: WomValue = WomArray(WomArrayType(valueType), m.values.toVector)
+        val values: WomValue =
+          WomArray(WomArrayType(valueType), m.values.toVector)
         val vJs = jsFromWomValue(values.womType, values)
         JsObject("keys" -> kJs, "values" -> vJs)
 
@@ -139,7 +146,10 @@ case class WdlVarLinksConverter(
       case (WomCompositeType(typeMap, None), _) =>
         throw new Exception("struct without a name")
 
-      case (WomCompositeType(typeMap, Some(structName)), WomObject(m: Map[String, WomValue], _)) =>
+      case (
+          WomCompositeType(typeMap, Some(structName)),
+          WomObject(m: Map[String, WomValue], _)
+          ) =>
         // Convert each of the elements
         val mJs = m.map {
           case (key, womValue) =>
@@ -169,9 +179,11 @@ case class WdlVarLinksConverter(
             "null"
           else
             s"(${womValue.toWomString}, ${womValue.womType})"
-        throw new Exception(s"""|Unsupported combination:
+        throw new Exception(
+          s"""|Unsupported combination:
                                         |    womType:  ${womTypeStr}
-                                        |    womValue: ${womValueStr}""".stripMargin)
+                                        |    womValue: ${womValueStr}""".stripMargin
+        )
     }
   }
 
@@ -184,7 +196,11 @@ case class WdlVarLinksConverter(
   // Convert a job input to a WomValue. Do not download any files, convert them
   // to a string representation. For example: dx://proj-xxxx:file-yyyy::/A/B/C.txt
   //
-  private def jobInputToWomValue(name: String, womType: WomType, jsValue: JsValue): WomValue = {
+  private def jobInputToWomValue(
+      name: String,
+      womType: WomType,
+      jsValue: JsValue
+  ): WomValue = {
     (womType, jsValue) match {
       // base case: primitive types
       case (WomBooleanType, JsBoolean(b))   => WomBoolean(b.booleanValue)
@@ -274,7 +290,11 @@ case class WdlVarLinksConverter(
     }
   }
 
-  def unpackJobInput(name: String, womType: WomType, jsv: JsValue): (WomValue, Vector[DxFile]) = {
+  def unpackJobInput(
+      name: String,
+      womType: WomType,
+      jsv: JsValue
+  ): (WomValue, Vector[DxFile]) = {
     val jsv1 =
       jsv match {
         case JsObject(fields) if fields contains "___" =>
@@ -310,7 +330,9 @@ case class WdlVarLinksConverter(
           }
         case DxlWorkflowInput(varEncName) =>
           JsObject(
-            "$dnanexus_link" -> JsObject("workflowInputField" -> JsString(nodots(varEncName)))
+            "$dnanexus_link" -> JsObject(
+              "workflowInputField" -> JsString(nodots(varEncName))
+            )
           )
         case DxlExec(dxJob, varEncName) =>
           DxUtils.makeEBOR(dxJob, nodots(varEncName))
@@ -346,9 +368,17 @@ case class WdlVarLinksConverter(
           val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX
           Map(
             bindEncName ->
-              JsObject("$dnanexus_link" -> JsObject("workflowInputField" -> JsString(varEncName))),
+              JsObject(
+                "$dnanexus_link" -> JsObject(
+                  "workflowInputField" -> JsString(varEncName)
+                )
+              ),
             bindEncName_F ->
-              JsObject("$dnanexus_link" -> JsObject("workflowInputField" -> JsString(varEncName_F)))
+              JsObject(
+                "$dnanexus_link" -> JsObject(
+                  "workflowInputField" -> JsString(varEncName_F)
+                )
+              )
           )
         case DxlExec(dxJob, varEncName) =>
           val varEncName_F = varEncName + Utils.FLAT_FILES_SUFFIX

--- a/src/main/scala/dxWDL/util/WomPrettyPrint.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrint.scala
@@ -9,104 +9,106 @@ import wom.types._
 
 object WomPrettyPrint {
 
-    def apply(node: GraphNode,
-              indent : String = "") : String = {
-        node match {
-            case ssc : ScatterNode =>
-                val ids = ssc.scatterVariableNodes.map{svn => svn.identifier.localName.value}
-                s"${indent}Scatter(${ids})"
+  def apply(node: GraphNode, indent: String = ""): String = {
+    node match {
+      case ssc: ScatterNode =>
+        val ids = ssc.scatterVariableNodes.map { svn =>
+          svn.identifier.localName.value
+        }
+        s"${indent}Scatter(${ids})"
 
-            case cond : ConditionalNode =>
-                val inner =
-                    cond.innerGraph.nodes.map{ node =>
-                        apply(node, indent + "  ")
-                    }.mkString("\n")
-                s"""|Conditional(${cond.conditionExpression.womExpression.sourceString}) {
+      case cond: ConditionalNode =>
+        val inner =
+          cond.innerGraph.nodes
+            .map { node =>
+              apply(node, indent + "  ")
+            }
+            .mkString("\n")
+        s"""|Conditional(${cond.conditionExpression.womExpression.sourceString}) {
                     |${inner}
                     |}
                     |""".stripMargin
 
+      case call: CommandCallNode =>
+        val inputNames = call.inputPorts.map(_.name)
+        s"CommandCall(${call.identifier.localName.value}, ${inputNames})"
 
-            case call : CommandCallNode =>
-                val inputNames = call.inputPorts.map(_.name)
-                s"CommandCall(${call.identifier.localName.value}, ${inputNames})"
+      // Expression Nodes
+      case expr: PlainAnonymousExpressionNode =>
+        s"PlainAnonymousExpressionNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
 
-            // Expression Nodes
-            case expr : PlainAnonymousExpressionNode =>
-                s"PlainAnonymousExpressionNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
+      case expr: TaskCallInputExpressionNode =>
+        s"TaskCallInputExpressionNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType}, ${expr.singleOutputPort})"
 
-            case expr : TaskCallInputExpressionNode =>
-                s"TaskCallInputExpressionNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType}, ${expr.singleOutputPort})"
+      case expr: ExpressionBasedGraphOutputNode =>
+        s"ExpressionBasedGraphOutputNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
 
-            case expr : ExpressionBasedGraphOutputNode =>
-                s"ExpressionBasedGraphOutputNode(${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
+      case expr: ExpressionNode =>
+        s"ExpressionNode(${expr.getClass}, ${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
 
-            case expr : ExpressionNode =>
-                s"ExpressionNode(${expr.getClass}, ${expr.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
+      // Graph input nodes
+      case egin: ExternalGraphInputNode =>
+        s"ExternalGraphInputNode(${egin.nameInInputSet})"
 
-            // Graph input nodes
-            case egin : ExternalGraphInputNode =>
-                s"ExternalGraphInputNode(${egin.nameInInputSet})"
+      // Graph output nodes
+      case pbgon: PortBasedGraphOutputNode =>
+        s"PortBasedGraphOutputNode(${pbgon.identifier.localName.value})"
 
-            // Graph output nodes
-            case pbgon : PortBasedGraphOutputNode =>
-                s"PortBasedGraphOutputNode(${pbgon.identifier.localName.value})"
+      case svNode: ScatterVariableNode =>
+        val expr = svNode.scatterExpressionNode
+        s"ScatterVariableNode[OGIN](${svNode.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
 
-            case svNode: ScatterVariableNode =>
-                val expr = svNode.scatterExpressionNode
-                s"ScatterVariableNode[OGIN](${svNode.identifier.localName.value}, ${expr.womExpression.sourceString}, ${expr.womType})"
+      case ogin: OuterGraphInputNode =>
+        s"OuterGraphInputNode(${ogin.identifier.localName.value})"
 
-            case ogin : OuterGraphInputNode =>
-                s"OuterGraphInputNode(${ogin.identifier.localName.value})"
-
-            case other =>
-                s"${other.getClass}"
-        }
+      case other =>
+        s"${other.getClass}"
     }
+  }
 
-    def apply(iPort: GraphNodePort.InputPort) : String = {
-        iPort match {
-            case cip : GraphNodePort.ConnectedInputPort =>
-                s"ConnectedInputPort(${cip.name})"
-            case other =>
-                s"(${other.getClass} ${other.name})"
-        }
+  def apply(iPort: GraphNodePort.InputPort): String = {
+    iPort match {
+      case cip: GraphNodePort.ConnectedInputPort =>
+        s"ConnectedInputPort(${cip.name})"
+      case other =>
+        s"(${other.getClass} ${other.name})"
     }
+  }
 
-    def apply(oPort: GraphNodePort.OutputPort) : String = {
-        val ownerNode : String = apply(oPort.graphNode)
-        oPort match {
-            case gnop : GraphNodePort.GraphNodeOutputPort =>
-                s"GraphNodeOutputPort(${gnop.identifier.localName.value}, ${ownerNode})"
-            case ebop : GraphNodePort.ExpressionBasedOutputPort =>
-                s"ExpressionBasedOutputPort(${ebop.identifier.localName.value}, ${ownerNode})"
-            case other =>
-                s"OutputPort(${other.getClass})"
-        }
+  def apply(oPort: GraphNodePort.OutputPort): String = {
+    val ownerNode: String = apply(oPort.graphNode)
+    oPort match {
+      case gnop: GraphNodePort.GraphNodeOutputPort =>
+        s"GraphNodeOutputPort(${gnop.identifier.localName.value}, ${ownerNode})"
+      case ebop: GraphNodePort.ExpressionBasedOutputPort =>
+        s"ExpressionBasedOutputPort(${ebop.identifier.localName.value}, ${ownerNode})"
+      case other =>
+        s"OutputPort(${other.getClass})"
     }
+  }
 
-    def apply(inputDef: InputDefinition) : String = {
-        inputDef match {
-            // A required input, no default.
-            case RequiredInputDefinition(iName, womType, _, _) =>
-                s"RequiredInputDefinition(${iName}, ${womType})"
+  def apply(inputDef: InputDefinition): String = {
+    inputDef match {
+      // A required input, no default.
+      case RequiredInputDefinition(iName, womType, _, _) =>
+        s"RequiredInputDefinition(${iName}, ${womType})"
 
-            // An input definition that has a default value supplied.
-            // Typical WDL example would be a declaration like: "Int x = 5"
-            case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                s"InputDefinitionWithDefault(${iName}, ${womType})"
+      // An input definition that has a default value supplied.
+      // Typical WDL example would be a declaration like: "Int x = 5"
+      case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        s"InputDefinitionWithDefault(${iName}, ${womType})"
 
-            // An input whose value should always be calculated from the default, and is
-            // not allowed to be overridden.
-            case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                s"FixedInputDefinition(${iName}, ${womType},  default=${defaultExpr})"
+      // An input whose value should always be calculated from the default, and is
+      // not allowed to be overridden.
+      case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        s"FixedInputDefinition(${iName}, ${womType},  default=${defaultExpr})"
 
-            case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
-                s"OptionalInputDefinition(${iName}, ${womType})"
-        }
+      case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
+        s"OptionalInputDefinition(${iName}, ${womType})"
     }
+  }
 
-    def apply(nodes: Seq[GraphNode]) : String = {
-        nodes.map(node => apply(node)).mkString("\n")
-    }
+  def apply(nodes: Seq[GraphNode]): String = {
+    nodes.map(node => apply(node)).mkString("\n")
+  }
 }

--- a/src/main/scala/dxWDL/util/WomPrettyPrint.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrint.scala
@@ -95,7 +95,13 @@ object WomPrettyPrint {
 
       // An input definition that has a default value supplied.
       // Typical WDL example would be a declaration like: "Int x = 5"
-      case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+      case OverridableInputDefinitionWithDefault(
+          iName,
+          womType,
+          defaultExpr,
+          _,
+          _
+          ) =>
         s"InputDefinitionWithDefault(${iName}, ${womType})"
 
       // An input whose value should always be calculated from the default, and is

--- a/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
@@ -52,16 +52,19 @@ object WomPrettyPrintApproxWdl {
               applyGNode(node, indent + "  ")
             }
             .mkString("\n")
-        Some(s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
+        Some(
+          s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
                          |${innerBlock}
                          |${indent}}
-                         |""".stripMargin)
+                         |""".stripMargin
+        )
 
       case call: CommandCallNode =>
         val inputNames = call.upstream
           .collect {
             case exprNode: ExpressionNode =>
-              val paramName = getUnqualifiedName(exprNode.identifier.localName.value)
+              val paramName =
+                getUnqualifiedName(exprNode.identifier.localName.value)
               s"${paramName} = ${exprNode.womExpression.sourceString}"
           }
           .mkString(",")
@@ -109,7 +112,13 @@ object WomPrettyPrintApproxWdl {
       case RequiredInputDefinition(iName, womType, _, _) =>
         s"${typeName(womType)} ${iName}"
 
-      case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+      case OverridableInputDefinitionWithDefault(
+          iName,
+          womType,
+          defaultExpr,
+          _,
+          _
+          ) =>
         s"${typeName(womType)} ${iName} = ${defaultExpr.sourceString}"
 
       // An input whose value should always be calculated from the default, and is

--- a/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
@@ -11,125 +11,141 @@ import dxWDL.base.WomTypeSerialization.typeName
 
 object WomPrettyPrintApproxWdl {
 
-    // Convert a fully qualified name to a local name.
-    // Examples:
-    //   SOURCE         RESULT
-    //   lib.concat     concat
-    //   lib.sum_list   sum_list
-    private def getUnqualifiedName(fqn: String) : String = {
-        if (fqn contains ".")
-            fqn.split("\\.").last
+  // Convert a fully qualified name to a local name.
+  // Examples:
+  //   SOURCE         RESULT
+  //   lib.concat     concat
+  //   lib.sum_list   sum_list
+  private def getUnqualifiedName(fqn: String): String = {
+    if (fqn contains ".")
+      fqn.split("\\.").last
+    else
+      fqn
+  }
+
+  private def applyGNode(node: GraphNode, indent: String): Option[String] = {
+    node match {
+      case sct: ScatterNode =>
+        val varNames = sct.scatterVariableNodes.map { svn =>
+          svn.identifier.localName.value
+        }
+        assert(varNames.size == 1)
+        val varName                     = varNames.head
+        val svNode: ScatterVariableNode = sct.scatterVariableNodes.head
+        val collection                  = svNode.scatterExpressionNode.womExpression.sourceString
+        val orderedNodes                = Block.partialSortByDep(sct.innerGraph.nodes)
+        val innerBlock = orderedNodes
+          .flatMap { node =>
+            applyGNode(node, indent + "  ")
+          }
+          .mkString("\n")
+        Some(s"""|${indent}scatter (${varName} in ${collection}) {
+                         |${innerBlock}
+                         |${indent}}
+                         |""".stripMargin)
+
+      case cnd: ConditionalNode =>
+        val orderedNodes = Block.partialSortByDep(cnd.innerGraph.nodes)
+        val innerBlock =
+          orderedNodes
+            .flatMap { node =>
+              applyGNode(node, indent + "  ")
+            }
+            .mkString("\n")
+        Some(s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
+                         |${innerBlock}
+                         |${indent}}
+                         |""".stripMargin)
+
+      case call: CommandCallNode =>
+        val inputNames = call.upstream
+          .collect {
+            case exprNode: ExpressionNode =>
+              val paramName = getUnqualifiedName(exprNode.identifier.localName.value)
+              s"${paramName} = ${exprNode.womExpression.sourceString}"
+          }
+          .mkString(",")
+        val calleeName = getUnqualifiedName(call.callable.name)
+        val callName   = call.identifier.localName.value
+        val inputs =
+          if (inputNames.isEmpty) ""
+          else s"{ input: ${inputNames} }"
+        if (callName == calleeName)
+          Some(s"${indent}call ${callName} ${inputs}")
         else
-            fqn
+          Some(s"${indent}call ${calleeName} as ${callName} ${inputs}")
+
+      case expr: ExpressionBasedGraphOutputNode =>
+        val exprSource = expr.womExpression.sourceString
+        Some(
+          s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} = ${exprSource}"
+        )
+
+      case expr: ExposedExpressionNode =>
+        Some(
+          s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} =  ${expr.womExpression.sourceString}"
+        )
+
+      case expr: ExpressionNode =>
+        //Some(expr.womExpression.sourceString)
+        None
+
+      case _: OuterGraphInputNode =>
+        None
+
+      case PortBasedGraphOutputNode(id, womType, sourcePort) =>
+        None
+
+      case _: GraphInputNode =>
+        None
+
+      case other =>
+        Some(other.toString)
     }
+  }
 
-    private def applyGNode(node: GraphNode,
-                           indent : String) : Option[String] = {
-        node match {
-            case sct : ScatterNode =>
-                val varNames = sct.scatterVariableNodes.map{svn => svn.identifier.localName.value}
-                assert(varNames.size == 1)
-                val varName = varNames.head
-                val svNode: ScatterVariableNode = sct.scatterVariableNodes.head
-                val collection = svNode.scatterExpressionNode.womExpression.sourceString
-                val orderedNodes = Block.partialSortByDep(sct.innerGraph.nodes)
-                val innerBlock = orderedNodes.flatMap{ node =>
-                    applyGNode(node, indent + "  ")
-                }.mkString("\n")
-                Some(s"""|${indent}scatter (${varName} in ${collection}) {
-                         |${innerBlock}
-                         |${indent}}
-                         |""".stripMargin)
+  private def applyInput(iDef: InputDefinition): String = {
+    iDef match {
+      case RequiredInputDefinition(iName, womType, _, _) =>
+        s"${typeName(womType)} ${iName}"
 
-            case cnd : ConditionalNode =>
-                val orderedNodes = Block.partialSortByDep(cnd.innerGraph.nodes)
-                val innerBlock =
-                    orderedNodes.flatMap{ node =>
-                        applyGNode(node, indent + "  ")
-                    }.mkString("\n")
-                Some(s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
-                         |${innerBlock}
-                         |${indent}}
-                         |""".stripMargin)
+      case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        s"${typeName(womType)} ${iName} = ${defaultExpr.sourceString}"
 
-            case call : CommandCallNode =>
-                val inputNames = call.upstream.collect{
-                    case exprNode: ExpressionNode =>
-                        val paramName = getUnqualifiedName(exprNode.identifier.localName.value)
-                        s"${paramName} = ${exprNode.womExpression.sourceString}"
-                }.mkString(",")
-                val calleeName = getUnqualifiedName(call.callable.name)
-                val callName = call.identifier.localName.value
-                val inputs =
-                    if (inputNames.isEmpty) ""
-                    else s"{ input: ${inputNames} }"
-                if (callName == calleeName)
-                    Some(s"${indent}call ${callName} ${inputs}")
-                else
-                    Some(s"${indent}call ${calleeName} as ${callName} ${inputs}")
+      // An input whose value should always be calculated from the default, and is
+      // not allowed to be overridden.
+      case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
+        s"${typeName(womType)} ${iName} = ${defaultExpr.sourceString}"
 
-            case expr :ExpressionBasedGraphOutputNode =>
-                val exprSource = expr.womExpression.sourceString
-                Some(s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} = ${exprSource}")
+      case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
+        s"${typeName(womType)}? ${iName}"
 
-            case expr : ExposedExpressionNode =>
-                Some(s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} =  ${expr.womExpression.sourceString}")
-
-            case expr : ExpressionNode =>
-                //Some(expr.womExpression.sourceString)
-                None
-
-            case _ : OuterGraphInputNode =>
-                None
-
-            case PortBasedGraphOutputNode(id, womType, sourcePort) =>
-                None
-
-            case _ : GraphInputNode =>
-                None
-
-            case other =>
-                Some(other.toString)
-        }
+      case other =>
+        throw new Exception(s"${other} not handled")
     }
+  }
 
+  def graphInputs(inputDefs: Seq[InputDefinition]): String = {
+    inputDefs
+      .map {
+        applyInput(_)
+      }
+      .mkString("\n")
+  }
 
-    private def applyInput(iDef : InputDefinition) : String = {
-        iDef match {
-            case RequiredInputDefinition(iName, womType, _, _) =>
-                s"${typeName(womType)} ${iName}"
+  def graphOutputs(outputs: Seq[GraphOutputNode]): String = {
+    outputs
+      .flatMap {
+        applyGNode(_, "    ")
+      }
+      .mkString("\n")
+  }
 
-            case OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                s"${typeName(womType)} ${iName} = ${defaultExpr.sourceString}"
-
-            // An input whose value should always be calculated from the default, and is
-            // not allowed to be overridden.
-            case FixedInputDefinitionWithDefault(iName, womType, defaultExpr, _, _) =>
-                s"${typeName(womType)} ${iName} = ${defaultExpr.sourceString}"
-
-            case OptionalInputDefinition(iName, WomOptionalType(womType), _, _) =>
-                s"${typeName(womType)}? ${iName}"
-
-            case other =>
-                throw new Exception(s"${other} not handled")
-        }
-    }
-
-    def graphInputs(inputDefs : Seq[InputDefinition]) : String = {
-        inputDefs.map{
-            applyInput(_)
-        }.mkString("\n")
-    }
-
-    def graphOutputs(outputs : Seq[GraphOutputNode]) : String = {
-        outputs.flatMap{
-            applyGNode(_, "    ")
-        }.mkString("\n")
-    }
-
-    def block(block : Block) : String = {
-        block.nodes.flatMap{
-            applyGNode(_, "    ")
-        }.mkString("\n")
-    }
+  def block(block: Block): String = {
+    block.nodes
+      .flatMap {
+        applyGNode(_, "    ")
+      }
+      .mkString("\n")
+  }
 }

--- a/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
@@ -30,10 +30,10 @@ object WomPrettyPrintApproxWdl {
           svn.identifier.localName.value
         }
         assert(varNames.size == 1)
-        val varName                     = varNames.head
+        val varName = varNames.head
         val svNode: ScatterVariableNode = sct.scatterVariableNodes.head
-        val collection                  = svNode.scatterExpressionNode.womExpression.sourceString
-        val orderedNodes                = Block.partialSortByDep(sct.innerGraph.nodes)
+        val collection = svNode.scatterExpressionNode.womExpression.sourceString
+        val orderedNodes = Block.partialSortByDep(sct.innerGraph.nodes)
         val innerBlock = orderedNodes
           .flatMap { node =>
             applyGNode(node, indent + "  ")
@@ -66,7 +66,7 @@ object WomPrettyPrintApproxWdl {
           }
           .mkString(",")
         val calleeName = getUnqualifiedName(call.callable.name)
-        val callName   = call.identifier.localName.value
+        val callName = call.identifier.localName.value
         val inputs =
           if (inputNames.isEmpty) ""
           else s"{ input: ${inputNames} }"

--- a/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
+++ b/src/main/scala/dxWDL/util/WomPrettyPrintApproxWdl.scala
@@ -53,7 +53,7 @@ object WomPrettyPrintApproxWdl {
             }
             .mkString("\n")
         Some(
-          s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
+            s"""|${indent}if ${cnd.conditionExpression.womExpression.sourceString} {
                          |${innerBlock}
                          |${indent}}
                          |""".stripMargin
@@ -81,12 +81,12 @@ object WomPrettyPrintApproxWdl {
       case expr: ExpressionBasedGraphOutputNode =>
         val exprSource = expr.womExpression.sourceString
         Some(
-          s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} = ${exprSource}"
+            s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} = ${exprSource}"
         )
 
       case expr: ExposedExpressionNode =>
         Some(
-          s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} =  ${expr.womExpression.sourceString}"
+            s"${indent}${typeName(expr.womType)} ${expr.identifier.localName.value} =  ${expr.womExpression.sourceString}"
         )
 
       case expr: ExpressionNode =>

--- a/src/main/scala/dxWDL/util/WomValueAnalysis.scala
+++ b/src/main/scala/dxWDL/util/WomValueAnalysis.scala
@@ -13,7 +13,7 @@ object WomValueAnalysis {
   // These are used for evaluating if a WOM expression is constant.
   // Ideally, we should not be using any of the IO functions, since
   // these checks may be part of the compilation process.
-  private lazy val dxPathConfig  = DxPathConfig(Paths.get("/tmp/"), false, false)
+  private lazy val dxPathConfig = DxPathConfig(Paths.get("/tmp/"), false, false)
   private lazy val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, 0)
 
   // Examine task foo:

--- a/src/main/scala/dxWDL/util/WomValueAnalysis.scala
+++ b/src/main/scala/dxWDL/util/WomValueAnalysis.scala
@@ -89,9 +89,9 @@ object WomValueAnalysis {
 
       case (_, _) =>
         throw new Exception(
-          s"""|Unsupported combination type=(${womType.stableName},${womType})
+            s"""|Unsupported combination type=(${womType.stableName},${womType})
                     |value=(${value.toWomString}, ${value})""".stripMargin
-            .replaceAll("\n", " ")
+              .replaceAll("\n", " ")
         )
     }
   }

--- a/src/main/scala/dxWDL/util/WomValueAnalysis.scala
+++ b/src/main/scala/dxWDL/util/WomValueAnalysis.scala
@@ -77,7 +77,10 @@ object WomValueAnalysis {
       case (_, WomOptionalValue(_, None)) => false
 
       // struct -- make sure all of its fields do not require evaluation
-      case (WomCompositeType(typeMap: Map[String, WomType], _), WomObject(valueMap, _)) =>
+      case (
+          WomCompositeType(typeMap: Map[String, WomType], _),
+          WomObject(valueMap, _)
+          ) =>
         typeMap.exists {
           case (name, t) =>
             val value: WomValue = valueMap(name)
@@ -85,8 +88,11 @@ object WomValueAnalysis {
         }
 
       case (_, _) =>
-        throw new Exception(s"""|Unsupported combination type=(${womType.stableName},${womType})
-                    |value=(${value.toWomString}, ${value})""".stripMargin.replaceAll("\n", " "))
+        throw new Exception(
+          s"""|Unsupported combination type=(${womType.stableName},${womType})
+                    |value=(${value.toWomString}, ${value})""".stripMargin
+            .replaceAll("\n", " ")
+        )
     }
   }
 
@@ -114,7 +120,8 @@ object WomValueAnalysis {
 
   def evalConst(womType: WomType, expr: WomExpression): WomValue = {
     ifConstEval(womType, expr) match {
-      case None           => throw new Exception(s"Expression ${expr} is not a WDL constant")
+      case None =>
+        throw new Exception(s"Expression ${expr} is not a WDL constant")
       case Some(wdlValue) => wdlValue
     }
   }

--- a/src/main/scala/dxWDL/util/WomValueAnalysis.scala
+++ b/src/main/scala/dxWDL/util/WomValueAnalysis.scala
@@ -10,114 +10,113 @@ import wom.expression._
 import dxWDL.base.Utils
 
 object WomValueAnalysis {
-    // These are used for evaluating if a WOM expression is constant.
-    // Ideally, we should not be using any of the IO functions, since
-    // these checks may be part of the compilation process.
-    private lazy val dxPathConfig = DxPathConfig(Paths.get("/tmp/"), false, false)
-    private lazy val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, 0)
+  // These are used for evaluating if a WOM expression is constant.
+  // Ideally, we should not be using any of the IO functions, since
+  // these checks may be part of the compilation process.
+  private lazy val dxPathConfig  = DxPathConfig(Paths.get("/tmp/"), false, false)
+  private lazy val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, 0)
 
-    // Examine task foo:
-    //
-    // task foo {
-    //    command {
-    //       # create file mut.vcf
-    //    }
-    //    output {
-    //       File mutations = "mut.vcf"
-    //    }
-    // }
-    //
-    // File 'mutations' is not a constant output. It is generated,
-    // read from disk, and uploaded to the platform.  A file can't
-    // have a constant string as an input, this has to be a dnanexus
-    // link.
-    private def requiresEvaluation(womType: WomType,
-                                   value: WomValue) : Boolean = {
-        def isMutableFile(constantFileStr: String) : Boolean = {
-            constantFileStr match {
-                case path if path.startsWith(Utils.DX_URL_PREFIX) =>
-                    // platform files are immutable
-                    false
-                case path if path contains "://" =>
-                    throw new Exception(s"protocol not supported, cannot access ${path}")
-                case _ =>
-                    // anything else might be mutable
-                    true
-            }
-        }
-
-        (womType, value) match {
-            // Base case: primitive types.
-            case (WomBooleanType, _) => false
-            case (WomIntegerType, _) => false
-            case (WomFloatType, _) => false
-            case (WomStringType, _) => false
-            case (WomSingleFileType, WomString(s)) => isMutableFile(s)
-            case (WomSingleFileType, WomSingleFile(s)) => isMutableFile(s)
-
-            // arrays
-            case (WomArrayType(t), WomArray(_, elems)) =>
-                elems.exists(e => requiresEvaluation(t, e))
-
-            // maps
-            case (WomMapType(keyType, valueType), WomMap(_, m)) =>
-                m.keys.exists(k => requiresEvaluation(keyType, k)) ||
-                m.values.exists(v => requiresEvaluation(valueType, v))
-
-            case (WomPairType(lType, rType), WomPair(l,r)) =>
-                requiresEvaluation(lType, l) ||
-                requiresEvaluation(rType, r)
-
-            // Strip optional type
-            case (WomOptionalType(t), WomOptionalValue(_,Some(w))) =>
-                requiresEvaluation(t, w)
-            case (WomOptionalType(t), w) =>
-                requiresEvaluation(t, w)
-
-            // missing value
-            case (_, WomOptionalValue(_,None)) => false
-
-            // struct -- make sure all of its fields do not require evaluation
-            case (WomCompositeType(typeMap: Map[String, WomType], _), WomObject(valueMap, _)) =>
-                typeMap.exists{ case (name, t) =>
-                    val value : WomValue = valueMap(name)
-                    requiresEvaluation(t, value)
-                }
-
-            case (_,_) => throw new Exception(
-                s"""|Unsupported combination type=(${womType.stableName},${womType})
-                    |value=(${value.toWomString}, ${value})"""
-                    .stripMargin.replaceAll("\n", " "))
-        }
+  // Examine task foo:
+  //
+  // task foo {
+  //    command {
+  //       # create file mut.vcf
+  //    }
+  //    output {
+  //       File mutations = "mut.vcf"
+  //    }
+  // }
+  //
+  // File 'mutations' is not a constant output. It is generated,
+  // read from disk, and uploaded to the platform.  A file can't
+  // have a constant string as an input, this has to be a dnanexus
+  // link.
+  private def requiresEvaluation(womType: WomType, value: WomValue): Boolean = {
+    def isMutableFile(constantFileStr: String): Boolean = {
+      constantFileStr match {
+        case path if path.startsWith(Utils.DX_URL_PREFIX) =>
+          // platform files are immutable
+          false
+        case path if path contains "://" =>
+          throw new Exception(s"protocol not supported, cannot access ${path}")
+        case _ =>
+          // anything else might be mutable
+          true
+      }
     }
 
-    // Check if the WDL expression is a constant. If so, calculate and return it.
-    // Otherwise, return None.
-    //
-    def ifConstEval(womType: WomType, expr: WomExpression) : Option[WomValue] = {
-        val result: ErrorOr[WomValue] =
-            expr.evaluateValue(Map.empty[String, WomValue], dxIoFunctions)
-        result match {
-            case Invalid(_) => None
-            case Valid(value: WomValue) if requiresEvaluation(womType, value) =>
-                // There are WDL constants that require evaluation.
-                None
-            case Valid(value) => Some(value)
-        }
-    }
+    (womType, value) match {
+      // Base case: primitive types.
+      case (WomBooleanType, _)                   => false
+      case (WomIntegerType, _)                   => false
+      case (WomFloatType, _)                     => false
+      case (WomStringType, _)                    => false
+      case (WomSingleFileType, WomString(s))     => isMutableFile(s)
+      case (WomSingleFileType, WomSingleFile(s)) => isMutableFile(s)
 
-    def isExpressionConst(womType: WomType, expr: WomExpression) : Boolean = {
-        ifConstEval(womType, expr) match {
-            case None => false
-            case Some(_) => true
-        }
-    }
+      // arrays
+      case (WomArrayType(t), WomArray(_, elems)) =>
+        elems.exists(e => requiresEvaluation(t, e))
 
-    def evalConst(womType: WomType, expr: WomExpression) : WomValue = {
-        ifConstEval(womType, expr) match {
-            case None => throw new Exception(s"Expression ${expr} is not a WDL constant")
-            case Some(wdlValue) => wdlValue
+      // maps
+      case (WomMapType(keyType, valueType), WomMap(_, m)) =>
+        m.keys.exists(k => requiresEvaluation(keyType, k)) ||
+          m.values.exists(v => requiresEvaluation(valueType, v))
+
+      case (WomPairType(lType, rType), WomPair(l, r)) =>
+        requiresEvaluation(lType, l) ||
+          requiresEvaluation(rType, r)
+
+      // Strip optional type
+      case (WomOptionalType(t), WomOptionalValue(_, Some(w))) =>
+        requiresEvaluation(t, w)
+      case (WomOptionalType(t), w) =>
+        requiresEvaluation(t, w)
+
+      // missing value
+      case (_, WomOptionalValue(_, None)) => false
+
+      // struct -- make sure all of its fields do not require evaluation
+      case (WomCompositeType(typeMap: Map[String, WomType], _), WomObject(valueMap, _)) =>
+        typeMap.exists {
+          case (name, t) =>
+            val value: WomValue = valueMap(name)
+            requiresEvaluation(t, value)
         }
+
+      case (_, _) =>
+        throw new Exception(s"""|Unsupported combination type=(${womType.stableName},${womType})
+                    |value=(${value.toWomString}, ${value})""".stripMargin.replaceAll("\n", " "))
     }
+  }
+
+  // Check if the WDL expression is a constant. If so, calculate and return it.
+  // Otherwise, return None.
+  //
+  def ifConstEval(womType: WomType, expr: WomExpression): Option[WomValue] = {
+    val result: ErrorOr[WomValue] =
+      expr.evaluateValue(Map.empty[String, WomValue], dxIoFunctions)
+    result match {
+      case Invalid(_)                                                   => None
+      case Valid(value: WomValue) if requiresEvaluation(womType, value) =>
+        // There are WDL constants that require evaluation.
+        None
+      case Valid(value) => Some(value)
+    }
+  }
+
+  def isExpressionConst(womType: WomType, expr: WomExpression): Boolean = {
+    ifConstEval(womType, expr) match {
+      case None    => false
+      case Some(_) => true
+    }
+  }
+
+  def evalConst(womType: WomType, expr: WomExpression): WomValue = {
+    ifConstEval(womType, expr) match {
+      case None           => throw new Exception(s"Expression ${expr} is not a WDL constant")
+      case Some(wdlValue) => wdlValue
+    }
+  }
 
 }

--- a/src/test/scala/dxWDL/base/ExtrasTest.scala
+++ b/src/test/scala/dxWDL/base/ExtrasTest.scala
@@ -9,7 +9,7 @@ import wom.values._
 import DefaultJsonProtocol._
 
 class ExtrasTest extends FlatSpec with Matchers {
-  val verbose  = Verbose(true, true, Set.empty)
+  val verbose = Verbose(true, true, Set.empty)
   val verbose2 = Verbose(false, true, Set.empty)
 
   private def getIdFromName(name: String): String = {
@@ -121,7 +121,7 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-    val js     = runSpecValid.parseJson
+    val js = runSpecValid.parseJson
     val extras = Extras.parse(js, verbose)
     extras.defaultTaskDxAttributes should be(
       Some(
@@ -166,7 +166,7 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-    val js     = runSpec.parseJson
+    val js = runSpec.parseJson
     val extras = Extras.parse(js, verbose)
 
     val restartPolicy =
@@ -208,7 +208,7 @@ class ExtrasTest extends FlatSpec with Matchers {
   ignore should "parse the custom_reorg object" in {
 
     // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val appId: String = getIdFromName("/release_test/mummer_nucmer_aligner")
     val fileId: String = getIdFromName("Readme.md")
 
     // inputs is Readme.md file in project-FJ90qPj0jy8zYvVV9yz3F5gv
@@ -333,7 +333,7 @@ class ExtrasTest extends FlatSpec with Matchers {
   it should "throw IllegalArgumentException due to invalid file ID" in {
 
     // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val appId: String = getIdFromName("/release_test/mummer_nucmer_aligner")
     val inputs: String = "file-1223445"
     val reorg: JsValue =
       s"""|{
@@ -355,7 +355,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
 
-    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val appId: String = getIdFromName("/release_test/mummer_nucmer_aligner")
     val inputs: String = "dx://file-AZBYlBQ0jy1qpqJz17gpXFf8"
     val reorg: JsValue =
       s"""|{
@@ -462,7 +462,7 @@ class ExtrasTest extends FlatSpec with Matchers {
                 | }
                 |}""".stripMargin.parseJson
 
-    val extras                      = Extras.parse(runtimeAttrs, verbose)
+    val extras = Extras.parse(runtimeAttrs, verbose)
     val dockerOpt: Option[WomValue] = extras.defaultRuntimeAttributes.m.get("docker")
     dockerOpt match {
       case None =>

--- a/src/test/scala/dxWDL/base/ExtrasTest.scala
+++ b/src/test/scala/dxWDL/base/ExtrasTest.scala
@@ -170,11 +170,22 @@ class ExtrasTest extends FlatSpec with Matchers {
     val extras = Extras.parse(js, verbose)
 
     val restartPolicy =
-      Map("UnresponsiveWorker" -> 2, "JMInternalError" -> 0, "ExecutionError" -> 4)
+      Map(
+        "UnresponsiveWorker" -> 2,
+        "JMInternalError" -> 0,
+        "ExecutionError" -> 4
+      )
     extras.defaultTaskDxAttributes should be(
       Some(
         DxAttrs(
-          Some(DxRunSpec(None, Some(DxExecPolicy(Some(restartPolicy), Some(5))), None, None)),
+          Some(
+            DxRunSpec(
+              None,
+              Some(DxExecPolicy(Some(restartPolicy), Some(5))),
+              None,
+              None
+            )
+          ),
           None
         )
       )
@@ -242,7 +253,9 @@ class ExtrasTest extends FlatSpec with Matchers {
       Extras.parse(reorg, verbose2)
     }
 
-    thrown.getMessage should be("app_id must be specified in the custom_reorg section.")
+    thrown.getMessage should be(
+      "app_id must be specified in the custom_reorg section."
+    )
   }
 
   it should "throw IllegalArgumentException due to missing inputs in custom_reorg section" in {
@@ -463,12 +476,15 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}""".stripMargin.parseJson
 
     val extras = Extras.parse(runtimeAttrs, verbose)
-    val dockerOpt: Option[WomValue] = extras.defaultRuntimeAttributes.m.get("docker")
+    val dockerOpt: Option[WomValue] =
+      extras.defaultRuntimeAttributes.m.get("docker")
     dockerOpt match {
       case None =>
         throw new Exception("Wrong type for dockerOpt")
       case Some(docker) =>
-        docker should equal(WomString("quay.io/encode-dcc/atac-seq-pipeline:v1"))
+        docker should equal(
+          WomString("quay.io/encode-dcc/atac-seq-pipeline:v1")
+        )
     }
   }
 
@@ -482,7 +498,9 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}""".stripMargin.parseJson
 
     val extrasEmpty = Extras.parse(rtEmpty, verbose)
-    extrasEmpty.defaultRuntimeAttributes should equal(WdlRuntimeAttrs(Map.empty))
+    extrasEmpty.defaultRuntimeAttributes should equal(
+      WdlRuntimeAttrs(Map.empty)
+    )
   }
 
   it should "accept per task attributes" in {
@@ -553,7 +571,9 @@ class ExtrasTest extends FlatSpec with Matchers {
           None
         ),
         "Add" -> DxAttrs(
-          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+          Some(
+            DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
+          ),
           None
         )
       )
@@ -630,7 +650,9 @@ class ExtrasTest extends FlatSpec with Matchers {
     extras.perTaskDxAttributes should be(
       Map(
         "Add" -> DxAttrs(
-          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+          Some(
+            DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
+          ),
           Some(
             DxDetails(
               Some(
@@ -698,7 +720,9 @@ class ExtrasTest extends FlatSpec with Matchers {
     extras.defaultTaskDxAttributes should be(
       Some(
         DxAttrs(
-          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, Some(12), None)))),
+          Some(
+            DxRunSpec(None, None, None, Some(DxTimeout(None, Some(12), None)))
+          ),
           None
         )
       )
@@ -741,7 +765,13 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(data, verbose)
     extras.dockerRegistry should be(
-      Some(DockerRegistry("foo.bar.dnanexus.com", "perkins", "The Bandersnatch has gotten loose"))
+      Some(
+        DockerRegistry(
+          "foo.bar.dnanexus.com",
+          "perkins",
+          "The Bandersnatch has gotten loose"
+        )
+      )
     )
   }
 
@@ -811,8 +841,22 @@ class ExtrasTest extends FlatSpec with Matchers {
              |""".stripMargin.parseJson
 
     val upstreamProjects = List(
-      DxLicense("name", "repoURL", "version1", "license1", "licenseURL", "author1"),
-      DxLicense("name2", "repoURL", "version2", "license2", "licenseURL", "author2")
+      DxLicense(
+        "name",
+        "repoURL",
+        "version1",
+        "license1",
+        "licenseURL",
+        "author1"
+      ),
+      DxLicense(
+        "name2",
+        "repoURL",
+        "version2",
+        "license2",
+        "licenseURL",
+        "author2"
+      )
     )
 
     val dxDetails = DxDetails(Some(upstreamProjects))
@@ -872,7 +916,8 @@ class ExtrasTest extends FlatSpec with Matchers {
             |
           """.stripMargin.parseJson
 
-    val expected: Map[String, JsValue] = Map("upstreamProjects" -> expectedContent)
+    val expected: Map[String, JsValue] =
+      Map("upstreamProjects" -> expectedContent)
 
     val dxAttrs: DxAttrs = DxAttrs(
       None,

--- a/src/test/scala/dxWDL/base/ExtrasTest.scala
+++ b/src/test/scala/dxWDL/base/ExtrasTest.scala
@@ -31,7 +31,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(runtimeAttrs, verbose)
     extras.defaultTaskDxAttributes should be(
-      Some(DxAttrs(Some(DxRunSpec(None, None, Some("all"), None)), None))
+        Some(DxAttrs(Some(DxRunSpec(None, None, Some("all"), None)), None))
     )
   }
 
@@ -124,27 +124,27 @@ class ExtrasTest extends FlatSpec with Matchers {
     val js = runSpecValid.parseJson
     val extras = Extras.parse(js, verbose)
     extras.defaultTaskDxAttributes should be(
-      Some(
-        DxAttrs(
-          Some(
-            DxRunSpec(
-              Some(
-                DxAccess(
-                  Some(Vector("*")),
-                  Some(AccessLevel.CONTRIBUTE),
-                  Some(AccessLevel.VIEW),
-                  Some(true),
-                  None
-                )
-              ),
-              Some(DxExecPolicy(Some(Map("*" -> 3)), None)),
-              None,
-              Some(DxTimeout(None, Some(12), None))
+        Some(
+            DxAttrs(
+                Some(
+                    DxRunSpec(
+                        Some(
+                            DxAccess(
+                                Some(Vector("*")),
+                                Some(AccessLevel.CONTRIBUTE),
+                                Some(AccessLevel.VIEW),
+                                Some(true),
+                                None
+                            )
+                        ),
+                        Some(DxExecPolicy(Some(Map("*" -> 3)), None)),
+                        None,
+                        Some(DxTimeout(None, Some(12), None))
+                    )
+                ),
+                None
             )
-          ),
-          None
         )
-      )
     )
   }
 
@@ -171,24 +171,24 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val restartPolicy =
       Map(
-        "UnresponsiveWorker" -> 2,
-        "JMInternalError" -> 0,
-        "ExecutionError" -> 4
+          "UnresponsiveWorker" -> 2,
+          "JMInternalError" -> 0,
+          "ExecutionError" -> 4
       )
     extras.defaultTaskDxAttributes should be(
-      Some(
-        DxAttrs(
-          Some(
-            DxRunSpec(
-              None,
-              Some(DxExecPolicy(Some(restartPolicy), Some(5))),
-              None,
-              None
+        Some(
+            DxAttrs(
+                Some(
+                    DxRunSpec(
+                        None,
+                        Some(DxExecPolicy(Some(restartPolicy), Some(5))),
+                        None,
+                        None
+                    )
+                ),
+                None
             )
-          ),
-          None
         )
-      )
     )
   }
 
@@ -234,7 +234,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(reorg, verbose2)
     extras.customReorgAttributes should be(
-      Some(ReorgAttrs(appId, fileId))
+        Some(ReorgAttrs(appId, fileId))
     )
   }
 
@@ -254,7 +254,7 @@ class ExtrasTest extends FlatSpec with Matchers {
     }
 
     thrown.getMessage should be(
-      "app_id must be specified in the custom_reorg section."
+        "app_id must be specified in the custom_reorg section."
     )
   }
 
@@ -276,7 +276,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     //thrown.getMessage should contain  ("inputs must be specified in the custom_reorg section.")
     thrown.getMessage should be(
-      "conf must be specified in the custom_reorg section. Please set the value to null if there is no conf file."
+        "conf must be specified in the custom_reorg section. Please set the value to null if there is no conf file."
     )
   }
 
@@ -295,7 +295,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(reorg, verbose2)
     extras.customReorgAttributes should be(
-      Some(ReorgAttrs(appId, ""))
+        Some(ReorgAttrs(appId, ""))
     )
   }
 
@@ -317,7 +317,7 @@ class ExtrasTest extends FlatSpec with Matchers {
     }
 
     thrown.getMessage should be(
-      s"dxId must match applet-[A-Za-z0-9]{24}"
+        s"dxId must match applet-[A-Za-z0-9]{24}"
     )
   }
 
@@ -339,7 +339,7 @@ class ExtrasTest extends FlatSpec with Matchers {
     }
 
     thrown.getMessage should be(
-      s"""Error running command dx describe $appId --json"""
+        s"""Error running command dx describe $appId --json"""
     )
 
   }
@@ -361,7 +361,7 @@ class ExtrasTest extends FlatSpec with Matchers {
       Extras.parse(reorg, verbose2)
     }
     thrown.getMessage should include(
-      "does not match [A-Za-z0-9]{24}"
+        "does not match [A-Za-z0-9]{24}"
     )
   }
   it should "throw ResourceNotFoundException due to non-existant file" in {
@@ -406,8 +406,8 @@ class ExtrasTest extends FlatSpec with Matchers {
     }
 
     thrown.getMessage should be(
-      s"ERROR: App(let) for custom reorg stage ${appId} does not " +
-        s"have CONTRIBUTOR or ADMINISTRATOR access and this is required."
+        s"ERROR: App(let) for custom reorg stage ${appId} does not " +
+          s"have CONTRIBUTOR or ADMINISTRATOR access and this is required."
     )
   }
 
@@ -425,7 +425,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(reorg, verbose2)
     extras.customReorgAttributes should be(
-      Some(ReorgAttrs(appId, ""))
+        Some(ReorgAttrs(appId, ""))
     )
   }
 
@@ -483,7 +483,7 @@ class ExtrasTest extends FlatSpec with Matchers {
         throw new Exception("Wrong type for dockerOpt")
       case Some(docker) =>
         docker should equal(
-          WomString("quay.io/encode-dcc/atac-seq-pipeline:v1")
+            WomString("quay.io/encode-dcc/atac-seq-pipeline:v1")
         )
     }
   }
@@ -499,7 +499,7 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extrasEmpty = Extras.parse(rtEmpty, verbose)
     extrasEmpty.defaultRuntimeAttributes should equal(
-      WdlRuntimeAttrs(Map.empty)
+        WdlRuntimeAttrs(Map.empty)
     )
   }
 
@@ -543,40 +543,40 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(runSpec, verbose)
     extras.defaultTaskDxAttributes should be(
-      Some(
-        DxAttrs(
-          Some(
-            DxRunSpec(
-              None,
-              None,
-              None,
-              Some(DxTimeout(None, Some(12), None))
+        Some(
+            DxAttrs(
+                Some(
+                    DxRunSpec(
+                        None,
+                        None,
+                        None,
+                        Some(DxTimeout(None, Some(12), None))
+                    )
+                ),
+                None
             )
-          ),
-          None
         )
-      )
     )
     extras.perTaskDxAttributes should be(
-      Map(
-        "Multiply" -> DxAttrs(
-          Some(
-            DxRunSpec(
-              Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
-              None,
-              None,
-              Some(DxTimeout(None, None, Some(30)))
+        Map(
+            "Multiply" -> DxAttrs(
+                Some(
+                    DxRunSpec(
+                        Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
+                        None,
+                        None,
+                        Some(DxTimeout(None, None, Some(30)))
+                    )
+                ),
+                None
+            ),
+            "Add" -> DxAttrs(
+                Some(
+                    DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
+                ),
+                None
             )
-          ),
-          None
-        ),
-        "Add" -> DxAttrs(
-          Some(
-            DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
-          ),
-          None
         )
-      )
     )
   }
 
@@ -632,56 +632,56 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(runSpec, verbose)
     extras.defaultTaskDxAttributes should be(
-      Some(
-        DxAttrs(
-          Some(
-            DxRunSpec(
-              None,
-              None,
-              None,
-              Some(DxTimeout(None, Some(12), None))
+        Some(
+            DxAttrs(
+                Some(
+                    DxRunSpec(
+                        None,
+                        None,
+                        None,
+                        Some(DxTimeout(None, Some(12), None))
+                    )
+                ),
+                None
             )
-          ),
-          None
         )
-      )
     )
 
     extras.perTaskDxAttributes should be(
-      Map(
-        "Add" -> DxAttrs(
-          Some(
-            DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
-          ),
-          Some(
-            DxDetails(
-              Some(
-                List(
-                  DxLicense(
-                    "GATK4",
-                    "https://github.com/broadinstitute/gatk",
-                    "GATK-4.0.1.2",
-                    "BSD-3-Clause",
-                    "https://github.com/broadinstitute/LICENSE.TXT",
-                    "Broad Institute"
-                  )
+        Map(
+            "Add" -> DxAttrs(
+                Some(
+                    DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))
+                ),
+                Some(
+                    DxDetails(
+                        Some(
+                            List(
+                                DxLicense(
+                                    "GATK4",
+                                    "https://github.com/broadinstitute/gatk",
+                                    "GATK-4.0.1.2",
+                                    "BSD-3-Clause",
+                                    "https://github.com/broadinstitute/LICENSE.TXT",
+                                    "Broad Institute"
+                                )
+                            )
+                        )
+                    )
                 )
-              )
+            ),
+            "Multiply" -> DxAttrs(
+                Some(
+                    DxRunSpec(
+                        Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
+                        None,
+                        None,
+                        Some(DxTimeout(None, None, Some(30)))
+                    )
+                ),
+                None
             )
-          )
-        ),
-        "Multiply" -> DxAttrs(
-          Some(
-            DxRunSpec(
-              Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
-              None,
-              None,
-              Some(DxTimeout(None, None, Some(30)))
-            )
-          ),
-          None
         )
-      )
     )
   }
 
@@ -718,37 +718,37 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(runSpec, verbose)
     extras.defaultTaskDxAttributes should be(
-      Some(
-        DxAttrs(
-          Some(
-            DxRunSpec(None, None, None, Some(DxTimeout(None, Some(12), None)))
-          ),
-          None
+        Some(
+            DxAttrs(
+                Some(
+                    DxRunSpec(None, None, None, Some(DxTimeout(None, Some(12), None)))
+                ),
+                None
+            )
         )
-      )
     )
     extras.perTaskDxAttributes should be(
-      Map(
-        "Add" -> DxAttrs(
-          None,
-          Some(
-            DxDetails(
-              Some(
-                List(
-                  DxLicense(
-                    "GATK4",
-                    "https://github.com/broadinstitute/gatk",
-                    "GATK-4.0.1.2",
-                    "BSD-3-Clause",
-                    "https://github.com/broadinstitute/LICENSE.TXT",
-                    "Broad Institute"
-                  )
+        Map(
+            "Add" -> DxAttrs(
+                None,
+                Some(
+                    DxDetails(
+                        Some(
+                            List(
+                                DxLicense(
+                                    "GATK4",
+                                    "https://github.com/broadinstitute/gatk",
+                                    "GATK-4.0.1.2",
+                                    "BSD-3-Clause",
+                                    "https://github.com/broadinstitute/LICENSE.TXT",
+                                    "Broad Institute"
+                                )
+                            )
+                        )
+                    )
                 )
-              )
             )
-          )
         )
-      )
     )
   }
 
@@ -765,13 +765,13 @@ class ExtrasTest extends FlatSpec with Matchers {
 
     val extras = Extras.parse(data, verbose)
     extras.dockerRegistry should be(
-      Some(
-        DockerRegistry(
-          "foo.bar.dnanexus.com",
-          "perkins",
-          "The Bandersnatch has gotten loose"
+        Some(
+            DockerRegistry(
+                "foo.bar.dnanexus.com",
+                "perkins",
+                "The Bandersnatch has gotten loose"
+            )
         )
-      )
     )
   }
 
@@ -841,22 +841,22 @@ class ExtrasTest extends FlatSpec with Matchers {
              |""".stripMargin.parseJson
 
     val upstreamProjects = List(
-      DxLicense(
-        "name",
-        "repoURL",
-        "version1",
-        "license1",
-        "licenseURL",
-        "author1"
-      ),
-      DxLicense(
-        "name2",
-        "repoURL",
-        "version2",
-        "license2",
-        "licenseURL",
-        "author2"
-      )
+        DxLicense(
+            "name",
+            "repoURL",
+            "version1",
+            "license1",
+            "licenseURL",
+            "author1"
+        ),
+        DxLicense(
+            "name2",
+            "repoURL",
+            "version2",
+            "license2",
+            "licenseURL",
+            "author2"
+        )
     )
 
     val dxDetails = DxDetails(Some(upstreamProjects))
@@ -878,8 +878,8 @@ class ExtrasTest extends FlatSpec with Matchers {
     val expected: Map[String, JsValue] = Map("timeoutPolicy" -> expectedPolicy)
 
     val dxAttrs: DxAttrs = DxAttrs(
-      Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
-      None
+        Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+        None
     )
 
     val runSpecJson: Map[String, JsValue] = dxAttrs.getRunSpecJson
@@ -920,23 +920,23 @@ class ExtrasTest extends FlatSpec with Matchers {
       Map("upstreamProjects" -> expectedContent)
 
     val dxAttrs: DxAttrs = DxAttrs(
-      None,
-      Some(
-        DxDetails(
-          Some(
-            List(
-              DxLicense(
-                "GATK4",
-                "https://github.com/broadinstitute/gatk",
-                "GATK-4.0.1.2",
-                "BSD-3-Clause",
-                "https://github.com/broadinstitute/LICENSE.TXT",
-                "Broad Institute"
-              )
+        None,
+        Some(
+            DxDetails(
+                Some(
+                    List(
+                        DxLicense(
+                            "GATK4",
+                            "https://github.com/broadinstitute/gatk",
+                            "GATK-4.0.1.2",
+                            "BSD-3-Clause",
+                            "https://github.com/broadinstitute/LICENSE.TXT",
+                            "Broad Institute"
+                        )
+                    )
+                )
             )
-          )
         )
-      )
     )
 
     val detailsJson = dxAttrs.getDetailsJson

--- a/src/test/scala/dxWDL/base/ExtrasTest.scala
+++ b/src/test/scala/dxWDL/base/ExtrasTest.scala
@@ -9,19 +9,19 @@ import wom.values._
 import DefaultJsonProtocol._
 
 class ExtrasTest extends FlatSpec with Matchers {
-    val verbose = Verbose(true, true, Set.empty)
-    val verbose2 = Verbose(false, true, Set.empty)
+  val verbose  = Verbose(true, true, Set.empty)
+  val verbose2 = Verbose(false, true, Set.empty)
 
-    private def getIdFromName(name: String): String = {
-      val (stdout, stderr) = Utils.execCommand(s"dx describe ${name} --json")
-      stdout.parseJson.asJsObject match {
-        case JsObject(x) => JsObject(x).fields("id").convertTo[String]
-      }
+  private def getIdFromName(name: String): String = {
+    val (stdout, stderr) = Utils.execCommand(s"dx describe ${name} --json")
+    stdout.parseJson.asJsObject match {
+      case JsObject(x) => JsObject(x).fields("id").convertTo[String]
     }
+  }
 
-    it should "recognize restartable entry points" in {
-        val runtimeAttrs : JsValue =
-            """|{
+  it should "recognize restartable entry points" in {
+    val runtimeAttrs: JsValue =
+      """|{
                |  "default_task_dx_attributes" : {
                |     "runSpec" : {
                |       "restartableEntryPoints": "all"
@@ -29,14 +29,15 @@ class ExtrasTest extends FlatSpec with Matchers {
                |  }
                |}""".stripMargin.parseJson
 
-        val extras = Extras.parse(runtimeAttrs, verbose)
-        extras.defaultTaskDxAttributes should be (Some(
-            DxAttrs(Some(DxRunSpec(None, None, Some("all"), None)), None)))
-    }
+    val extras = Extras.parse(runtimeAttrs, verbose)
+    extras.defaultTaskDxAttributes should be(
+      Some(DxAttrs(Some(DxRunSpec(None, None, Some("all"), None)), None))
+    )
+  }
 
-    it should "invalid runSpec I" in {
-        val ex1 =
-            """|{
+  it should "invalid runSpec I" in {
+    val ex1 =
+      """|{
                | "default_task_dx_attributes" : {
                |     "timeoutPolicy": {
                |        "main": {
@@ -47,15 +48,14 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        assertThrows[Exception] {
-            Extras.parse(ex1.parseJson, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(ex1.parseJson, verbose)
     }
+  }
 
-
-    it should "invalid runSpec II" in {
-        val ex2 =
-            """|{
+  it should "invalid runSpec II" in {
+    val ex2 =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "timeoutPolicy": {
@@ -68,14 +68,14 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        assertThrows[Exception] {
-            Extras.parse(ex2.parseJson, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(ex2.parseJson, verbose)
     }
+  }
 
-    it should "invalid runSpec III" in {
-        val ex3 =
-            """|{
+  it should "invalid runSpec III" in {
+    val ex3 =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "access" : {
@@ -88,15 +88,14 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        assertThrows[Exception] {
-            Extras.parse(ex3.parseJson, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(ex3.parseJson, verbose)
     }
+  }
 
-
-    it should "parse the run spec" in {
-        val runSpecValid =
-            """|{
+  it should "parse the run spec" in {
+    val runSpecValid =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "executionPolicy": {
@@ -122,28 +121,36 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val js = runSpecValid.parseJson
-        val extras = Extras.parse(js, verbose)
-        extras.defaultTaskDxAttributes should be (
-            Some(DxAttrs(Some(DxRunSpec(
-                           Some(DxAccess(Some(Vector("*")),
-                                         Some(AccessLevel.CONTRIBUTE),
-                                         Some(AccessLevel.VIEW),
-                                         Some(true),
-                                         None)),
-                           Some(DxExecPolicy(Some(Map("*" -> 3)),
-                                             None)),
-                           None,
-                           Some(DxTimeout(None,
-                                          Some(12),
-                                          None))
-                       )), None)))
-    }
+    val js     = runSpecValid.parseJson
+    val extras = Extras.parse(js, verbose)
+    extras.defaultTaskDxAttributes should be(
+      Some(
+        DxAttrs(
+          Some(
+            DxRunSpec(
+              Some(
+                DxAccess(
+                  Some(Vector("*")),
+                  Some(AccessLevel.CONTRIBUTE),
+                  Some(AccessLevel.VIEW),
+                  Some(true),
+                  None
+                )
+              ),
+              Some(DxExecPolicy(Some(Map("*" -> 3)), None)),
+              None,
+              Some(DxTimeout(None, Some(12), None))
+            )
+          ),
+          None
+        )
+      )
+    )
+  }
 
-
-    it should "parse complex execution policy" in {
-        val runSpec =
-            """|{
+  it should "parse complex execution policy" in {
+    val runSpec =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "executionPolicy": {
@@ -159,21 +166,24 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val js = runSpec.parseJson
-        val extras = Extras.parse(js, verbose)
+    val js     = runSpec.parseJson
+    val extras = Extras.parse(js, verbose)
 
-        val restartPolicy = Map("UnresponsiveWorker" -> 2, "JMInternalError" -> 0, "ExecutionError" -> 4)
-        extras.defaultTaskDxAttributes should be (Some(DxAttrs(Some(DxRunSpec(
-                                                           None,
-                                                           Some(DxExecPolicy(Some(restartPolicy), Some(5))),
-                                                           None,
-                                                           None)
-                                                  ), None)))
-    }
+    val restartPolicy =
+      Map("UnresponsiveWorker" -> 2, "JMInternalError" -> 0, "ExecutionError" -> 4)
+    extras.defaultTaskDxAttributes should be(
+      Some(
+        DxAttrs(
+          Some(DxRunSpec(None, Some(DxExecPolicy(Some(restartPolicy), Some(5))), None, None)),
+          None
+        )
+      )
+    )
+  }
 
-    it should "recognize error in complex execution policy" in {
-        val runSpec =
-            """|{
+  it should "recognize error in complex execution policy" in {
+    val runSpec =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "executionPolicy": {
@@ -188,22 +198,22 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val js = runSpec.parseJson
-        assertThrows[Exception] {
-            Extras.parse(js, verbose2)
-        }
+    val js = runSpec.parseJson
+    assertThrows[Exception] {
+      Extras.parse(js, verbose2)
     }
+  }
 
-    // Need to include method to upload the README.md file.
-    ignore should "parse the custom_reorg object" in {
+  // Need to include method to upload the README.md file.
+  ignore should "parse the custom_reorg object" in {
 
-        // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
-        val fileId : String = getIdFromName("Readme.md")
+    // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val fileId: String = getIdFromName("Readme.md")
 
-        // inputs is Readme.md file in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val reorg: JsValue   =
-            s"""|{
+    // inputs is Readme.md file in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val reorg: JsValue =
+      s"""|{
                | "custom_reorg" : {
                |    "app_id" :"${appId}",
                |    "conf" : "${fileId}"
@@ -211,60 +221,58 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin.parseJson
 
-        val extras = Extras.parse(reorg, verbose2)
-        extras.customReorgAttributes  should be (
-            Some(ReorgAttrs(appId, fileId))
-        )
-    }
+    val extras = Extras.parse(reorg, verbose2)
+    extras.customReorgAttributes should be(
+      Some(ReorgAttrs(appId, fileId))
+    )
+  }
 
-    it should "throw IllegalArgumentException due to missing applet id" in {
+  it should "throw IllegalArgumentException due to missing applet id" in {
 
-        val inputs: String = "dx://file-123456"
-        val reorg: JsValue   =
-            s"""|{
+    val inputs: String = "dx://file-123456"
+    val reorg: JsValue =
+      s"""|{
                 | "custom_reorg" : {
                 |    "conf" : "${inputs}"
                 |  }
                 |}
                 |""".stripMargin.parseJson
 
-
-        val thrown = intercept[dxWDL.base.IllegalArgumentException] {
-            Extras.parse(reorg, verbose2)
-        }
-
-        thrown.getMessage should be ("app_id must be specified in the custom_reorg section.")
+    val thrown = intercept[dxWDL.base.IllegalArgumentException] {
+      Extras.parse(reorg, verbose2)
     }
 
-    it should "throw IllegalArgumentException due to missing inputs in custom_reorg section" in {
+    thrown.getMessage should be("app_id must be specified in the custom_reorg section.")
+  }
 
-        // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
-        val reorg: JsValue   =
-        s"""|{
+  it should "throw IllegalArgumentException due to missing inputs in custom_reorg section" in {
+
+    // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val appId: String = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val reorg: JsValue =
+      s"""|{
             | "custom_reorg" : {
             |    "app_id" : "${appId}"
             |  }
             |}
             |""".stripMargin.parseJson
 
-
-      val thrown = intercept[dxWDL.base.IllegalArgumentException] {
-          Extras.parse(reorg, verbose2)
-      }
-
-      //thrown.getMessage should contain  ("inputs must be specified in the custom_reorg section.")
-      thrown.getMessage should be  (
-          "conf must be specified in the custom_reorg section. Please set the value to null if there is no conf file."
-      )
+    val thrown = intercept[dxWDL.base.IllegalArgumentException] {
+      Extras.parse(reorg, verbose2)
     }
 
-    it should "Allow inputs to be null in custom reorg" in {
+    //thrown.getMessage should contain  ("inputs must be specified in the custom_reorg section.")
+    thrown.getMessage should be(
+      "conf must be specified in the custom_reorg section. Please set the value to null if there is no conf file."
+    )
+  }
 
-        // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
-        val reorg: JsValue   =
-            s"""|{
+  it should "Allow inputs to be null in custom reorg" in {
+
+    // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val appId: String = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val reorg: JsValue =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appId}",
                 |    "conf" : null
@@ -272,18 +280,18 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val extras = Extras.parse(reorg, verbose2)
-        extras.customReorgAttributes should be (
-            Some(ReorgAttrs(appId, ""))
-        )
-    }
+    val extras = Extras.parse(reorg, verbose2)
+    extras.customReorgAttributes should be(
+      Some(ReorgAttrs(appId, ""))
+    )
+  }
 
-    it should "throw IllegalArgumentException due to invalid applet ID" in {
+  it should "throw IllegalArgumentException due to invalid applet ID" in {
 
     // invalid applet ID
-        val appId : String = "applet-123456"
-        val reorg : JsValue =
-            s"""|{
+    val appId: String = "applet-123456"
+    val reorg: JsValue =
+      s"""|{
                 |  "custom_reorg" : {
                 |      "app_id" : "${appId}",
                 |      "conf": null
@@ -291,21 +299,21 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val thrown = intercept[dxWDL.base.IllegalArgumentException] {
-            Extras.parse(reorg, verbose2)
-        }
-
-        thrown.getMessage should be  (
-            s"dxId must match applet-[A-Za-z0-9]{24}"
-        )
+    val thrown = intercept[dxWDL.base.IllegalArgumentException] {
+      Extras.parse(reorg, verbose2)
     }
 
-    ignore should "throw ResourceNotFoundException due to non-existent applet" in {
+    thrown.getMessage should be(
+      s"dxId must match applet-[A-Za-z0-9]{24}"
+    )
+  }
 
-        // non-existent (made up) applet ID
-        val appId : String = "applet-mPX7K2j0Gv2K2jXF75Bf21v2"
-        val reorg : JsValue =
-            s"""|{
+  ignore should "throw ResourceNotFoundException due to non-existent applet" in {
+
+    // non-existent (made up) applet ID
+    val appId: String = "applet-mPX7K2j0Gv2K2jXF75Bf21v2"
+    val reorg: JsValue =
+      s"""|{
               |  "custom_reorg" : {
               |      "app_id" : "${appId}",
               |      "conf": null
@@ -313,22 +321,22 @@ class ExtrasTest extends FlatSpec with Matchers {
               |}
               |""".stripMargin.parseJson
 
-        val thrown = intercept[Exception] {
-            Extras.parse(reorg, verbose2)
+    val thrown = intercept[Exception] {
+      Extras.parse(reorg, verbose2)
     }
 
-    thrown.getMessage should be  (
+    thrown.getMessage should be(
       s"""Error running command dx describe $appId --json"""
     )
 
-    }
-    it should "throw IllegalArgumentException due to invalid file ID" in {
+  }
+  it should "throw IllegalArgumentException due to invalid file ID" in {
 
-        // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
-        val inputs : String = "file-1223445"
-        val reorg : JsValue =
-            s"""|{
+    // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val inputs: String = "file-1223445"
+    val reorg: JsValue =
+      s"""|{
                 |  "custom_reorg" : {
                 |      "app_id" : "${appId}",
                 |      "conf": "${inputs}"
@@ -336,21 +344,21 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val thrown = intercept[java.lang.IllegalArgumentException] {
-            Extras.parse(reorg, verbose2)
-        }
-        thrown.getMessage should include  (
-            "does not match [A-Za-z0-9]{24}"
-        )
+    val thrown = intercept[java.lang.IllegalArgumentException] {
+      Extras.parse(reorg, verbose2)
     }
-    it should "throw ResourceNotFoundException due to non-existant file" in {
+    thrown.getMessage should include(
+      "does not match [A-Za-z0-9]{24}"
+    )
+  }
+  it should "throw ResourceNotFoundException due to non-existant file" in {
 
     // app_id is mummer nucmer app in project-FJ90qPj0jy8zYvVV9yz3F5gv
 
-        val appId : String = getIdFromName("/release_test/mummer_nucmer_aligner")
-        val inputs : String = "dx://file-AZBYlBQ0jy1qpqJz17gpXFf8"
-        val reorg : JsValue =
-            s"""|{
+    val appId: String  = getIdFromName("/release_test/mummer_nucmer_aligner")
+    val inputs: String = "dx://file-AZBYlBQ0jy1qpqJz17gpXFf8"
+    val reorg: JsValue =
+      s"""|{
                 |  "custom_reorg" : {
                 |      "app_id" : "${appId}",
                 |      "conf": "${inputs}"
@@ -358,21 +366,21 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val thrown = intercept[ResourceNotFoundException] {
-            Extras.parse(reorg, verbose2)
-        }
-
-        val fileId : String = inputs.replace("dx://", "")
-
-        thrown.getMessage should be  (s""""${fileId}" is not a recognized ID""")
+    val thrown = intercept[ResourceNotFoundException] {
+      Extras.parse(reorg, verbose2)
     }
 
-    ignore should "throw PermissionDeniedException due to applet not having contribute access in the project" in {
+    val fileId: String = inputs.replace("dx://", "")
 
-        // app_id is sum app in project-FJ90qPj0jy8zYvVV9yz3F5gv
-        val appId : String = getIdFromName("/release_test/Sum ")
-        val reorg: JsValue =
-            s"""|{
+    thrown.getMessage should be(s""""${fileId}" is not a recognized ID""")
+  }
+
+  ignore should "throw PermissionDeniedException due to applet not having contribute access in the project" in {
+
+    // app_id is sum app in project-FJ90qPj0jy8zYvVV9yz3F5gv
+    val appId: String = getIdFromName("/release_test/Sum ")
+    val reorg: JsValue =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appId}",
                 |    "conf": "null"
@@ -380,21 +388,21 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-            val thrown = intercept[PermissionDeniedException] {
-                Extras.parse(reorg, verbose2)
-            }
-
-        thrown.getMessage should be (
-            s"ERROR: App(let) for custom reorg stage ${appId} does not " +
-            s"have CONTRIBUTOR or ADMINISTRATOR access and this is required."
-        )
+    val thrown = intercept[PermissionDeniedException] {
+      Extras.parse(reorg, verbose2)
     }
 
-    it should "take app id as well as applet id for custom reorg" taggedAs (EdgeTest) in {
+    thrown.getMessage should be(
+      s"ERROR: App(let) for custom reorg stage ${appId} does not " +
+        s"have CONTRIBUTOR or ADMINISTRATOR access and this is required."
+    )
+  }
 
-        val appId : String = getIdFromName("cloud_workstation")
-        val reorg: JsValue =
-            s"""|{
+  it should "take app id as well as applet id for custom reorg" taggedAs (EdgeTest) in {
+
+    val appId: String = getIdFromName("cloud_workstation")
+    val reorg: JsValue =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appId}",
                 |    "conf": null
@@ -402,15 +410,15 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val extras = Extras.parse(reorg, verbose2)
-        extras.customReorgAttributes  should be (
-            Some(ReorgAttrs(appId, ""))
-        )
-    }
+    val extras = Extras.parse(reorg, verbose2)
+    extras.customReorgAttributes should be(
+      Some(ReorgAttrs(appId, ""))
+    )
+  }
 
-    it should "generate valid JSON execution policy" in {
-    val expectedJs : JsValue =
-        """|{
+  it should "generate valid JSON execution policy" in {
+    val expectedJs: JsValue =
+      """|{
             | "executionPolicy": {
             |    "restartOn": {
             |       "*": 5
@@ -420,14 +428,13 @@ class ExtrasTest extends FlatSpec with Matchers {
             |}
             |""".stripMargin.parseJson
 
-        val execPolicy = DxExecPolicy(Some(Map("*" -> 5)),
-                                      Some(4))
-        JsObject(execPolicy.toJson) should be(expectedJs)
-    }
+    val execPolicy = DxExecPolicy(Some(Map("*" -> 5)), Some(4))
+    JsObject(execPolicy.toJson) should be(expectedJs)
+  }
 
-    it should "generate valid JSON timeout policy" in {
-        val expectedJs : JsValue =
-            """|{
+  it should "generate valid JSON timeout policy" in {
+    val expectedJs: JsValue =
+      """|{
                 |  "timeoutPolicy": {
                 |     "*": {
                 |        "hours": 12,
@@ -437,13 +444,13 @@ class ExtrasTest extends FlatSpec with Matchers {
                 |}
                 |""".stripMargin.parseJson
 
-        val timeout = DxTimeout(None, Some(12), Some(30))
-        JsObject(timeout.toJson) should be(expectedJs)
-    }
+    val timeout = DxTimeout(None, Some(12), Some(30))
+    JsObject(timeout.toJson) should be(expectedJs)
+  }
 
-    it should "handle default runtime attributes" in {
-        val runtimeAttrs : JsValue=
-            """|{
+  it should "handle default runtime attributes" in {
+    val runtimeAttrs: JsValue =
+      """|{
                 | "default_runtime_attributes" : {
                 |     "docker" : "quay.io/encode-dcc/atac-seq-pipeline:v1",
                 |     "zones": "us-west1-a us-west1-b us-west1-c us-central1-c us-central1-b",
@@ -455,32 +462,32 @@ class ExtrasTest extends FlatSpec with Matchers {
                 | }
                 |}""".stripMargin.parseJson
 
-        val extras = Extras.parse(runtimeAttrs, verbose)
-        val dockerOpt: Option[WomValue] = extras.defaultRuntimeAttributes.m.get("docker")
-        dockerOpt match {
-            case None =>
-                throw new Exception("Wrong type for dockerOpt")
-            case Some(docker) =>
-                 docker should equal (WomString("quay.io/encode-dcc/atac-seq-pipeline:v1"))
-        }
+    val extras                      = Extras.parse(runtimeAttrs, verbose)
+    val dockerOpt: Option[WomValue] = extras.defaultRuntimeAttributes.m.get("docker")
+    dockerOpt match {
+      case None =>
+        throw new Exception("Wrong type for dockerOpt")
+      case Some(docker) =>
+        docker should equal(WomString("quay.io/encode-dcc/atac-seq-pipeline:v1"))
     }
+  }
 
-    it should "handle default runtime attributes that are empty" in {
-        val rtEmpty : JsValue =
-            """|{
+  it should "handle default runtime attributes that are empty" in {
+    val rtEmpty: JsValue =
+      """|{
                | "default_runtime_attributes" : {
                |     "preemptible": "0",
                |     "bootDiskSizeGb": "10"
                | }
                |}""".stripMargin.parseJson
 
-        val extrasEmpty = Extras.parse(rtEmpty, verbose)
-        extrasEmpty.defaultRuntimeAttributes should equal(WdlRuntimeAttrs(Map.empty))
-    }
+    val extrasEmpty = Extras.parse(rtEmpty, verbose)
+    extrasEmpty.defaultRuntimeAttributes should equal(WdlRuntimeAttrs(Map.empty))
+  }
 
-    it should "accept per task attributes" in {
-        val runSpec : JsValue =
-            """|{
+  it should "accept per task attributes" in {
+    val runSpec: JsValue =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "timeoutPolicy": {
@@ -516,24 +523,46 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin.parseJson
 
-        val extras = Extras.parse(runSpec, verbose)
-        extras.defaultTaskDxAttributes should be (
-            Some(DxAttrs(Some(DxRunSpec(
-                     None,
-                     None,
-                     None,
-                     Some(DxTimeout(None, Some(12), None))
-                 )), None)))
-        extras.perTaskDxAttributes should be (
-            Map("Multiply" -> DxAttrs(Some(DxRunSpec(Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
-                                        None, None, Some(DxTimeout(None, None, Some(30))))), None),
-                "Add" -> DxAttrs(Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))), None)
-        ))
-    }
+    val extras = Extras.parse(runSpec, verbose)
+    extras.defaultTaskDxAttributes should be(
+      Some(
+        DxAttrs(
+          Some(
+            DxRunSpec(
+              None,
+              None,
+              None,
+              Some(DxTimeout(None, Some(12), None))
+            )
+          ),
+          None
+        )
+      )
+    )
+    extras.perTaskDxAttributes should be(
+      Map(
+        "Multiply" -> DxAttrs(
+          Some(
+            DxRunSpec(
+              Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
+              None,
+              None,
+              Some(DxTimeout(None, None, Some(30)))
+            )
+          ),
+          None
+        ),
+        "Add" -> DxAttrs(
+          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+          None
+        )
+      )
+    )
+  }
 
-    it should "include optional details and runSpec in per task attributes" in {
-        val runSpec : JsValue =
-            """|{
+  it should "include optional details and runSpec in per task attributes" in {
+    val runSpec: JsValue =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "timeoutPolicy": {
@@ -581,36 +610,62 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin.parseJson
 
-        val extras = Extras.parse(runSpec, verbose)
-        extras.defaultTaskDxAttributes should be (
-            Some(DxAttrs(Some(DxRunSpec(
-                None,
-                None,
-                None,
-                Some(DxTimeout(None, Some(12), None))
-            )), None)))
-
-        extras.perTaskDxAttributes should be (
-            Map("Add" -> DxAttrs(
-                Some(DxRunSpec(
-                    None, None, None, Some(DxTimeout(None, None, Some(30))))),
-                Some(DxDetails(Some(
-                    List(DxLicense(
-                        "GATK4",
-                        "https://github.com/broadinstitute/gatk",
-                        "GATK-4.0.1.2",
-                        "BSD-3-Clause",
-                        "https://github.com/broadinstitute/LICENSE.TXT",
-                        "Broad Institute")))))),
-                "Multiply" -> DxAttrs(
-                    Some(DxRunSpec(Some(DxAccess(None,Some(AccessLevel.UPLOAD),None,None,None)), None, None, Some(DxTimeout(None, None, Some(30))))), None)
+    val extras = Extras.parse(runSpec, verbose)
+    extras.defaultTaskDxAttributes should be(
+      Some(
+        DxAttrs(
+          Some(
+            DxRunSpec(
+              None,
+              None,
+              None,
+              Some(DxTimeout(None, Some(12), None))
             )
+          ),
+          None
         )
-    }
+      )
+    )
 
-    it should "include optional details in per task attributes" in {
-        val runSpec : JsValue =
-            """|{
+    extras.perTaskDxAttributes should be(
+      Map(
+        "Add" -> DxAttrs(
+          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+          Some(
+            DxDetails(
+              Some(
+                List(
+                  DxLicense(
+                    "GATK4",
+                    "https://github.com/broadinstitute/gatk",
+                    "GATK-4.0.1.2",
+                    "BSD-3-Clause",
+                    "https://github.com/broadinstitute/LICENSE.TXT",
+                    "Broad Institute"
+                  )
+                )
+              )
+            )
+          )
+        ),
+        "Multiply" -> DxAttrs(
+          Some(
+            DxRunSpec(
+              Some(DxAccess(None, Some(AccessLevel.UPLOAD), None, None, None)),
+              None,
+              None,
+              Some(DxTimeout(None, None, Some(30)))
+            )
+          ),
+          None
+        )
+      )
+    )
+  }
+
+  it should "include optional details in per task attributes" in {
+    val runSpec: JsValue =
+      """|{
                | "default_task_dx_attributes" : {
                |   "runSpec": {
                |     "timeoutPolicy": {
@@ -639,31 +694,43 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin.parseJson
 
-        val extras = Extras.parse(runSpec, verbose)
-        extras.defaultTaskDxAttributes should be (
-            Some(
-                DxAttrs(
-                    Some(DxRunSpec(None,None,None,Some(DxTimeout(None,Some(12),None)))),
-                    None
-            )))
-        extras.perTaskDxAttributes should be (
-            Map("Add" -> DxAttrs(
-                None,
-                Some(DxDetails(Some(
-                    List(DxLicense(
-                        "GATK4",
-                        "https://github.com/broadinstitute/gatk",
-                        "GATK-4.0.1.2",
-                        "BSD-3-Clause",
-                        "https://github.com/broadinstitute/LICENSE.TXT",
-                        "Broad Institute"))))))
-            )
+    val extras = Extras.parse(runSpec, verbose)
+    extras.defaultTaskDxAttributes should be(
+      Some(
+        DxAttrs(
+          Some(DxRunSpec(None, None, None, Some(DxTimeout(None, Some(12), None)))),
+          None
         )
-    }
+      )
+    )
+    extras.perTaskDxAttributes should be(
+      Map(
+        "Add" -> DxAttrs(
+          None,
+          Some(
+            DxDetails(
+              Some(
+                List(
+                  DxLicense(
+                    "GATK4",
+                    "https://github.com/broadinstitute/gatk",
+                    "GATK-4.0.1.2",
+                    "BSD-3-Clause",
+                    "https://github.com/broadinstitute/LICENSE.TXT",
+                    "Broad Institute"
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  }
 
-    it should "parse the docker registry section" in {
-        val data =
-            """|{
+  it should "parse the docker registry section" in {
+    val data =
+      """|{
                | "docker_registry" : {
                |   "registry" : "foo.bar.dnanexus.com",
                |   "username" : "perkins",
@@ -672,17 +739,15 @@ class ExtrasTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin.parseJson
 
-        val extras = Extras.parse(data, verbose)
-        extras.dockerRegistry should be (
-            Some(DockerRegistry(
-                     "foo.bar.dnanexus.com",
-                     "perkins",
-                     "The Bandersnatch has gotten loose")))
-    }
+    val extras = Extras.parse(data, verbose)
+    extras.dockerRegistry should be(
+      Some(DockerRegistry("foo.bar.dnanexus.com", "perkins", "The Bandersnatch has gotten loose"))
+    )
+  }
 
-    it should "recognize errors in docker registry section" in {
-        val data =
-            """|{
+  it should "recognize errors in docker registry section" in {
+    val data =
+      """|{
                | "docker_registry" : {
                |   "registry_my" : "foo.bar.dnanexus.com",
                |   "username" : "perkins",
@@ -690,43 +755,42 @@ class ExtrasTest extends FlatSpec with Matchers {
                | }
                |}
                |""".stripMargin.parseJson
-        assertThrows[Exception] {
-            Extras.parse(data, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(data, verbose)
     }
+  }
 
-    it should "recognize errors in docker registry section II" in {
-        val data =
-            """|{
+  it should "recognize errors in docker registry section II" in {
+    val data =
+      """|{
                | "docker_registry" : {
                |   "registry" : "foo.bar.dnanexus.com",
                |   "credentials" : "BandersnatchOnTheLoose"
                | }
                |}
                |""".stripMargin.parseJson
-        assertThrows[Exception] {
-            Extras.parse(data, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(data, verbose)
     }
+  }
 
-
-    it should "recognize errors in docker registry section III" in {
-        val data =
-            """|{
+  it should "recognize errors in docker registry section III" in {
+    val data =
+      """|{
                | "docker_registry" : {
                |   "creds" : "XXX"
                | }
                |}
                |""".stripMargin.parseJson
-        assertThrows[Exception] {
-            Extras.parse(data, verbose)
-        }
+    assertThrows[Exception] {
+      Extras.parse(data, verbose)
     }
+  }
 
-    it should "convert DxLicense to JsValue" in {
+  it should "convert DxLicense to JsValue" in {
 
-        val dxDetailsJson : JsValue =
-          """|[
+    val dxDetailsJson: JsValue =
+      """|[
              |   {
              |      "author":"author1",
              |      "license":"license1",
@@ -746,21 +810,20 @@ class ExtrasTest extends FlatSpec with Matchers {
              |]
              |""".stripMargin.parseJson
 
+    val upstreamProjects = List(
+      DxLicense("name", "repoURL", "version1", "license1", "licenseURL", "author1"),
+      DxLicense("name2", "repoURL", "version2", "license2", "licenseURL", "author2")
+    )
 
-        val upstreamProjects  = List(
-            DxLicense("name", "repoURL", "version1", "license1", "licenseURL", "author1"),
-            DxLicense("name2", "repoURL", "version2", "license2", "licenseURL", "author2"),
-        )
+    val dxDetails = DxDetails(Some(upstreamProjects))
 
-        val dxDetails = DxDetails(Some(upstreamProjects))
+    val result = dxDetails.toDetailsJson
+    result("upstreamProjects") should be(dxDetailsJson)
+  }
 
-        val result = dxDetails.toDetailsJson
-        result("upstreamProjects") should be (dxDetailsJson)
-    }
+  it should "all DxAttr to return RunSpec Json" in {
 
-    it should "all DxAttr to return RunSpec Json" in {
-
-        val expectedPolicy = """
+    val expectedPolicy = """
             |{
             |  "*": {
             |    "minutes": 30
@@ -768,35 +831,34 @@ class ExtrasTest extends FlatSpec with Matchers {
             |}
           """.stripMargin.parseJson
 
-        val expected: Map[String, JsValue] = Map("timeoutPolicy" -> expectedPolicy)
+    val expected: Map[String, JsValue] = Map("timeoutPolicy" -> expectedPolicy)
 
-        val dxAttrs: DxAttrs = DxAttrs(
-            Some(DxRunSpec(
-                None, None, None, Some(DxTimeout(None, None, Some(30))))),
-            None
-        )
+    val dxAttrs: DxAttrs = DxAttrs(
+      Some(DxRunSpec(None, None, None, Some(DxTimeout(None, None, Some(30))))),
+      None
+    )
 
-        val runSpecJson: Map[String, JsValue] = dxAttrs.getRunSpecJson
-        (runSpecJson) should be (expected)
+    val runSpecJson: Map[String, JsValue] = dxAttrs.getRunSpecJson
+    (runSpecJson) should be(expected)
 
-    }
+  }
 
-    it should "all DxAttr to return empty runSpec and details Json" in {
+  it should "all DxAttr to return empty runSpec and details Json" in {
 
-        val dxAttrs = DxAttrs(None, None)
+    val dxAttrs = DxAttrs(None, None)
 
-        val runSpecJson = dxAttrs.getRunSpecJson
-        runSpecJson should be (Map.empty)
+    val runSpecJson = dxAttrs.getRunSpecJson
+    runSpecJson should be(Map.empty)
 
-        val detailJson = dxAttrs.getDetailsJson
-        detailJson should be (Map.empty)
+    val detailJson = dxAttrs.getDetailsJson
+    detailJson should be(Map.empty)
 
-    }
+  }
 
-    it should "all DxAttr to return Details Json" in {
+  it should "all DxAttr to return Details Json" in {
 
-        val expectedContent =
-          """
+    val expectedContent =
+      """
             |[
             |  {
             |    "name": "GATK4",
@@ -810,25 +872,30 @@ class ExtrasTest extends FlatSpec with Matchers {
             |
           """.stripMargin.parseJson
 
-        val expected: Map[String, JsValue] = Map("upstreamProjects" -> expectedContent)
+    val expected: Map[String, JsValue] = Map("upstreamProjects" -> expectedContent)
 
-        val dxAttrs: DxAttrs = DxAttrs(
-            None,
-            Some(DxDetails(Some(
-                List(DxLicense(
-                    "GATK4",
-                    "https://github.com/broadinstitute/gatk",
-                    "GATK-4.0.1.2",
-                    "BSD-3-Clause",
-                    "https://github.com/broadinstitute/LICENSE.TXT",
-                    "Broad Institute")
-                )
-            ))
+    val dxAttrs: DxAttrs = DxAttrs(
+      None,
+      Some(
+        DxDetails(
+          Some(
+            List(
+              DxLicense(
+                "GATK4",
+                "https://github.com/broadinstitute/gatk",
+                "GATK-4.0.1.2",
+                "BSD-3-Clause",
+                "https://github.com/broadinstitute/LICENSE.TXT",
+                "Broad Institute"
+              )
             )
+          )
         )
+      )
+    )
 
-        val detailsJson = dxAttrs.getDetailsJson
+    val detailsJson = dxAttrs.getDetailsJson
 
-        expected should be (detailsJson)
-}
+    expected should be(detailsJson)
+  }
 }

--- a/src/test/scala/dxWDL/base/UtilsTest.scala
+++ b/src/test/scala/dxWDL/base/UtilsTest.scala
@@ -4,41 +4,41 @@ import org.scalatest.{FlatSpec, Matchers}
 import spray.json._
 
 class UtilsTest extends FlatSpec with Matchers {
-    val sentence = "I am major major"
+  val sentence = "I am major major"
 
+  it should "Correctly compress and decompress" in {
+    val s2 = Utils.gzipDecompress(Utils.gzipCompress(sentence.getBytes))
+    sentence should be(s2)
+  }
 
-    it should "Correctly compress and decompress" in {
-        val s2 = Utils.gzipDecompress(Utils.gzipCompress(sentence.getBytes))
-        sentence should be (s2)
-    }
+  it should "Correctly encode and decode base64" in {
+    val encodeDecode = Utils.base64DecodeAndGunzip(Utils.gzipAndBase64Encode(sentence))
+    sentence should be(encodeDecode)
+  }
 
-    it should "Correctly encode and decode base64" in {
-        val encodeDecode = Utils.base64DecodeAndGunzip(Utils.gzipAndBase64Encode(sentence))
-        sentence should be (encodeDecode)
-    }
+  it should "make JSON maps deterministic" in {
+    val x = JsObject("a" -> JsNumber(1), "b" -> JsNumber(2))
+    val y = JsObject("b" -> JsNumber(2), "a" -> JsNumber(1))
+    Utils.makeDeterministic(x) should be(Utils.makeDeterministic(y))
 
-    it should "make JSON maps deterministic" in {
-        val x = JsObject("a" -> JsNumber(1), "b" -> JsNumber(2))
-        val y = JsObject("b" -> JsNumber(2), "a" -> JsNumber(1))
-        Utils.makeDeterministic(x) should be(Utils.makeDeterministic(y))
+    val x2 = JsObject("a" -> JsNumber(10), "b" -> JsNumber(2))
+    val y2 = JsObject("b" -> JsNumber(2), "a"  -> JsNumber(1))
+    assert(Utils.makeDeterministic(x2) != Utils.makeDeterministic(y2))
+  }
 
-        val x2 = JsObject("a" -> JsNumber(10), "b" -> JsNumber(2))
-        val y2 = JsObject("b" -> JsNumber(2), "a" -> JsNumber(1))
-        assert(Utils.makeDeterministic(x2) != Utils.makeDeterministic(y2))
-    }
+  it should "build limited sized names" in {
+    val retval = Utils.buildLimitedSizeName(Vector(1, 2, 3).map(_.toString), 10)
+    retval should be("[1, 2, 3]")
 
+    val retval2 = Utils.buildLimitedSizeName(Vector(100, 200, 300).map(_.toString), 10)
+    retval2 should be("[100, 200]")
 
-    it should "build limited sized names" in {
-        val retval = Utils.buildLimitedSizeName(Vector(1, 2, 3).map(_.toString), 10)
-        retval should be ("[1, 2, 3]")
+    Utils.buildLimitedSizeName(Vector("A", "B", "hel", "nope"), 10) should be("[A, B, hel]")
 
-        val retval2 = Utils.buildLimitedSizeName(Vector(100, 200, 300).map(_.toString), 10)
-        retval2 should be ("[100, 200]")
+    Utils.buildLimitedSizeName(Vector("A", "B", "C", "D", "neverland"), 13) should be(
+      "[A, B, C, D]"
+    )
 
-        Utils.buildLimitedSizeName(Vector("A", "B", "hel", "nope"), 10) should be ("[A, B, hel]")
-
-        Utils.buildLimitedSizeName(Vector("A", "B", "C", "D", "neverland"), 13) should be ("[A, B, C, D]")
-
-        Utils.buildLimitedSizeName(Vector.empty, 4) should be ("[]")
-    }
+    Utils.buildLimitedSizeName(Vector.empty, 4) should be("[]")
+  }
 }

--- a/src/test/scala/dxWDL/base/UtilsTest.scala
+++ b/src/test/scala/dxWDL/base/UtilsTest.scala
@@ -12,7 +12,8 @@ class UtilsTest extends FlatSpec with Matchers {
   }
 
   it should "Correctly encode and decode base64" in {
-    val encodeDecode = Utils.base64DecodeAndGunzip(Utils.gzipAndBase64Encode(sentence))
+    val encodeDecode =
+      Utils.base64DecodeAndGunzip(Utils.gzipAndBase64Encode(sentence))
     sentence should be(encodeDecode)
   }
 
@@ -30,10 +31,13 @@ class UtilsTest extends FlatSpec with Matchers {
     val retval = Utils.buildLimitedSizeName(Vector(1, 2, 3).map(_.toString), 10)
     retval should be("[1, 2, 3]")
 
-    val retval2 = Utils.buildLimitedSizeName(Vector(100, 200, 300).map(_.toString), 10)
+    val retval2 =
+      Utils.buildLimitedSizeName(Vector(100, 200, 300).map(_.toString), 10)
     retval2 should be("[100, 200]")
 
-    Utils.buildLimitedSizeName(Vector("A", "B", "hel", "nope"), 10) should be("[A, B, hel]")
+    Utils.buildLimitedSizeName(Vector("A", "B", "hel", "nope"), 10) should be(
+      "[A, B, hel]"
+    )
 
     Utils.buildLimitedSizeName(Vector("A", "B", "C", "D", "neverland"), 13) should be(
       "[A, B, C, D]"

--- a/src/test/scala/dxWDL/base/UtilsTest.scala
+++ b/src/test/scala/dxWDL/base/UtilsTest.scala
@@ -22,7 +22,7 @@ class UtilsTest extends FlatSpec with Matchers {
     Utils.makeDeterministic(x) should be(Utils.makeDeterministic(y))
 
     val x2 = JsObject("a" -> JsNumber(10), "b" -> JsNumber(2))
-    val y2 = JsObject("b" -> JsNumber(2), "a"  -> JsNumber(1))
+    val y2 = JsObject("b" -> JsNumber(2), "a" -> JsNumber(1))
     assert(Utils.makeDeterministic(x2) != Utils.makeDeterministic(y2))
   }
 

--- a/src/test/scala/dxWDL/base/UtilsTest.scala
+++ b/src/test/scala/dxWDL/base/UtilsTest.scala
@@ -36,11 +36,11 @@ class UtilsTest extends FlatSpec with Matchers {
     retval2 should be("[100, 200]")
 
     Utils.buildLimitedSizeName(Vector("A", "B", "hel", "nope"), 10) should be(
-      "[A, B, hel]"
+        "[A, B, hel]"
     )
 
     Utils.buildLimitedSizeName(Vector("A", "B", "C", "D", "neverland"), 13) should be(
-      "[A, B, C, D]"
+        "[A, B, C, D]"
     )
 
     Utils.buildLimitedSizeName(Vector.empty, 4) should be("[]")

--- a/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
@@ -49,7 +49,7 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
 
   it should "work for structs" in {
     val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
-    val typeSerialize                     = WomTypeSerialization(typeAliases)
+    val typeSerialize = WomTypeSerialization(typeAliases)
 
     for (t <- structTestCases) {
       typeSerialize.fromString(typeSerialize.toString(t)) should be(t)
@@ -65,7 +65,7 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
 
   it should "detect bad type descriptions" in {
     val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
-    val typeSerialize                     = WomTypeSerialization(typeAliases)
+    val typeSerialize = WomTypeSerialization(typeAliases)
 
     for (typeDesc <- badTypeNames) {
       assertThrows[Exception] {

--- a/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
@@ -5,89 +5,81 @@ import wom.types._
 
 class WomTypeSerializationTest extends FlatSpec with Matchers {
 
-    val testCases : List[WomType] = List(
-        // Primitive types
-        WomNothingType,
-        WomBooleanType,
-        WomIntegerType,
-        WomLongType,
-        WomFloatType,
-        WomStringType,
-        WomSingleFileType,
+  val testCases: List[WomType] = List(
+    // Primitive types
+    WomNothingType,
+    WomBooleanType,
+    WomIntegerType,
+    WomLongType,
+    WomFloatType,
+    WomStringType,
+    WomSingleFileType,
+    // array
+    WomMaybeEmptyArrayType(WomStringType),
+    WomNonEmptyArrayType(WomSingleFileType),
+    // maps
+    WomMapType(WomStringType, WomSingleFileType),
+    WomMapType(WomStringType, WomMapType(WomFloatType, WomIntegerType)),
+    // optionals
+    WomOptionalType(WomLongType),
+    WomOptionalType(WomMaybeEmptyArrayType(WomBooleanType)),
+    WomPairType(WomIntegerType, WomStringType)
+  )
 
-        // array
-        WomMaybeEmptyArrayType(WomStringType),
-        WomNonEmptyArrayType(WomSingleFileType),
+  it should "work for various WDL types" in {
+    val typeSerialize = WomTypeSerialization(Map.empty)
 
-        // maps
-        WomMapType(WomStringType, WomSingleFileType),
-        WomMapType(WomStringType, WomMapType(WomFloatType, WomIntegerType)),
-
-        // optionals
-        WomOptionalType(WomLongType),
-        WomOptionalType(WomMaybeEmptyArrayType(WomBooleanType)),
-
-        WomPairType(WomIntegerType, WomStringType)
-    )
-
-    it should "work for various WDL types" in {
-        val typeSerialize = WomTypeSerialization(Map.empty)
-
-        for (t <- testCases) {
-            typeSerialize.fromString(typeSerialize.toString(t)) should be (t)
-        }
+    for (t <- testCases) {
+      typeSerialize.fromString(typeSerialize.toString(t)) should be(t)
     }
+  }
 
-    val personType = WomCompositeType(Map("name" -> WomStringType,
-                                          "age" -> WomIntegerType),
-                                      Some("Person"))
-    val houseType = WomCompositeType(Map("street" -> WomStringType,
-                                         "zip code" -> WomIntegerType,
-                                         "owner" -> personType),
-                                      Some("House"))
+  val personType =
+    WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+  val houseType = WomCompositeType(
+    Map("street" -> WomStringType, "zip code" -> WomIntegerType, "owner" -> personType),
+    Some("House")
+  )
 
-    val structTestCases : List[WomType] = List(
-        personType,
-        WomPairType(personType, houseType),
-        WomOptionalType(houseType)
-    )
+  val structTestCases: List[WomType] = List(
+    personType,
+    WomPairType(personType, houseType),
+    WomOptionalType(houseType)
+  )
 
-    it should "work for structs" in {
-        val typeAliases: Map[String, WomType] = Map("Person" -> personType,
-                                                    "House" -> houseType)
-        val typeSerialize = WomTypeSerialization(typeAliases)
+  it should "work for structs" in {
+    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val typeSerialize                     = WomTypeSerialization(typeAliases)
 
-        for (t <- structTestCases) {
-            typeSerialize.fromString(typeSerialize.toString(t)) should be (t)
-        }
+    for (t <- structTestCases) {
+      typeSerialize.fromString(typeSerialize.toString(t)) should be(t)
     }
+  }
 
-    val badTypeNames : List[String] = List(
-        "A bad type",
-        "dummy",
-        "Map[Int, UnrealFile]",
-        "Pair[Int, Map[Int, X__String]]"
-    )
+  val badTypeNames: List[String] = List(
+    "A bad type",
+    "dummy",
+    "Map[Int, UnrealFile]",
+    "Pair[Int, Map[Int, X__String]]"
+  )
 
-    it should "detect bad type descriptions" in {
-        val typeAliases: Map[String, WomType] = Map("Person" -> personType,
-                                                    "House" -> houseType)
-        val typeSerialize = WomTypeSerialization(typeAliases)
+  it should "detect bad type descriptions" in {
+    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val typeSerialize                     = WomTypeSerialization(typeAliases)
 
-        for (typeDesc <- badTypeNames) {
-            assertThrows[Exception] {
-                typeSerialize.fromString(typeDesc)
-            }
-        }
+    for (typeDesc <- badTypeNames) {
+      assertThrows[Exception] {
+        typeSerialize.fromString(typeDesc)
+      }
     }
+  }
 
-    it should "detect objects that aren't structs" in {
-        val typeSerialize = WomTypeSerialization(Map.empty)
-        val objectWithoutName  = WomCompositeType(Map("name" -> WomStringType,
-                                                      "age" -> WomIntegerType),
-                                                  None)
-        assertThrows[Exception] {
-            typeSerialize.toString(objectWithoutName)
-        }
+  it should "detect objects that aren't structs" in {
+    val typeSerialize = WomTypeSerialization(Map.empty)
+    val objectWithoutName =
+      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), None)
+    assertThrows[Exception] {
+      typeSerialize.toString(objectWithoutName)
     }
+  }
 }

--- a/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
@@ -35,9 +35,16 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
   }
 
   val personType =
-    WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+    WomCompositeType(
+      Map("name" -> WomStringType, "age" -> WomIntegerType),
+      Some("Person")
+    )
   val houseType = WomCompositeType(
-    Map("street" -> WomStringType, "zip code" -> WomIntegerType, "owner" -> personType),
+    Map(
+      "street" -> WomStringType,
+      "zip code" -> WomIntegerType,
+      "owner" -> personType
+    ),
     Some("House")
   )
 
@@ -48,7 +55,8 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
   )
 
   it should "work for structs" in {
-    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val typeAliases: Map[String, WomType] =
+      Map("Person" -> personType, "House" -> houseType)
     val typeSerialize = WomTypeSerialization(typeAliases)
 
     for (t <- structTestCases) {
@@ -64,7 +72,8 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
   )
 
   it should "detect bad type descriptions" in {
-    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val typeAliases: Map[String, WomType] =
+      Map("Person" -> personType, "House" -> houseType)
     val typeSerialize = WomTypeSerialization(typeAliases)
 
     for (typeDesc <- badTypeNames) {
@@ -77,7 +86,10 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
   it should "detect objects that aren't structs" in {
     val typeSerialize = WomTypeSerialization(Map.empty)
     val objectWithoutName =
-      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), None)
+      WomCompositeType(
+        Map("name" -> WomStringType, "age" -> WomIntegerType),
+        None
+      )
     assertThrows[Exception] {
       typeSerialize.toString(objectWithoutName)
     }

--- a/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomTypeSerializationTest.scala
@@ -6,24 +6,24 @@ import wom.types._
 class WomTypeSerializationTest extends FlatSpec with Matchers {
 
   val testCases: List[WomType] = List(
-    // Primitive types
-    WomNothingType,
-    WomBooleanType,
-    WomIntegerType,
-    WomLongType,
-    WomFloatType,
-    WomStringType,
-    WomSingleFileType,
-    // array
-    WomMaybeEmptyArrayType(WomStringType),
-    WomNonEmptyArrayType(WomSingleFileType),
-    // maps
-    WomMapType(WomStringType, WomSingleFileType),
-    WomMapType(WomStringType, WomMapType(WomFloatType, WomIntegerType)),
-    // optionals
-    WomOptionalType(WomLongType),
-    WomOptionalType(WomMaybeEmptyArrayType(WomBooleanType)),
-    WomPairType(WomIntegerType, WomStringType)
+      // Primitive types
+      WomNothingType,
+      WomBooleanType,
+      WomIntegerType,
+      WomLongType,
+      WomFloatType,
+      WomStringType,
+      WomSingleFileType,
+      // array
+      WomMaybeEmptyArrayType(WomStringType),
+      WomNonEmptyArrayType(WomSingleFileType),
+      // maps
+      WomMapType(WomStringType, WomSingleFileType),
+      WomMapType(WomStringType, WomMapType(WomFloatType, WomIntegerType)),
+      // optionals
+      WomOptionalType(WomLongType),
+      WomOptionalType(WomMaybeEmptyArrayType(WomBooleanType)),
+      WomPairType(WomIntegerType, WomStringType)
   )
 
   it should "work for various WDL types" in {
@@ -36,22 +36,22 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
 
   val personType =
     WomCompositeType(
-      Map("name" -> WomStringType, "age" -> WomIntegerType),
-      Some("Person")
+        Map("name" -> WomStringType, "age" -> WomIntegerType),
+        Some("Person")
     )
   val houseType = WomCompositeType(
-    Map(
-      "street" -> WomStringType,
-      "zip code" -> WomIntegerType,
-      "owner" -> personType
-    ),
-    Some("House")
+      Map(
+          "street" -> WomStringType,
+          "zip code" -> WomIntegerType,
+          "owner" -> personType
+      ),
+      Some("House")
   )
 
   val structTestCases: List[WomType] = List(
-    personType,
-    WomPairType(personType, houseType),
-    WomOptionalType(houseType)
+      personType,
+      WomPairType(personType, houseType),
+      WomOptionalType(houseType)
   )
 
   it should "work for structs" in {
@@ -65,10 +65,10 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
   }
 
   val badTypeNames: List[String] = List(
-    "A bad type",
-    "dummy",
-    "Map[Int, UnrealFile]",
-    "Pair[Int, Map[Int, X__String]]"
+      "A bad type",
+      "dummy",
+      "Map[Int, UnrealFile]",
+      "Pair[Int, Map[Int, X__String]]"
   )
 
   it should "detect bad type descriptions" in {
@@ -87,8 +87,8 @@ class WomTypeSerializationTest extends FlatSpec with Matchers {
     val typeSerialize = WomTypeSerialization(Map.empty)
     val objectWithoutName =
       WomCompositeType(
-        Map("name" -> WomStringType, "age" -> WomIntegerType),
-        None
+          Map("name" -> WomStringType, "age" -> WomIntegerType),
+          None
       )
     assertThrows[Exception] {
       typeSerialize.toString(objectWithoutName)

--- a/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
@@ -13,7 +13,7 @@ class WomValueSerializationTest extends FlatSpec with Matchers {
     Some("House")
   )
   val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
-  val valueSerializer                   = WomValueSerialization(typeAliases)
+  val valueSerializer = WomValueSerialization(typeAliases)
 
   val valueTestCases: List[WomValue] = List(
     // primitive types

--- a/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
@@ -6,72 +6,67 @@ import wom.values._
 import wom.types._
 
 class WomValueSerializationTest extends FlatSpec with Matchers {
-    val personType = WomCompositeType(Map("name" -> WomStringType,
-                                          "age" -> WomIntegerType),
-                                      Some("Person"))
-    val houseType = WomCompositeType(Map("street" -> WomStringType,
-                                         "zip code" -> WomIntegerType,
-                                         "owner" -> personType),
-                                      Some("House"))
-    val typeAliases: Map[String, WomType] = Map("Person" -> personType,
-                                                "House" -> houseType)
-    val valueSerializer = WomValueSerialization(typeAliases)
+  val personType =
+    WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+  val houseType = WomCompositeType(
+    Map("street" -> WomStringType, "zip code" -> WomIntegerType, "owner" -> personType),
+    Some("House")
+  )
+  val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+  val valueSerializer                   = WomValueSerialization(typeAliases)
 
-    val valueTestCases : List[WomValue] = List(
-        // primitive types
-        WomBoolean(false),
-        WomInteger(12),
-        WomFloat(1.4),
-        WomString("charming"),
-        WomSingleFile("/tmp/foo.txg"),
+  val valueTestCases: List[WomValue] = List(
+    // primitive types
+    WomBoolean(false),
+    WomInteger(12),
+    WomFloat(1.4),
+    WomString("charming"),
+    WomSingleFile("/tmp/foo.txg"),
+    // arrays
+    WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(4), WomInteger(5))),
+    // compounds
+    WomOptionalValue(WomIntegerType, Some(WomInteger(13))),
+    WomPair(WomString("A"), WomArray(WomArrayType(WomStringType), Vector.empty)),
+    // map with string keys
+    WomMap(
+      WomMapType(WomStringType, WomIntegerType),
+      Map(
+        WomString("A") -> WomInteger(1),
+        WomString("C") -> WomInteger(4),
+        WomString("G") -> WomInteger(5),
+        WomString("T") -> WomInteger(5)
+      )
+    ),
+    // map with non-string keys
+    WomMap(
+      WomMapType(WomIntegerType, WomSingleFileType),
+      Map(
+        WomInteger(1) -> WomSingleFile("/tmp/A.txt"),
+        WomInteger(3) -> WomSingleFile("/tmp/B.txt")
+      )
+    ),
+    // structs
+    WomObject(Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)), personType)
+  )
 
-        // arrays
-        WomArray(WomArrayType(WomIntegerType),
-                 Vector(WomInteger(4), WomInteger(5))),
-
-        // compounds
-        WomOptionalValue(WomIntegerType, Some(WomInteger(13))),
-        WomPair(WomString("A"), WomArray(WomArrayType(WomStringType), Vector.empty)),
-
-        // map with string keys
-        WomMap(WomMapType(WomStringType, WomIntegerType),
-               Map(WomString("A") -> WomInteger(1),
-                   WomString("C") -> WomInteger(4),
-                   WomString("G") -> WomInteger(5),
-                   WomString("T") -> WomInteger(5))),
-
-        // map with non-string keys
-        WomMap(WomMapType(WomIntegerType, WomSingleFileType),
-               Map(WomInteger(1) -> WomSingleFile("/tmp/A.txt"),
-                   WomInteger(3) -> WomSingleFile("/tmp/B.txt"))),
-
-        // structs
-        WomObject(Map("name" -> WomString("Bradly"),
-                      "age" -> WomInteger(42)),
-                  personType),
-    )
-
-
-    it should "work on a variety of values" in {
-        for (v <- valueTestCases) {
-            valueSerializer.fromJSON(valueSerializer.toJSON(v)) should be(v)
-        }
+  it should "work on a variety of values" in {
+    for (v <- valueTestCases) {
+      valueSerializer.fromJSON(valueSerializer.toJSON(v)) should be(v)
     }
+  }
 
-    it should "detect bad JSON" in {
-        val badJson = JsObject("a" -> JsNumber(1),
-                               "b" -> JsString("hello"))
+  it should "detect bad JSON" in {
+    val badJson = JsObject("a" -> JsNumber(1), "b" -> JsString("hello"))
 
-        assertThrows[Exception] {
-            valueSerializer.fromJSON(badJson)
-        }
+    assertThrows[Exception] {
+      valueSerializer.fromJSON(badJson)
     }
+  }
 
-    it should "detect bad objects" in {
-        val invalidObject = WomObject(Map("name" -> WomString("Bradly"),
-                                          "age" -> WomInteger(42)))
-        assertThrows[Exception] {
-            valueSerializer.toJSON(invalidObject)
-        }
+  it should "detect bad objects" in {
+    val invalidObject = WomObject(Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)))
+    assertThrows[Exception] {
+      valueSerializer.toJSON(invalidObject)
     }
+  }
 }

--- a/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
@@ -7,12 +7,20 @@ import wom.types._
 
 class WomValueSerializationTest extends FlatSpec with Matchers {
   val personType =
-    WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+    WomCompositeType(
+      Map("name" -> WomStringType, "age" -> WomIntegerType),
+      Some("Person")
+    )
   val houseType = WomCompositeType(
-    Map("street" -> WomStringType, "zip code" -> WomIntegerType, "owner" -> personType),
+    Map(
+      "street" -> WomStringType,
+      "zip code" -> WomIntegerType,
+      "owner" -> personType
+    ),
     Some("House")
   )
-  val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+  val typeAliases: Map[String, WomType] =
+    Map("Person" -> personType, "House" -> houseType)
   val valueSerializer = WomValueSerialization(typeAliases)
 
   val valueTestCases: List[WomValue] = List(
@@ -23,10 +31,16 @@ class WomValueSerializationTest extends FlatSpec with Matchers {
     WomString("charming"),
     WomSingleFile("/tmp/foo.txg"),
     // arrays
-    WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(4), WomInteger(5))),
+    WomArray(
+      WomArrayType(WomIntegerType),
+      Vector(WomInteger(4), WomInteger(5))
+    ),
     // compounds
     WomOptionalValue(WomIntegerType, Some(WomInteger(13))),
-    WomPair(WomString("A"), WomArray(WomArrayType(WomStringType), Vector.empty)),
+    WomPair(
+      WomString("A"),
+      WomArray(WomArrayType(WomStringType), Vector.empty)
+    ),
     // map with string keys
     WomMap(
       WomMapType(WomStringType, WomIntegerType),
@@ -46,7 +60,10 @@ class WomValueSerializationTest extends FlatSpec with Matchers {
       )
     ),
     // structs
-    WomObject(Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)), personType)
+    WomObject(
+      Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)),
+      personType
+    )
   )
 
   it should "work on a variety of values" in {
@@ -64,7 +81,8 @@ class WomValueSerializationTest extends FlatSpec with Matchers {
   }
 
   it should "detect bad objects" in {
-    val invalidObject = WomObject(Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)))
+    val invalidObject =
+      WomObject(Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)))
     assertThrows[Exception] {
       valueSerializer.toJSON(invalidObject)
     }

--- a/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WomValueSerializationTest.scala
@@ -8,62 +8,62 @@ import wom.types._
 class WomValueSerializationTest extends FlatSpec with Matchers {
   val personType =
     WomCompositeType(
-      Map("name" -> WomStringType, "age" -> WomIntegerType),
-      Some("Person")
+        Map("name" -> WomStringType, "age" -> WomIntegerType),
+        Some("Person")
     )
   val houseType = WomCompositeType(
-    Map(
-      "street" -> WomStringType,
-      "zip code" -> WomIntegerType,
-      "owner" -> personType
-    ),
-    Some("House")
+      Map(
+          "street" -> WomStringType,
+          "zip code" -> WomIntegerType,
+          "owner" -> personType
+      ),
+      Some("House")
   )
   val typeAliases: Map[String, WomType] =
     Map("Person" -> personType, "House" -> houseType)
   val valueSerializer = WomValueSerialization(typeAliases)
 
   val valueTestCases: List[WomValue] = List(
-    // primitive types
-    WomBoolean(false),
-    WomInteger(12),
-    WomFloat(1.4),
-    WomString("charming"),
-    WomSingleFile("/tmp/foo.txg"),
-    // arrays
-    WomArray(
-      WomArrayType(WomIntegerType),
-      Vector(WomInteger(4), WomInteger(5))
-    ),
-    // compounds
-    WomOptionalValue(WomIntegerType, Some(WomInteger(13))),
-    WomPair(
-      WomString("A"),
-      WomArray(WomArrayType(WomStringType), Vector.empty)
-    ),
-    // map with string keys
-    WomMap(
-      WomMapType(WomStringType, WomIntegerType),
-      Map(
-        WomString("A") -> WomInteger(1),
-        WomString("C") -> WomInteger(4),
-        WomString("G") -> WomInteger(5),
-        WomString("T") -> WomInteger(5)
+      // primitive types
+      WomBoolean(false),
+      WomInteger(12),
+      WomFloat(1.4),
+      WomString("charming"),
+      WomSingleFile("/tmp/foo.txg"),
+      // arrays
+      WomArray(
+          WomArrayType(WomIntegerType),
+          Vector(WomInteger(4), WomInteger(5))
+      ),
+      // compounds
+      WomOptionalValue(WomIntegerType, Some(WomInteger(13))),
+      WomPair(
+          WomString("A"),
+          WomArray(WomArrayType(WomStringType), Vector.empty)
+      ),
+      // map with string keys
+      WomMap(
+          WomMapType(WomStringType, WomIntegerType),
+          Map(
+              WomString("A") -> WomInteger(1),
+              WomString("C") -> WomInteger(4),
+              WomString("G") -> WomInteger(5),
+              WomString("T") -> WomInteger(5)
+          )
+      ),
+      // map with non-string keys
+      WomMap(
+          WomMapType(WomIntegerType, WomSingleFileType),
+          Map(
+              WomInteger(1) -> WomSingleFile("/tmp/A.txt"),
+              WomInteger(3) -> WomSingleFile("/tmp/B.txt")
+          )
+      ),
+      // structs
+      WomObject(
+          Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)),
+          personType
       )
-    ),
-    // map with non-string keys
-    WomMap(
-      WomMapType(WomIntegerType, WomSingleFileType),
-      Map(
-        WomInteger(1) -> WomSingleFile("/tmp/A.txt"),
-        WomInteger(3) -> WomSingleFile("/tmp/B.txt")
-      )
-    ),
-    // structs
-    WomObject(
-      Map("name" -> WomString("Bradly"), "age" -> WomInteger(42)),
-      personType
-    )
   )
 
   it should "work on a variety of values" in {

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -27,47 +27,47 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
   // task compilation
   private val cFlags = List(
-    "--compileMode",
-    "ir",
-    "-quiet",
-    "-fatalValidationWarnings",
-    "--locked",
-    "--project",
-    dxProject.getId
-  )
-
-  private val cFlagsUnlocked =
-    List(
       "--compileMode",
       "ir",
       "-quiet",
       "-fatalValidationWarnings",
+      "--locked",
       "--project",
       dxProject.getId
+  )
+
+  private val cFlagsUnlocked =
+    List(
+        "--compileMode",
+        "ir",
+        "-quiet",
+        "-fatalValidationWarnings",
+        "--project",
+        dxProject.getId
     )
 
   val dbgFlags = List(
-    "--compileMode",
-    "ir",
-    "--verbose",
-    "--verboseKey",
-    "GenerateIR",
-    "--locked",
-    "--project",
-    dxProject.id
+      "--compileMode",
+      "ir",
+      "--verbose",
+      "--verboseKey",
+      "GenerateIR",
+      "--locked",
+      "--project",
+      dxProject.id
   )
 
   it should "IR compile a single WDL task" in {
     val path = pathFromBasename("compiler", "add.wdl")
     Main.compile(path.toString :: cFlags) shouldBe a[
-      Main.SuccessfulTerminationIR
+        Main.SuccessfulTerminationIR
     ]
   }
 
   it should "IR compile a task with docker" in {
     val path = pathFromBasename("compiler", "BroadGenomicsDocker.wdl")
     Main.compile(path.toString :: cFlags) shouldBe a[
-      Main.SuccessfulTerminationIR
+        Main.SuccessfulTerminationIR
     ]
   }
 
@@ -75,66 +75,66 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "IR compile a linear WDL workflow without expressions" in {
     val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
     Main.compile(path.toString :: cFlags) shouldBe a[
-      Main.SuccessfulTerminationIR
+        Main.SuccessfulTerminationIR
     ]
   }
 
   it should "IR compile a linear WDL workflow" in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "IR compile unlocked workflow" in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
     Main.compile(
-      path.toString :: cFlagsUnlocked
+        path.toString :: cFlagsUnlocked
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "IR compile a non trivial linear workflow with variable coercions" in {
     val path = pathFromBasename("compiler", "cast.wdl")
     Main.compile(path.toString :: cFlags) shouldBe a[
-      Main.SuccessfulTerminationIR
+        Main.SuccessfulTerminationIR
     ]
   }
 
   it should "IR compile a workflow with two consecutive calls" in {
     val path = pathFromBasename("compiler", "strings.wdl")
     Main.compile(path.toString :: cFlags) shouldBe a[
-      Main.SuccessfulTerminationIR
+        Main.SuccessfulTerminationIR
     ]
   }
 
   it should "IR compile a workflow with a scatter without a call" in {
     val path = pathFromBasename("compiler", "scatter_no_call.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "IR compile optionals" in {
     val path = pathFromBasename("compiler", "optionals.wdl")
     Main.compile(
-      path.toString
+        path.toString
 //                :: "--verbose"
 //                :: "--verboseKey" :: "GenerateIR"
-        :: cFlags
+          :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "support imports" in {
     val path = pathFromBasename("compiler", "check_imports.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "IR compile a draft2 workflow" in {
     val path = pathFromBasename("draft2", "shapes.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -142,28 +142,28 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "expressions in an output block" in {
     val path = pathFromBasename("compiler", "expr_output_block.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "scatters over maps" in {
     val path = pathFromBasename("compiler", "dict2.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "skip missing optional arguments" in {
     val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle calling subworkflows" in {
     val path = pathFromBasename("subworkflows", "trains.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
     val irwf = retval match {
@@ -180,20 +180,20 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "compile a sub-block with several calls" in {
     val path = pathFromBasename("compiler", "subblock_several_calls.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "missing workflow inputs" in {
     val path = pathFromBasename("input_file", "missing_args.wdl")
     Main.compile(
-      path.toString :: List(
-        "--compileMode",
-        "ir",
-        "--quiet",
-        "--project",
-        dxProject.id
-      )
+        path.toString :: List(
+            "--compileMode",
+            "ir",
+            "--quiet",
+            "--project",
+            dxProject.id
+        )
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -201,14 +201,14 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "compile two level nested workflow" in {
     val path = pathFromBasename("nested", "two_levels.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle passing closure arguments to nested blocks" in {
     val path = pathFromBasename("nested", "param_passing.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -266,7 +266,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "three nesting levels" in {
     val path = pathFromBasename("nested", "three_levels.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
     val bundle = retval match {
@@ -289,7 +289,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "four nesting levels" in {
     val path = pathFromBasename("nested", "four_levels.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     /*        inside(retval) {
             case Main.UnsuccessfulTermination(errMsg) =>
@@ -316,7 +316,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "handle streaming files" in {
     val path = pathFromBasename("compiler", "streaming_files.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
     val bundle = retval match {
@@ -326,24 +326,24 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val cgrepTask = getTaskByName("cgrep", bundle)
     cgrepTask.parameterMeta shouldBe (Map(
-      "in_file" -> MetaValueElement.MetaValueElementString("stream")
+        "in_file" -> MetaValueElement.MetaValueElementString("stream")
     ))
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
     iDef.parameterMeta shouldBe (Some(
-      MetaValueElement.MetaValueElementString("stream")
+        MetaValueElement.MetaValueElementString("stream")
     ))
 
     val diffTask = getTaskByName("diff", bundle)
     diffTask.parameterMeta shouldBe (Map(
-      "a" -> MetaValueElement.MetaValueElementString("stream"),
-      "b" -> MetaValueElement.MetaValueElementString("stream")
+        "a" -> MetaValueElement.MetaValueElementString("stream"),
+        "b" -> MetaValueElement.MetaValueElementString("stream")
     ))
   }
 
   it should "recognize the streaming object annotation" in {
     val path = pathFromBasename("compiler", "streaming_files_obj.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
     val bundle = retval match {
@@ -353,36 +353,36 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val cgrepTask = getTaskByName("cgrep", bundle)
     cgrepTask.parameterMeta shouldBe (Map(
-      "in_file" -> MetaValueElement
-        .MetaValueElementObject(
-          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
-        )
+        "in_file" -> MetaValueElement
+          .MetaValueElementObject(
+              Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+          )
     ))
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
     iDef.parameterMeta shouldBe (Some(
-      MetaValueElement
-        .MetaValueElementObject(
-          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
-        )
+        MetaValueElement
+          .MetaValueElementObject(
+              Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+          )
     ))
 
     val diffTask = getTaskByName("diff", bundle)
     diffTask.parameterMeta shouldBe (
-      Map(
-        "a" -> MetaValueElement.MetaValueElementObject(
-          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
-        ),
-        "b" -> MetaValueElement.MetaValueElementObject(
-          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+        Map(
+            "a" -> MetaValueElement.MetaValueElementObject(
+                Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+            ),
+            "b" -> MetaValueElement.MetaValueElementObject(
+                Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+            )
         )
-      )
     )
   }
 
   it should "recognize the streaming annotation for wdl draft2" in {
     val path = pathFromBasename("draft2", "streaming.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
     val bundle = retval match {
@@ -391,15 +391,15 @@ class GenerateIRTest extends FlatSpec with Matchers {
     }
     val diffTask = getTaskByName("diff", bundle)
     diffTask.parameterMeta shouldBe (Map(
-      "a" -> MetaValueElement.MetaValueElementString("stream"),
-      "b" -> MetaValueElement.MetaValueElementString("stream")
+        "a" -> MetaValueElement.MetaValueElementString("stream"),
+        "b" -> MetaValueElement.MetaValueElementString("stream")
     ))
   }
 
   it should "handle an empty workflow" in {
     val path = pathFromBasename("util", "empty_workflow.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -407,7 +407,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "handle structs" in {
     val path = pathFromBasename("struct", "Person.wdl")
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -450,7 +450,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val path = pathFromBasename("compiler/imports", "A.wdl")
     val libraryPath = path.getParent.resolve("lib")
     val retval = Main.compile(
-      path.toString :: "--imports" :: libraryPath.toString :: cFlags
+        path.toString :: "--imports" :: libraryPath.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -472,8 +472,8 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
   it should "handle multiple struct definitions" in {
     val path = pathFromBasename(
-      "struct/DEVEX-1196-struct-resolution-wrong-order",
-      "file3.wdl"
+        "struct/DEVEX-1196-struct-resolution-wrong-order",
+        "file3.wdl"
     )
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
@@ -482,10 +482,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "retain all characters in a WDL task" in {
     val path = pathFromBasename("bugs", "missing_chars_in_task.wdl")
     val retval = Main.compile(
-      path.toString
+        path.toString
 //                                      :: "--verbose"
 //                                      :: "--verboseKey" :: "GenerateIR"
-        :: cFlags
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
 
@@ -520,10 +520,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "detect a request for GPU" in {
     val path = pathFromBasename("compiler", "GPU.wdl")
     val retval = Main.compile(
-      path.toString
-      //                                      :: "--verbose"
-      //                                      :: "--verboseKey" :: "GenerateIR"
-        :: cFlags
+        path.toString
+        //                                      :: "--verbose"
+        //                                      :: "--verboseKey" :: "GenerateIR"
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
 
@@ -542,10 +542,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val path =
       pathFromBasename("compiler", "scatter_subworkflow_with_optional.wdl")
     val retval = Main.compile(
-      path.toString
+        path.toString
 //                                      :: "--verbose"
 //                                      :: "--verboseKey" :: "GenerateIR"
-        :: cFlags
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
 
@@ -578,7 +578,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val path = pathFromBasename("subworkflows", basename = "trains.wdl")
 
     val retval = Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -588,10 +588,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val path = pathFromBasename("subworkflows", basename = "ensure_trains.wdl")
 
     val retval = Main.compile(
-      path.toString
+        path.toString
 //                :: "--verbose"
 //                :: "--verboseKey" :: "GenerateIR"
-        :: cFlags
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -37,7 +37,14 @@ class GenerateIRTest extends FlatSpec with Matchers {
   )
 
   private val cFlagsUnlocked =
-    List("--compileMode", "ir", "-quiet", "-fatalValidationWarnings", "--project", dxProject.getId)
+    List(
+      "--compileMode",
+      "ir",
+      "-quiet",
+      "-fatalValidationWarnings",
+      "--project",
+      dxProject.getId
+    )
 
   val dbgFlags = List(
     "--compileMode",
@@ -52,18 +59,24 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
   it should "IR compile a single WDL task" in {
     val path = pathFromBasename("compiler", "add.wdl")
-    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+    Main.compile(path.toString :: cFlags) shouldBe a[
+      Main.SuccessfulTerminationIR
+    ]
   }
 
   it should "IR compile a task with docker" in {
     val path = pathFromBasename("compiler", "BroadGenomicsDocker.wdl")
-    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+    Main.compile(path.toString :: cFlags) shouldBe a[
+      Main.SuccessfulTerminationIR
+    ]
   }
 
   // workflow compilation
   it should "IR compile a linear WDL workflow without expressions" in {
     val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
-    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+    Main.compile(path.toString :: cFlags) shouldBe a[
+      Main.SuccessfulTerminationIR
+    ]
   }
 
   it should "IR compile a linear WDL workflow" in {
@@ -82,12 +95,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
   it should "IR compile a non trivial linear workflow with variable coercions" in {
     val path = pathFromBasename("compiler", "cast.wdl")
-    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+    Main.compile(path.toString :: cFlags) shouldBe a[
+      Main.SuccessfulTerminationIR
+    ]
   }
 
   it should "IR compile a workflow with two consecutive calls" in {
     val path = pathFromBasename("compiler", "strings.wdl")
-    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+    Main.compile(path.toString :: cFlags) shouldBe a[
+      Main.SuccessfulTerminationIR
+    ]
   }
 
   it should "IR compile a workflow with a scatter without a call" in {
@@ -170,7 +187,13 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "missing workflow inputs" in {
     val path = pathFromBasename("input_file", "missing_args.wdl")
     Main.compile(
-      path.toString :: List("--compileMode", "ir", "--quiet", "--project", dxProject.id)
+      path.toString :: List(
+        "--compileMode",
+        "ir",
+        "--quiet",
+        "--project",
+        dxProject.id
+      )
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -275,7 +298,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
-  private def getTaskByName(name: String, bundle: IR.Bundle): CallableTaskDefinition = {
+  private def getTaskByName(
+      name: String,
+      bundle: IR.Bundle
+  ): CallableTaskDefinition = {
     val applet = bundle.allCallables(name) match {
       case a: IR.Applet => a
       case _            => throw new Exception(s"${name} is not an applet")
@@ -303,7 +329,9 @@ class GenerateIRTest extends FlatSpec with Matchers {
       "in_file" -> MetaValueElement.MetaValueElementString("stream")
     ))
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
-    iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementString("stream")))
+    iDef.parameterMeta shouldBe (Some(
+      MetaValueElement.MetaValueElementString("stream")
+    ))
 
     val diffTask = getTaskByName("diff", bundle)
     diffTask.parameterMeta shouldBe (Map(
@@ -326,12 +354,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val cgrepTask = getTaskByName("cgrep", bundle)
     cgrepTask.parameterMeta shouldBe (Map(
       "in_file" -> MetaValueElement
-        .MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))
+        .MetaValueElementObject(
+          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+        )
     ))
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
     iDef.parameterMeta shouldBe (Some(
       MetaValueElement
-        .MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))
+        .MetaValueElementObject(
+          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+        )
     ))
 
     val diffTask = getTaskByName("diff", bundle)
@@ -417,25 +449,32 @@ class GenerateIRTest extends FlatSpec with Matchers {
   it should "respect import flag" in {
     val path = pathFromBasename("compiler/imports", "A.wdl")
     val libraryPath = path.getParent.resolve("lib")
-    val retval = Main.compile(path.toString :: "--imports" :: libraryPath.toString :: cFlags)
+    val retval = Main.compile(
+      path.toString :: "--imports" :: libraryPath.toString :: cFlags
+    )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "respect import -p flag" in {
     val path = pathFromBasename("compiler/imports", "A.wdl")
     val libraryPath = path.getParent.resolve("lib")
-    val retval = Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
+    val retval =
+      Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "pass environment between deep stages" in {
-    val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
+    val path =
+      pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle multiple struct definitions" in {
-    val path = pathFromBasename("struct/DEVEX-1196-struct-resolution-wrong-order", "file3.wdl")
+    val path = pathFromBasename(
+      "struct/DEVEX-1196-struct-resolution-wrong-order",
+      "file3.wdl"
+    )
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -500,7 +539,8 @@ class GenerateIRTest extends FlatSpec with Matchers {
   }
 
   it should "compile a scatter with a sub-workflow that has an optional argument" taggedAs (EdgeTest) in {
-    val path = pathFromBasename("compiler", "scatter_subworkflow_with_optional.wdl")
+    val path =
+      pathFromBasename("compiler", "scatter_subworkflow_with_optional.wdl")
     val retval = Main.compile(
       path.toString
 //                                      :: "--verbose"
@@ -516,15 +556,18 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val wfs: Vector[IR.Workflow] = bundle.allCallables
       .map {
-        case (name, wf: IR.Workflow) if wf.locked && wf.level == IR.Level.Sub => Some(wf)
-        case (_, _)                                                           => None
+        case (name, wf: IR.Workflow) if wf.locked && wf.level == IR.Level.Sub =>
+          Some(wf)
+        case (_, _) => None
       }
       .flatten
       .toVector
     wfs.length shouldBe (1)
     val subwf = wfs(0)
 
-    val samtools = subwf.inputs.find { case (cVar, _) => cVar.name == "samtools_memory" }
+    val samtools = subwf.inputs.find {
+      case (cVar, _) => cVar.name == "samtools_memory"
+    }
     inside(samtools) {
       case Some((cVar, _)) =>
         cVar.womType shouldBe (WomOptionalType(WomStringType))

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -13,424 +13,445 @@ import dxWDL.dx._
 // These tests involve compilation -without- access to the platform.
 //
 class GenerateIRTest extends FlatSpec with Matchers {
-    private def pathFromBasename(dir: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dir}/${basename}").getPath
-        Paths.get(p)
-    }
+  private def pathFromBasename(dir: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dir}/${basename}").getPath
+    Paths.get(p)
+  }
 
-    private val dxProject = {
-        val p = DxUtils.dxEnv.getProjectContext()
-        if (p == null)
-            throw new Exception("Must be logged in to run this test")
-        DxProject(p)
-    }
+  private val dxProject = {
+    val p = DxUtils.dxEnv.getProjectContext()
+    if (p == null)
+      throw new Exception("Must be logged in to run this test")
+    DxProject(p)
+  }
 
-    // task compilation
-    private val cFlags = List("--compileMode", "ir",
-                              "-quiet",
-                              "-fatalValidationWarnings",
-                              "--locked",
-                              "--project", dxProject.getId)
+  // task compilation
+  private val cFlags = List(
+    "--compileMode",
+    "ir",
+    "-quiet",
+    "-fatalValidationWarnings",
+    "--locked",
+    "--project",
+    dxProject.getId
+  )
 
-    private val cFlagsUnlocked = List("--compileMode", "ir",
-                                      "-quiet",
-                                      "-fatalValidationWarnings",
+  private val cFlagsUnlocked =
+    List("--compileMode", "ir", "-quiet", "-fatalValidationWarnings", "--project", dxProject.getId)
 
-                                      "--project", dxProject.getId)
+  val dbgFlags = List(
+    "--compileMode",
+    "ir",
+    "--verbose",
+    "--verboseKey",
+    "GenerateIR",
+    "--locked",
+    "--project",
+    dxProject.id
+  )
 
-    val dbgFlags = List("--compileMode", "ir",
-                        "--verbose",
-                        "--verboseKey", "GenerateIR",
-                        "--locked",
-                        "--project", dxProject.id)
+  it should "IR compile a single WDL task" in {
+    val path = pathFromBasename("compiler", "add.wdl")
+    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
+  it should "IR compile a task with docker" in {
+    val path = pathFromBasename("compiler", "BroadGenomicsDocker.wdl")
+    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "IR compile a single WDL task" in {
-        val path = pathFromBasename("compiler", "add.wdl")
-        Main.compile(path.toString :: cFlags) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  // workflow compilation
+  it should "IR compile a linear WDL workflow without expressions" in {
+    val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
+    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "IR compile a task with docker" in {
-        val path = pathFromBasename("compiler", "BroadGenomicsDocker.wdl")
-        Main.compile(path.toString :: cFlags) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "IR compile a linear WDL workflow" in {
+    val path = pathFromBasename("compiler", "wf_linear.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    // workflow compilation
-    it should "IR compile a linear WDL workflow without expressions" in {
-        val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
-        Main.compile(path.toString :: cFlags) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "IR compile unlocked workflow" in {
+    val path = pathFromBasename("compiler", "wf_linear.wdl")
+    Main.compile(
+      path.toString :: cFlagsUnlocked
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "IR compile a linear WDL workflow" in {
-        val path = pathFromBasename("compiler", "wf_linear.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "IR compile a non trivial linear workflow with variable coercions" in {
+    val path = pathFromBasename("compiler", "cast.wdl")
+    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
+  it should "IR compile a workflow with two consecutive calls" in {
+    val path = pathFromBasename("compiler", "strings.wdl")
+    Main.compile(path.toString :: cFlags) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "IR compile unlocked workflow" in {
-        val path = pathFromBasename("compiler", "wf_linear.wdl")
-        Main.compile(
-            path.toString :: cFlagsUnlocked
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "IR compile a workflow with a scatter without a call" in {
+    val path = pathFromBasename("compiler", "scatter_no_call.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "IR compile a non trivial linear workflow with variable coercions" in {
-        val path = pathFromBasename("compiler", "cast.wdl")
-        Main.compile(path.toString :: cFlags) shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "IR compile a workflow with two consecutive calls" in {
-        val path = pathFromBasename("compiler", "strings.wdl")
-        Main.compile(path.toString :: cFlags) shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "IR compile a workflow with a scatter without a call" in {
-        val path = pathFromBasename("compiler", "scatter_no_call.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "IR compile optionals" in {
-        val path = pathFromBasename("compiler", "optionals.wdl")
-        Main.compile(
-            path.toString
+  it should "IR compile optionals" in {
+    val path = pathFromBasename("compiler", "optionals.wdl")
+    Main.compile(
+      path.toString
 //                :: "--verbose"
 //                :: "--verboseKey" :: "GenerateIR"
-                :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+        :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "support imports" in {
+    val path = pathFromBasename("compiler", "check_imports.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "IR compile a draft2 workflow" in {
+    val path = pathFromBasename("draft2", "shapes.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "expressions in an output block" in {
+    val path = pathFromBasename("compiler", "expr_output_block.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "scatters over maps" in {
+    val path = pathFromBasename("compiler", "dict2.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "skip missing optional arguments" in {
+    val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "handle calling subworkflows" in {
+    val path = pathFromBasename("subworkflows", "trains.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val irwf = retval match {
+      case Main.SuccessfulTerminationIR(irwf) => irwf
+      case _                                  => throw new Exception("sanity")
     }
-
-    it should "support imports" in {
-        val path = pathFromBasename("compiler", "check_imports.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+    val primaryWf: IR.Workflow = irwf.primaryCallable match {
+      case Some(wf: IR.Workflow) => wf
+      case _                     => throw new Exception("sanity")
     }
+    primaryWf.stages.size shouldBe (2)
+  }
 
-    it should "IR compile a draft2 workflow" in {
-        val path = pathFromBasename("draft2", "shapes.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
+  it should "compile a sub-block with several calls" in {
+    val path = pathFromBasename("compiler", "subblock_several_calls.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "missing workflow inputs" in {
+    val path = pathFromBasename("input_file", "missing_args.wdl")
+    Main.compile(
+      path.toString :: List("--compileMode", "ir", "--quiet", "--project", dxProject.id)
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  // Nested blocks
+  it should "compile two level nested workflow" in {
+    val path = pathFromBasename("nested", "two_levels.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "handle passing closure arguments to nested blocks" in {
+    val path = pathFromBasename("nested", "param_passing.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "compile a workflow calling a subworkflow as a direct call" in {
+    val path = pathFromBasename("draft2", "movies.wdl")
+    val bundle: IR.Bundle = Main.compile(path.toString :: cFlags) match {
+      case Main.SuccessfulTerminationIR(bundle) => bundle
+      case other =>
+        Utils.error(other.toString)
+        throw new Exception(s"Failed to compile ${path}")
     }
-
-    it should "expressions in an output block" in {
-        val path = pathFromBasename("compiler", "expr_output_block.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+    val wf: IR.Workflow = bundle.primaryCallable match {
+      case Some(wf: IR.Workflow) =>
+        wf
+      case _ => throw new Exception("bad value in bundle")
     }
+    val stage = wf.stages.head
+    stage.description shouldBe ("review")
+  }
 
-    it should "scatters over maps" in {
-        val path = pathFromBasename("compiler", "dict2.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+  it should "compile a workflow calling a subworkflow as a direct call with development version" in {
+    val path = pathFromBasename("development", "movies.wdl")
+    val bundle: IR.Bundle = Main.compile(path.toString :: cFlags) match {
+      case Main.SuccessfulTerminationIR(bundle) => bundle
+      case other =>
+        Utils.error(other.toString)
+        throw new Exception(s"Failed to compile ${path}")
     }
-
-    it should "skip missing optional arguments" in {
-        val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+    val wf: IR.Workflow = bundle.primaryCallable match {
+      case Some(wf: IR.Workflow) =>
+        wf
+      case _ => throw new Exception("bad value in bundle")
     }
+    val stage = wf.stages.head
+    stage.description shouldBe ("review")
+  }
 
-    it should "handle calling subworkflows" in {
-        val path = pathFromBasename("subworkflows", "trains.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-        val irwf = retval match {
-            case Main.SuccessfulTerminationIR(irwf) => irwf
-            case _ => throw new Exception("sanity")
-        }
-        val primaryWf : IR.Workflow = irwf.primaryCallable match {
-            case Some(wf : IR.Workflow) => wf
-            case _ => throw new Exception("sanity")
-        }
-        primaryWf.stages.size shouldBe(2)
+  it should "compile a workflow calling a subworkflow with native DNANexus applet as a direct call with development version" in {
+    val path = pathFromBasename("development", "call_dnanexus_applet.wdl")
+    val bundle: IR.Bundle = Main.compile(path.toString :: cFlags) match {
+      case Main.SuccessfulTerminationIR(bundle) => bundle
+      case other =>
+        Utils.error(other.toString)
+        throw new Exception(s"Failed to compile ${path}")
     }
-
-    it should "compile a sub-block with several calls" in {
-        val path = pathFromBasename("compiler", "subblock_several_calls.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+    val wf: IR.Workflow = bundle.primaryCallable match {
+      case Some(wf: IR.Workflow) =>
+        wf
+      case _ => throw new Exception("bad value in bundle")
     }
+    val stage = wf.stages.head
+    stage.description shouldBe ("native_sum_wf")
+  }
 
-    it should "missing workflow inputs" in {
-        val path = pathFromBasename("input_file", "missing_args.wdl")
-        Main.compile(
-            path.toString :: List("--compileMode", "ir", "--quiet",
-                                  "--project", dxProject.id)
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+  it should "three nesting levels" in {
+    val path = pathFromBasename("nested", "three_levels.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
     }
-
-    // Nested blocks
-    it should "compile two level nested workflow" in {
-        val path = pathFromBasename("nested", "two_levels.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
+    val primary: IR.Callable = bundle.primaryCallable.get
+    val wf = primary match {
+      case wf: IR.Workflow => wf
+      case _               => throw new Exception("sanity")
     }
+    wf.stages.size shouldBe (1)
 
-    it should "handle passing closure arguments to nested blocks" in {
-        val path = pathFromBasename("nested", "param_passing.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+    val level2 = bundle.allCallables(wf.name)
+    level2 shouldBe a[IR.Workflow]
+    val wfLevel2 = level2.asInstanceOf[IR.Workflow]
+    wfLevel2.stages.size shouldBe (1)
+  }
 
-    it should "compile a workflow calling a subworkflow as a direct call" in {
-        val path = pathFromBasename("draft2", "movies.wdl")
-        val bundle : IR.Bundle = Main.compile(path.toString :: cFlags) match {
-            case Main.SuccessfulTerminationIR(bundle) => bundle
-            case other =>
-                Utils.error(other.toString)
-                throw new Exception(s"Failed to compile ${path}")
-        }
-        val wf : IR.Workflow = bundle.primaryCallable match {
-            case Some(wf: IR.Workflow) =>
-                wf
-            case _ => throw new Exception("bad value in bundle")
-        }
-        val stage = wf.stages.head
-        stage.description shouldBe ("review")
-    }
-
-    it should "compile a workflow calling a subworkflow as a direct call with development version" in {
-        val path = pathFromBasename("development", "movies.wdl")
-        val bundle : IR.Bundle = Main.compile(path.toString :: cFlags) match {
-            case Main.SuccessfulTerminationIR(bundle) => bundle
-            case other =>
-                Utils.error(other.toString)
-                throw new Exception(s"Failed to compile ${path}")
-        }
-        val wf : IR.Workflow = bundle.primaryCallable match {
-            case Some(wf: IR.Workflow) =>
-                wf
-            case _ => throw new Exception("bad value in bundle")
-        }
-        val stage = wf.stages.head
-        stage.description shouldBe ("review")
-    }
-
-
-    it should "compile a workflow calling a subworkflow with native DNANexus applet as a direct call with development version" in {
-        val path = pathFromBasename("development", "call_dnanexus_applet.wdl")
-        val bundle : IR.Bundle = Main.compile(path.toString :: cFlags) match {
-            case Main.SuccessfulTerminationIR(bundle) => bundle
-            case other =>
-                Utils.error(other.toString)
-                throw new Exception(s"Failed to compile ${path}")
-        }
-        val wf : IR.Workflow = bundle.primaryCallable match {
-            case Some(wf: IR.Workflow) =>
-                wf
-            case _ => throw new Exception("bad value in bundle")
-        }
-        val stage = wf.stages.head
-        stage.description shouldBe ("native_sum_wf")
-    }
-
-    it should "three nesting levels" in {
-        val path = pathFromBasename("nested", "three_levels.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(ir) => ir
-            case _ => throw new Exception("sanity")
-        }
-        val primary : IR.Callable = bundle.primaryCallable.get
-        val wf = primary match {
-            case wf : IR.Workflow => wf
-            case _ => throw new Exception("sanity")
-        }
-        wf.stages.size shouldBe(1)
-
-        val level2 = bundle.allCallables(wf.name)
-        level2 shouldBe a[IR.Workflow]
-        val wfLevel2 = level2.asInstanceOf[IR.Workflow]
-        wfLevel2.stages.size shouldBe(1)
-    }
-
-
-    it should "four nesting levels" in {
-        val path = pathFromBasename("nested", "four_levels.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-/*        inside(retval) {
+  it should "four nesting levels" in {
+    val path = pathFromBasename("nested", "four_levels.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    /*        inside(retval) {
             case Main.UnsuccessfulTermination(errMsg) =>
                 errMsg should include ("nested scatter")
  }*/
-        retval shouldBe a [Main.SuccessfulTerminationIR]
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  private def getTaskByName(name: String, bundle: IR.Bundle): CallableTaskDefinition = {
+    val applet = bundle.allCallables(name) match {
+      case a: IR.Applet => a
+      case _            => throw new Exception(s"${name} is not an applet")
+    }
+    val task: CallableTaskDefinition = applet.kind match {
+      case IR.AppletKindTask(x) => x
+      case _                    => throw new Exception(s"${name} is not a task")
+    }
+    task
+  }
+
+  it should "handle streaming files" in {
+    val path = pathFromBasename("compiler", "streaming_files.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
     }
 
-    private def getTaskByName(name: String,
-                              bundle: IR.Bundle) : CallableTaskDefinition = {
-        val applet = bundle.allCallables(name) match {
-            case a : IR.Applet => a
-            case _ => throw new Exception(s"${name} is not an applet")
-        }
-        val task: CallableTaskDefinition = applet.kind match {
-            case IR.AppletKindTask(x) => x
-            case _ => throw new Exception(s"${name} is not a task")
-        }
-        task
+    val cgrepTask = getTaskByName("cgrep", bundle)
+    cgrepTask.parameterMeta shouldBe (Map(
+      "in_file" -> MetaValueElement.MetaValueElementString("stream")
+    ))
+    val iDef = cgrepTask.inputs.find(_.name == "in_file").get
+    iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementString("stream")))
+
+    val diffTask = getTaskByName("diff", bundle)
+    diffTask.parameterMeta shouldBe (Map(
+      "a" -> MetaValueElement.MetaValueElementString("stream"),
+      "b" -> MetaValueElement.MetaValueElementString("stream")
+    ))
+  }
+
+  it should "recognize the streaming object annotation" in {
+    val path = pathFromBasename("compiler", "streaming_files_obj.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
     }
 
-    it should "handle streaming files" in {
-        val path = pathFromBasename("compiler", "streaming_files.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
+    val cgrepTask = getTaskByName("cgrep", bundle)
+    cgrepTask.parameterMeta shouldBe (Map(
+      "in_file" -> MetaValueElement
+        .MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))
+    ))
+    val iDef = cgrepTask.inputs.find(_.name == "in_file").get
+    iDef.parameterMeta shouldBe (Some(
+      MetaValueElement
+        .MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))
+    ))
+
+    val diffTask = getTaskByName("diff", bundle)
+    diffTask.parameterMeta shouldBe (
+      Map(
+        "a" -> MetaValueElement.MetaValueElementObject(
+          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
+        ),
+        "b" -> MetaValueElement.MetaValueElementObject(
+          Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))
         )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(ir) => ir
-            case _ => throw new Exception("sanity")
-        }
+      )
+    )
+  }
 
-        val cgrepTask = getTaskByName("cgrep", bundle)
-        cgrepTask.parameterMeta shouldBe (Map("in_file" -> MetaValueElement.MetaValueElementString("stream")))
-        val iDef = cgrepTask.inputs.find(_.name == "in_file").get
-        iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementString("stream")))
-
-        val diffTask = getTaskByName("diff", bundle)
-        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementString("stream"),
-                                             "b" -> MetaValueElement.MetaValueElementString("stream")))
+  it should "recognize the streaming annotation for wdl draft2" in {
+    val path = pathFromBasename("draft2", "streaming.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
     }
+    val diffTask = getTaskByName("diff", bundle)
+    diffTask.parameterMeta shouldBe (Map(
+      "a" -> MetaValueElement.MetaValueElementString("stream"),
+      "b" -> MetaValueElement.MetaValueElementString("stream")
+    ))
+  }
 
-    it should "recognize the streaming object annotation" in {
-        val path = pathFromBasename("compiler", "streaming_files_obj.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(ir) => ir
-            case _ => throw new Exception("sanity")
-        }
+  it should "handle an empty workflow" in {
+    val path = pathFromBasename("util", "empty_workflow.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-        val cgrepTask = getTaskByName("cgrep", bundle)
-        cgrepTask.parameterMeta shouldBe (Map("in_file" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
-        val iDef = cgrepTask.inputs.find(_.name == "in_file").get
-        iDef.parameterMeta shouldBe (Some(MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
+  it should "handle structs" in {
+    val path = pathFromBasename("struct", "Person.wdl")
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-        val diffTask = getTaskByName("diff", bundle)
-        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true))),
-                                             "b" -> MetaValueElement.MetaValueElementObject(Map("stream" -> MetaValueElement.MetaValueElementBoolean(true)))))
+  it should "recognize that an argument with a default can be omitted at the call site" in {
+    val path   = pathFromBasename("compiler", "call_level2.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "check for reserved symbols" in {
+    val path   = pathFromBasename("compiler", "reserved.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+
+    inside(retval) {
+      case Main.UnsuccessfulTermination(errMsg) =>
+        errMsg should include("reserved substring ___")
     }
+  }
 
-    it should "recognize the streaming annotation for wdl draft2" in {
-        val path = pathFromBasename("draft2", "streaming.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(ir) => ir
-            case _ => throw new Exception("sanity")
-        }
-        val diffTask = getTaskByName("diff", bundle)
-        diffTask.parameterMeta shouldBe (Map("a" -> MetaValueElement.MetaValueElementString("stream"),
-                                             "b" -> MetaValueElement.MetaValueElementString("stream")))
-    }
+  it should "do nested scatters" in {
+    val path   = pathFromBasename("compiler", "nested_scatter.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "handle an empty workflow" in {
-        val path = pathFromBasename("util", "empty_workflow.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "handle struct imported several times" in {
+    val path   = pathFromBasename("struct/struct_imported_twice", "file3.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "handle structs" in {
-        val path = pathFromBasename("struct", "Person.wdl")
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "handle file constants in a workflow" in {
+    val path   = pathFromBasename("compiler", "wf_constants.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "recognize that an argument with a default can be omitted at the call site" in {
-        val path = pathFromBasename("compiler", "call_level2.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "respect import flag" in {
+    val path        = pathFromBasename("compiler/imports", "A.wdl")
+    val libraryPath = path.getParent.resolve("lib")
+    val retval      = Main.compile(path.toString :: "--imports" :: libraryPath.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "check for reserved symbols" in {
-        val path = pathFromBasename("compiler", "reserved.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
+  it should "respect import -p flag" in {
+    val path        = pathFromBasename("compiler/imports", "A.wdl")
+    val libraryPath = path.getParent.resolve("lib")
+    val retval      = Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-        inside(retval) {
-            case Main.UnsuccessfulTermination(errMsg) =>
-                errMsg should include ("reserved substring ___")
-        }
-    }
+  it should "pass environment between deep stages" in {
+    val path   = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "do nested scatters" in {
-        val path = pathFromBasename("compiler", "nested_scatter.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
+  it should "handle multiple struct definitions" in {
+    val path   = pathFromBasename("struct/DEVEX-1196-struct-resolution-wrong-order", "file3.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "handle struct imported several times" in {
-        val path = pathFromBasename("struct/struct_imported_twice", "file3.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "handle file constants in a workflow" in {
-        val path = pathFromBasename("compiler", "wf_constants.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "respect import flag" in {
-        val path = pathFromBasename("compiler/imports", "A.wdl")
-        val libraryPath = path.getParent.resolve("lib")
-        val retval = Main.compile(path.toString :: "--imports" :: libraryPath.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "respect import -p flag" in {
-        val path = pathFromBasename("compiler/imports", "A.wdl")
-        val libraryPath = path.getParent.resolve("lib")
-        val retval = Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "pass environment between deep stages" in {
-        val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "handle multiple struct definitions" in {
-        val path = pathFromBasename("struct/DEVEX-1196-struct-resolution-wrong-order",
-                                    "file3.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-    }
-
-    it should "retain all characters in a WDL task" in {
-        val path = pathFromBasename("bugs", "missing_chars_in_task.wdl")
-        val retval = Main.compile(path.toString
+  it should "retain all characters in a WDL task" in {
+    val path = pathFromBasename("bugs", "missing_chars_in_task.wdl")
+    val retval = Main.compile(
+      path.toString
 //                                      :: "--verbose"
 //                                      :: "--verboseKey" :: "GenerateIR"
-                                      :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
 
-        val commandSection =
-            """|  command {
+    val commandSection =
+      """|  command {
                |  echo 1 hello world | sed 's/world/wdl/'
                |  echo 2 hello \
                |  world \
@@ -441,89 +462,95 @@ class GenerateIRTest extends FlatSpec with Matchers {
                |  }
                |""".stripMargin
 
-        inside(retval) {
-            case Main.SuccessfulTerminationIR(bundle) =>
-                bundle.allCallables.size shouldBe(1)
-                val (_, callable) = bundle.allCallables.head
-                callable shouldBe a[IR.Applet]
-                val task = callable.asInstanceOf[IR.Applet]
-                task.womSourceCode should include (commandSection)
-        }
+    inside(retval) {
+      case Main.SuccessfulTerminationIR(bundle) =>
+        bundle.allCallables.size shouldBe (1)
+        val (_, callable) = bundle.allCallables.head
+        callable shouldBe a[IR.Applet]
+        val task = callable.asInstanceOf[IR.Applet]
+        task.womSourceCode should include(commandSection)
     }
+  }
 
-    it should "correctly flatten a workflow with imports" in {
-        val path = pathFromBasename("compiler", "wf_to_flatten.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
+  it should "correctly flatten a workflow with imports" in {
+    val path   = pathFromBasename("compiler", "wf_to_flatten.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "detect a request for GPU" in {
+    val path = pathFromBasename("compiler", "GPU.wdl")
+    val retval = Main.compile(
+      path.toString
+      //                                      :: "--verbose"
+      //                                      :: "--verboseKey" :: "GenerateIR"
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+
+    inside(retval) {
+      case Main.SuccessfulTerminationIR(bundle) =>
+        bundle.allCallables.size shouldBe (1)
+        val (_, callable) = bundle.allCallables.head
+        callable shouldBe a[IR.Applet]
+        val task = callable.asInstanceOf[IR.Applet]
+        task.instanceType shouldBe (IR
+          .InstanceTypeConst(Some("mem3_ssd1_gpu_x8"), None, None, None, None))
     }
+  }
 
-    it should "detect a request for GPU" in {
-        val path = pathFromBasename("compiler", "GPU.wdl")
-        val retval = Main.compile(path.toString
-            //                                      :: "--verbose"
-            //                                      :: "--verboseKey" :: "GenerateIR"
-            :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
-
-        inside(retval) {
-            case Main.SuccessfulTerminationIR(bundle) =>
-                bundle.allCallables.size shouldBe (1)
-                val (_, callable) = bundle.allCallables.head
-                callable shouldBe a[IR.Applet]
-                val task = callable.asInstanceOf[IR.Applet]
-                task.instanceType shouldBe (IR.InstanceTypeConst(Some("mem3_ssd1_gpu_x8"), None, None, None, None))
-        }
-    }
-
-    it should "compile a scatter with a sub-workflow that has an optional argument" taggedAs(EdgeTest) in {
-        val path = pathFromBasename("compiler", "scatter_subworkflow_with_optional.wdl")
-        val retval = Main.compile(path.toString
+  it should "compile a scatter with a sub-workflow that has an optional argument" taggedAs (EdgeTest) in {
+    val path = pathFromBasename("compiler", "scatter_subworkflow_with_optional.wdl")
+    val retval = Main.compile(
+      path.toString
 //                                      :: "--verbose"
 //                                      :: "--verboseKey" :: "GenerateIR"
-                                      :: cFlags)
-        retval shouldBe a[Main.SuccessfulTerminationIR]
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
 
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(bundle) => bundle
-            case _ => throw new Exception("sanity")
-        }
-
-        val wfs : Vector[IR.Workflow] = bundle.allCallables.map {
-            case (name, wf : IR.Workflow) if wf.locked && wf.level == IR.Level.Sub => Some(wf)
-            case (_, _) => None
-        }.flatten.toVector
-        wfs.length shouldBe(1)
-        val subwf = wfs(0)
-
-        val samtools = subwf.inputs.find{ case (cVar, _) => cVar.name == "samtools_memory" }
-        inside(samtools) {
-            case Some((cVar, _)) =>
-                cVar.womType shouldBe(WomOptionalType(WomStringType))
-        }
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(bundle) => bundle
+      case _                                    => throw new Exception("sanity")
     }
 
-    it should "pass as subworkflows do not have expression statement in output block" taggedAs(EdgeTest) in {
-        val path = pathFromBasename("subworkflows", basename="trains.wdl")
+    val wfs: Vector[IR.Workflow] = bundle.allCallables
+      .map {
+        case (name, wf: IR.Workflow) if wf.locked && wf.level == IR.Level.Sub => Some(wf)
+        case (_, _)                                                           => None
+      }
+      .flatten
+      .toVector
+    wfs.length shouldBe (1)
+    val subwf = wfs(0)
 
-
-        val retval = Main.compile(
-            path.toString :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
+    val samtools = subwf.inputs.find { case (cVar, _) => cVar.name == "samtools_memory" }
+    inside(samtools) {
+      case Some((cVar, _)) =>
+        cVar.womType shouldBe (WomOptionalType(WomStringType))
     }
+  }
 
-    // this is currently failing.
-    it should "pass with subworkflows having expression" taggedAs(EdgeTest)  in {
-        val path = pathFromBasename("subworkflows", basename="ensure_trains.wdl")
+  it should "pass as subworkflows do not have expression statement in output block" taggedAs (EdgeTest) in {
+    val path = pathFromBasename("subworkflows", basename = "trains.wdl")
 
-        val retval = Main.compile(
-            path.toString
+    val retval = Main.compile(
+      path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  // this is currently failing.
+  it should "pass with subworkflows having expression" taggedAs (EdgeTest) in {
+    val path = pathFromBasename("subworkflows", basename = "ensure_trains.wdl")
+
+    val retval = Main.compile(
+      path.toString
 //                :: "--verbose"
 //                :: "--verboseKey" :: "GenerateIR"
-                :: cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
 }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -381,13 +381,13 @@ class GenerateIRTest extends FlatSpec with Matchers {
   }
 
   it should "recognize that an argument with a default can be omitted at the call site" in {
-    val path   = pathFromBasename("compiler", "call_level2.wdl")
+    val path = pathFromBasename("compiler", "call_level2.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "check for reserved symbols" in {
-    val path   = pathFromBasename("compiler", "reserved.wdl")
+    val path = pathFromBasename("compiler", "reserved.wdl")
     val retval = Main.compile(path.toString :: cFlags)
 
     inside(retval) {
@@ -397,45 +397,45 @@ class GenerateIRTest extends FlatSpec with Matchers {
   }
 
   it should "do nested scatters" in {
-    val path   = pathFromBasename("compiler", "nested_scatter.wdl")
+    val path = pathFromBasename("compiler", "nested_scatter.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle struct imported several times" in {
-    val path   = pathFromBasename("struct/struct_imported_twice", "file3.wdl")
+    val path = pathFromBasename("struct/struct_imported_twice", "file3.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle file constants in a workflow" in {
-    val path   = pathFromBasename("compiler", "wf_constants.wdl")
+    val path = pathFromBasename("compiler", "wf_constants.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "respect import flag" in {
-    val path        = pathFromBasename("compiler/imports", "A.wdl")
+    val path = pathFromBasename("compiler/imports", "A.wdl")
     val libraryPath = path.getParent.resolve("lib")
-    val retval      = Main.compile(path.toString :: "--imports" :: libraryPath.toString :: cFlags)
+    val retval = Main.compile(path.toString :: "--imports" :: libraryPath.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "respect import -p flag" in {
-    val path        = pathFromBasename("compiler/imports", "A.wdl")
+    val path = pathFromBasename("compiler/imports", "A.wdl")
     val libraryPath = path.getParent.resolve("lib")
-    val retval      = Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
+    val retval = Main.compile(path.toString :: "--p" :: libraryPath.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "pass environment between deep stages" in {
-    val path   = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
+    val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
   it should "handle multiple struct definitions" in {
-    val path   = pathFromBasename("struct/DEVEX-1196-struct-resolution-wrong-order", "file3.wdl")
+    val path = pathFromBasename("struct/DEVEX-1196-struct-resolution-wrong-order", "file3.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -473,7 +473,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
   }
 
   it should "correctly flatten a workflow with imports" in {
-    val path   = pathFromBasename("compiler", "wf_to_flatten.wdl")
+    val path = pathFromBasename("compiler", "wf_to_flatten.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }

--- a/src/test/scala/dxWDL/compiler/InputFileTest.scala
+++ b/src/test/scala/dxWDL/compiler/InputFileTest.scala
@@ -28,7 +28,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "handle one task and two inputs" in {
     val wdlCode = pathFromBasename("input_file", "add.wdl")
-    val inputs  = pathFromBasename("input_file", "add_inputs.json")
+    val inputs = pathFromBasename("input_file", "add_inputs.json")
     Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
         ++ cFlags
@@ -37,7 +37,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "deal with a locked workflow" in {
     val wdlCode = pathFromBasename("input_file", "math.wdl")
-    val inputs  = pathFromBasename("input_file", "math_inputs.json")
+    val inputs = pathFromBasename("input_file", "math_inputs.json")
     Main.compile(
       List(
         wdlCode.toString,
@@ -51,7 +51,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "not compile for several applets without a workflow" in {
     val wdlCode = pathFromBasename("input_file", "several_tasks.wdl")
-    val inputs  = pathFromBasename("input_file", "several_tasks_inputs.json")
+    val inputs = pathFromBasename("input_file", "several_tasks_inputs.json")
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
         ++ cFlags
@@ -64,7 +64,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "one input too many" in {
     val wdlCode = pathFromBasename("input_file", "math.wdl")
-    val inputs  = pathFromBasename("input_file", "math_inputs2.json")
+    val inputs = pathFromBasename("input_file", "math_inputs2.json")
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
         ++ cFlags
@@ -77,7 +77,7 @@ class InputFileTest extends FlatSpec with Matchers {
   }
 
   it should "build defaults into applet underneath workflow" in {
-    val wdlCode  = pathFromBasename("input_file", "population.wdl")
+    val wdlCode = pathFromBasename("input_file", "population.wdl")
     val defaults = pathFromBasename("input_file", "population_inputs.json")
     val retval = Main.compile(
       List(wdlCode.toString, "-defaults", defaults.toString)
@@ -88,7 +88,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "handle inputs specified in the json file, but missing in the workflow" in {
     val wdlCode = pathFromBasename("input_file", "missing_args.wdl")
-    val inputs  = pathFromBasename("input_file", "missing_args_inputs.json")
+    val inputs = pathFromBasename("input_file", "missing_args_inputs.json")
 
     Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -122,7 +122,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "support struct inputs" in {
     val wdlCode = pathFromBasename("struct", "Person.wdl")
-    val inputs  = pathFromBasename("struct", "Person_input.json")
+    val inputs = pathFromBasename("struct", "Person_input.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -133,7 +133,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "support array of pairs" in {
     val wdlCode = pathFromBasename("input_file", "echo_pairs.wdl")
-    val inputs  = pathFromBasename("input_file", "echo_pairs.json")
+    val inputs = pathFromBasename("input_file", "echo_pairs.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -144,7 +144,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "array of structs" in {
     val wdlCode = pathFromBasename("struct", "array_of_structs.wdl")
-    val inputs  = pathFromBasename("struct", "array_of_structs_input.json")
+    val inputs = pathFromBasename("struct", "array_of_structs_input.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -155,7 +155,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "override default values in input file" in {
     val wdlCode = pathFromBasename("input_file", "override.wdl")
-    val inputs  = pathFromBasename("input_file", "override_input.json")
+    val inputs = pathFromBasename("input_file", "override_input.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -166,7 +166,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "WDL map input" taggedAs (EdgeTest) in {
     val wdlCode = pathFromBasename("input_file", "map_argument.wdl")
-    val inputs  = pathFromBasename("input_file", "map_argument_input.json")
+    val inputs = pathFromBasename("input_file", "map_argument_input.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)
@@ -177,7 +177,7 @@ class InputFileTest extends FlatSpec with Matchers {
 
   it should "allow file as WDL map key" in {
     val wdlCode = pathFromBasename("input_file", "no_file_key.wdl")
-    val inputs  = pathFromBasename("input_file", "no_file_key_input.json")
+    val inputs = pathFromBasename("input_file", "no_file_key_input.json")
 
     val retval = Main.compile(
       List(wdlCode.toString, "-inputs", inputs.toString)

--- a/src/test/scala/dxWDL/compiler/InputFileTest.scala
+++ b/src/test/scala/dxWDL/compiler/InputFileTest.scala
@@ -30,8 +30,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val wdlCode = pathFromBasename("input_file", "add.wdl")
     val inputs = pathFromBasename("input_file", "add_inputs.json")
     Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -39,13 +39,13 @@ class InputFileTest extends FlatSpec with Matchers {
     val wdlCode = pathFromBasename("input_file", "math.wdl")
     val inputs = pathFromBasename("input_file", "math_inputs.json")
     Main.compile(
-      List(
-        wdlCode.toString,
-        "-inputs",
-        inputs.toString,
-        "--locked"
-        //, "--verbose", "--verboseKey", "GenerateIR"
-      ) ++ cFlags
+        List(
+            wdlCode.toString,
+            "-inputs",
+            inputs.toString,
+            "--locked"
+            //, "--verbose", "--verboseKey", "GenerateIR"
+        ) ++ cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -53,8 +53,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val wdlCode = pathFromBasename("input_file", "several_tasks.wdl")
     val inputs = pathFromBasename("input_file", "several_tasks_inputs.json")
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     inside(retval) {
       case Main.UnsuccessfulTermination(errMsg) =>
@@ -66,8 +66,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val wdlCode = pathFromBasename("input_file", "math.wdl")
     val inputs = pathFromBasename("input_file", "math_inputs2.json")
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
+          ++ cFlags
     )
 
     inside(retval) {
@@ -80,8 +80,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val wdlCode = pathFromBasename("input_file", "population.wdl")
     val defaults = pathFromBasename("input_file", "population_inputs.json")
     val retval = Main.compile(
-      List(wdlCode.toString, "-defaults", defaults.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-defaults", defaults.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -91,21 +91,21 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("input_file", "missing_args_inputs.json")
 
     Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
 
     // inputs as defaults
     Main.compile(
-      List(wdlCode.toString, "-defaults", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-defaults", inputs.toString)
+          ++ cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
 
     // Input to an applet.
     // Missing argument in a locked workflow should throw an exception.
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
+          ++ cFlags
     )
     inside(retval) {
       case Main.UnsuccessfulTermination(errMsg) =>
@@ -115,8 +115,8 @@ class InputFileTest extends FlatSpec with Matchers {
 
     // Missing arguments are legal in an unlocked workflow
     Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     ) shouldBe a[Main.SuccessfulTerminationIR]
   }
 
@@ -125,8 +125,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("struct", "Person_input.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -136,8 +136,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("input_file", "echo_pairs.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -147,8 +147,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("struct", "array_of_structs_input.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -158,8 +158,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("input_file", "override_input.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -169,8 +169,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("input_file", "map_argument_input.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
@@ -180,8 +180,8 @@ class InputFileTest extends FlatSpec with Matchers {
     val inputs = pathFromBasename("input_file", "no_file_key_input.json")
 
     val retval = Main.compile(
-      List(wdlCode.toString, "-inputs", inputs.toString)
-        ++ cFlags
+        List(wdlCode.toString, "-inputs", inputs.toString)
+          ++ cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }

--- a/src/test/scala/dxWDL/compiler/InputFileTest.scala
+++ b/src/test/scala/dxWDL/compiler/InputFileTest.scala
@@ -10,181 +10,180 @@ import dxWDL.dx._
 // These tests involve compilation -without- access to the platform.
 //
 class InputFileTest extends FlatSpec with Matchers {
-    private def pathFromBasename(dirname: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dirname}/${basename}").getPath
-        Paths.get(p)
+  private def pathFromBasename(dirname: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dirname}/${basename}").getPath
+    Paths.get(p)
+  }
+
+  private val dxProject = {
+    val p = DxUtils.dxEnv.getProjectContext()
+    if (p == null)
+      throw new Exception("Must be logged in to run this test")
+    DxProject(p)
+  }
+
+  val cFlags = List("--compileMode", "ir", "-quiet", "--project", dxProject.id)
+
+  // make sure we are logged in
+
+  it should "handle one task and two inputs" in {
+    val wdlCode = pathFromBasename("input_file", "add.wdl")
+    val inputs  = pathFromBasename("input_file", "add_inputs.json")
+    Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "deal with a locked workflow" in {
+    val wdlCode = pathFromBasename("input_file", "math.wdl")
+    val inputs  = pathFromBasename("input_file", "math_inputs.json")
+    Main.compile(
+      List(
+        wdlCode.toString,
+        "-inputs",
+        inputs.toString,
+        "--locked"
+        //, "--verbose", "--verboseKey", "GenerateIR"
+      ) ++ cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "not compile for several applets without a workflow" in {
+    val wdlCode = pathFromBasename("input_file", "several_tasks.wdl")
+    val inputs  = pathFromBasename("input_file", "several_tasks_inputs.json")
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    inside(retval) {
+      case Main.UnsuccessfulTermination(errMsg) =>
+        errMsg should include("Cannot generate one input file for 2 tasks")
+    }
+  }
+
+  it should "one input too many" in {
+    val wdlCode = pathFromBasename("input_file", "math.wdl")
+    val inputs  = pathFromBasename("input_file", "math_inputs2.json")
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
+        ++ cFlags
+    )
+
+    inside(retval) {
+      case Main.UnsuccessfulTermination(errMsg) =>
+        errMsg should include("Could not map all default fields")
+    }
+  }
+
+  it should "build defaults into applet underneath workflow" in {
+    val wdlCode  = pathFromBasename("input_file", "population.wdl")
+    val defaults = pathFromBasename("input_file", "population_inputs.json")
+    val retval = Main.compile(
+      List(wdlCode.toString, "-defaults", defaults.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
+
+  it should "handle inputs specified in the json file, but missing in the workflow" in {
+    val wdlCode = pathFromBasename("input_file", "missing_args.wdl")
+    val inputs  = pathFromBasename("input_file", "missing_args_inputs.json")
+
+    Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+
+    // inputs as defaults
+    Main.compile(
+      List(wdlCode.toString, "-defaults", inputs.toString)
+        ++ cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+
+    // Input to an applet.
+    // Missing argument in a locked workflow should throw an exception.
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
+        ++ cFlags
+    )
+    inside(retval) {
+      case Main.UnsuccessfulTermination(errMsg) =>
+        errMsg should include("input")
+        errMsg should include("to call <missing_args.Add> is unspecified")
     }
 
-    private val dxProject = {
-        val p = DxUtils.dxEnv.getProjectContext()
-        if (p == null)
-            throw new Exception("Must be logged in to run this test")
-        DxProject(p)
-    }
+    // Missing arguments are legal in an unlocked workflow
+    Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    ) shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    val cFlags = List("--compileMode", "ir", "-quiet",
-                      "--project", dxProject.id)
+  it should "support struct inputs" in {
+    val wdlCode = pathFromBasename("struct", "Person.wdl")
+    val inputs  = pathFromBasename("struct", "Person_input.json")
 
-    // make sure we are logged in
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "handle one task and two inputs" in {
-        val wdlCode = pathFromBasename("input_file", "add.wdl")
-        val inputs = pathFromBasename("input_file", "add_inputs.json")
-        Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "support array of pairs" in {
+    val wdlCode = pathFromBasename("input_file", "echo_pairs.wdl")
+    val inputs  = pathFromBasename("input_file", "echo_pairs.json")
 
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "deal with a locked workflow" in {
-        val wdlCode = pathFromBasename("input_file", "math.wdl")
-        val inputs = pathFromBasename("input_file", "math_inputs.json")
-        Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString, "--locked"
-                 //, "--verbose", "--verboseKey", "GenerateIR"
-            ) ++ cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "array of structs" in {
+    val wdlCode = pathFromBasename("struct", "array_of_structs.wdl")
+    val inputs  = pathFromBasename("struct", "array_of_structs_input.json")
 
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "not compile for several applets without a workflow" in {
-        val wdlCode = pathFromBasename("input_file", "several_tasks.wdl")
-        val inputs = pathFromBasename("input_file", "several_tasks_inputs.json")
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        inside(retval) {
-            case Main.UnsuccessfulTermination(errMsg) =>
-                errMsg should include ("Cannot generate one input file for 2 tasks")
-        }
-    }
+  it should "override default values in input file" in {
+    val wdlCode = pathFromBasename("input_file", "override.wdl")
+    val inputs  = pathFromBasename("input_file", "override_input.json")
 
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "one input too many" in {
-        val wdlCode = pathFromBasename("input_file", "math.wdl")
-        val inputs = pathFromBasename("input_file", "math_inputs2.json")
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
-                ++ cFlags
-        )
+  it should "WDL map input" taggedAs (EdgeTest) in {
+    val wdlCode = pathFromBasename("input_file", "map_argument.wdl")
+    val inputs  = pathFromBasename("input_file", "map_argument_input.json")
 
-        inside(retval) {
-            case Main.UnsuccessfulTermination(errMsg) =>
-                errMsg should include ("Could not map all default fields")
-        }
-    }
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
-    it should "build defaults into applet underneath workflow" in {
-        val wdlCode = pathFromBasename("input_file", "population.wdl")
-        val defaults = pathFromBasename("input_file", "population_inputs.json")
-        val retval = Main.compile(
-            List(wdlCode.toString, "-defaults", defaults.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
+  it should "allow file as WDL map key" in {
+    val wdlCode = pathFromBasename("input_file", "no_file_key.wdl")
+    val inputs  = pathFromBasename("input_file", "no_file_key_input.json")
 
-    it should "handle inputs specified in the json file, but missing in the workflow" in {
-        val wdlCode = pathFromBasename("input_file", "missing_args.wdl")
-        val inputs = pathFromBasename("input_file", "missing_args_inputs.json")
-
-        Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-
-        // inputs as defaults
-        Main.compile(
-            List(wdlCode.toString, "-defaults", inputs.toString)
-                ++ cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-
-        // Input to an applet.
-        // Missing argument in a locked workflow should throw an exception.
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString, "--locked")
-                ++ cFlags
-        )
-        inside(retval) {
-            case Main.UnsuccessfulTermination(errMsg) =>
-                errMsg should include ("input")
-                errMsg should include ("to call <missing_args.Add> is unspecified")
-        }
-
-        // Missing arguments are legal in an unlocked workflow
-        Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        ) shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-
-    it should "support struct inputs" in {
-        val wdlCode = pathFromBasename("struct", "Person.wdl")
-        val inputs = pathFromBasename("struct", "Person_input.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "support array of pairs" in {
-        val wdlCode = pathFromBasename("input_file", "echo_pairs.wdl")
-        val inputs = pathFromBasename("input_file", "echo_pairs.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "array of structs" in {
-        val wdlCode = pathFromBasename("struct", "array_of_structs.wdl")
-        val inputs = pathFromBasename("struct", "array_of_structs_input.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "override default values in input file" in {
-        val wdlCode = pathFromBasename("input_file", "override.wdl")
-        val inputs = pathFromBasename("input_file", "override_input.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "WDL map input" taggedAs(EdgeTest) in {
-        val wdlCode = pathFromBasename("input_file", "map_argument.wdl")
-        val inputs = pathFromBasename("input_file", "map_argument_input.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
-
-    it should "allow file as WDL map key" in {
-        val wdlCode = pathFromBasename("input_file", "no_file_key.wdl")
-        val inputs = pathFromBasename("input_file", "no_file_key_input.json")
-
-        val retval = Main.compile(
-            List(wdlCode.toString, "-inputs", inputs.toString)
-                ++ cFlags
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
-    }
+    val retval = Main.compile(
+      List(wdlCode.toString, "-inputs", inputs.toString)
+        ++ cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+  }
 
 }

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -61,7 +61,10 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     // build the directory with the native applets
-    Utils.execCommand(s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/", quiet = true)
+    Utils.execCommand(
+      s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/",
+      quiet = true
+    )
 
     // building necessary applets before starting the tests
     val native_applets = Vector(
@@ -193,7 +196,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     // check that the generated file contains the correct tasks
     val content = Source.fromFile(outputPath).getLines.mkString("\n")
 
-    val tasks: Map[String, String] = ParseWomSourceFile(false).scanForTasks(content)
+    val tasks: Map[String, String] =
+      ParseWomSourceFile(false).scanForTasks(content)
 
     tasks.keys shouldBe (Set(
       "native_sum",
@@ -249,7 +253,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "deep nesting" taggedAs (NativeTestXX) in {
-    val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
+    val path =
+      pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
     Main.compile(
       path.toString
       /*                :: "--verbose"
@@ -269,7 +274,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (stdout, stderr) =
+      Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
 
     val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
       case Some(JsObject(x)) =>
@@ -280,7 +286,11 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case other => throw new Exception(s"Unexpected result ${other}")
     }
     timeout shouldBe JsObject(
-      "*" -> JsObject("days" -> JsNumber(2), "hours" -> JsNumber(0), "minutes" -> JsNumber(0))
+      "*" -> JsObject(
+        "days" -> JsNumber(2),
+        "hours" -> JsNumber(0),
+        "minutes" -> JsNumber(0)
+      )
     )
   }
 
@@ -296,7 +306,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (stdout, stderr) =
+      Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
 
     val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
       case Some(JsObject(x)) =>
@@ -319,7 +330,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (stdout, stderr) =
+      Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
     val obj = stdout.parseJson.asJsObject
     val obj2 = obj.fields("runSpec").asJsObject
     val obj3 = obj2.fields("systemRequirements").asJsObject
@@ -441,7 +453,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     // remove compile mode
     val retval = Main.compile(
-      path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg.drop(2)
+      path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg
+        .drop(2)
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
 

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -86,9 +86,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   private def getAppletId(path: String): String = {
-    val folder   = Paths.get(path).getParent().toAbsolutePath().toString()
+    val folder = Paths.get(path).getParent().toAbsolutePath().toString()
     val basename = Paths.get(path).getFileName().toString()
-    val verbose  = Verbose(false, true, Set.empty)
+    val verbose = Verbose(false, true, Set.empty)
     val results = DxFindDataObjects(Some(10), verbose).apply(
       dxTestProject,
       Some(folder),
@@ -127,7 +127,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   // linear workflow
   it should "Native compile a linear WDL workflow without expressions" taggedAs (NativeTestXX) in {
-    val path   = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
+    val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
     val retval = Main.compile(path.toString :: cFlags)
     retval shouldBe a[Main.SuccessfulTermination]
   }
@@ -220,7 +220,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
               |]
             """.stripMargin.parseJson
 
-    val path      = pathFromBasename("compiler", "add.wdl")
+    val path = pathFromBasename("compiler", "add.wdl")
     val extraPath = pathFromBasename("compiler/extras", "extras_license.json")
 
     val appId = Main.compile(
@@ -234,7 +234,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     val dxApplet = DxApplet.getInstance(appId)
-    val desc     = dxApplet.describe(Set(Field.Details))
+    val desc = dxApplet.describe(Set(Field.Details))
     val license = desc.details match {
       case Some(JsObject(x)) =>
         x.get("upstreamProjects") match {
@@ -285,7 +285,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "timeout can be overriden from the extras file" taggedAs (NativeTestXX) in {
-    val path      = pathFromBasename("compiler", "add_timeout_override.wdl")
+    val path = pathFromBasename("compiler", "add_timeout_override.wdl")
     val extraPath = pathFromBasename("compiler/extras", "short_timeout.json")
     val appId = Main.compile(
       path.toString
@@ -320,10 +320,10 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     // make sure the timeout is what it should be
     val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
-    val obj              = stdout.parseJson.asJsObject
-    val obj2             = obj.fields("runSpec").asJsObject
-    val obj3             = obj2.fields("systemRequirements").asJsObject
-    val obj4             = obj3.fields("main").asJsObject
+    val obj = stdout.parseJson.asJsObject
+    val obj2 = obj.fields("runSpec").asJsObject
+    val obj3 = obj2.fields("systemRequirements").asJsObject
+    val obj4 = obj3.fields("main").asJsObject
     val instanceType = obj4.fields.get("instanceType") match {
       case Some(JsString(x)) => x
       case other             => throw new Exception(s"Unexpected result ${other}")
@@ -334,7 +334,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "Compile a workflow with subworkflows on the platform with the reorg app" taggedAs (EdgeTest) in {
-    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
     val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
     val extrasContent =
       s"""|{
@@ -356,8 +356,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case _                              => throw new Exception("sanity")
     }
 
-    val wf       = DxWorkflow.getInstance(wfId)
-    val wfDesc   = wf.describe(Set(Field.Stages))
+    val wf = DxWorkflow.getInstance(wfId)
+    val wfDesc = wf.describe(Set(Field.Stages))
     val wfStages = wfDesc.stages.get
 
     // there should be 4 stages: 1) common 2) train_stations 3) outputs 4) reorg
@@ -381,7 +381,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   // ignore for now as the test will fail in staging
   it should "Compile a workflow with subworkflows on the platform with the reorg app with config file in the input" in {
     // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
-    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
     val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
     // upload random file
     val (uploadOut, uploadErr) = Utils.execCommand(
@@ -409,9 +409,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case _                                => throw new Exception("sanity")
     }
 
-    val wf         = DxWorkflow.getInstance(wfId)
-    val wfDesc     = wf.describe(Set(Field.Stages))
-    val wfStages   = wfDesc.stages.get
+    val wf = DxWorkflow.getInstance(wfId)
+    val wfDesc = wf.describe(Set(Field.Stages))
+    val wfStages = wfDesc.stages.get
     val reorgStage = wfStages.last
 
     // There should be 3 inputs, the output from output stage and the custom reorg config file.
@@ -425,7 +425,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   }
   it should "Checks subworkflow with custom reorg app do not contain reorg attribute" in {
     // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
-    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
     val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
     // upload random file
     val extrasContent =

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -33,54 +33,54 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     } catch {
       case e: Exception =>
         throw new Exception(
-          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+            s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
                                         |the platform""".stripMargin
         )
     }
   lazy val cFlags = List(
-    "-compileMode",
-    "NativeWithoutRuntimeAsset",
-    "-project",
-    dxTestProject.getId,
-    "-folder",
-    "/unit_tests",
-    "-force",
-    "-locked",
-    "-quiet"
+      "-compileMode",
+      "NativeWithoutRuntimeAsset",
+      "-project",
+      dxTestProject.getId,
+      "-folder",
+      "/unit_tests",
+      "-force",
+      "-locked",
+      "-quiet"
   )
 
   lazy private val cFlagsReorg = List(
-    "-compileMode",
-    "NativeWithoutRuntimeAsset",
-    "--project",
-    dxTestProject.getId,
-    "-quiet",
-    "--folder",
-    "/reorg_tests"
+      "-compileMode",
+      "NativeWithoutRuntimeAsset",
+      "--project",
+      dxTestProject.getId,
+      "-quiet",
+      "--folder",
+      "/reorg_tests"
   )
 
   override def beforeAll(): Unit = {
     // build the directory with the native applets
     Utils.execCommand(
-      s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/",
-      quiet = true
+        s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/",
+        quiet = true
     )
 
     // building necessary applets before starting the tests
     val native_applets = Vector(
-      "native_concat",
-      "native_diff",
-      "native_mk_list",
-      "native_sum",
-      "native_sum_012",
-      "functional_reorg_test"
+        "native_concat",
+        "native_diff",
+        "native_mk_list",
+        "native_sum",
+        "native_sum_012",
+        "functional_reorg_test"
     )
     val topDir = Paths.get(System.getProperty("user.dir"))
     native_applets.foreach { app =>
       try {
         val (stdout, stderr) = Utils.execCommand(
-          s"dx build $topDir/test/applets/$app --destination ${TEST_PROJECT}:/unit_tests/applets/",
-          quiet = true
+            s"dx build $topDir/test/applets/$app --destination ${TEST_PROJECT}:/unit_tests/applets/",
+            quiet = true
         )
       } catch {
         case _: Throwable =>
@@ -93,13 +93,13 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val basename = Paths.get(path).getFileName().toString()
     val verbose = Verbose(false, true, Set.empty)
     val results = DxFindDataObjects(Some(10), verbose).apply(
-      dxTestProject,
-      Some(folder),
-      recurse = false,
-      klassRestriction = None,
-      withProperties = Vector.empty,
-      nameConstraints = Vector(basename),
-      withInputOutputSpec = false
+        dxTestProject,
+        Some(folder),
+        recurse = false,
+        klassRestriction = None,
+        withProperties = Vector.empty,
+        nameConstraints = Vector(basename),
+        withInputOutputSpec = false
     )
     results.size shouldBe (1)
     val desc = results.values.head
@@ -121,9 +121,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "Native compile a single WDL task" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("compiler", "add.wdl")
     val retval = Main.compile(
-      path.toString
+        path.toString
 //                                      :: "--verbose"
-        :: cFlags
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTermination]
   }
@@ -138,8 +138,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "Native compile a linear WDL workflow" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
     val retval = Main.compile(
-      path.toString
-        :: cFlags
+        path.toString
+          :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTermination]
   }
@@ -147,50 +147,50 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "Native compile a workflow with a scatter without a call" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("compiler", "scatter_no_call.wdl")
     Main.compile(
-      path.toString :: cFlags
+        path.toString :: cFlags
     ) shouldBe a[Main.SuccessfulTermination]
   }
 
   it should "Native compile a draft2 workflow" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("draft2", "shapes.wdl")
     Main.compile(
-      path.toString :: "--force" :: cFlags
+        path.toString :: "--force" :: cFlags
     ) shouldBe a[Main.SuccessfulTermination]
   }
 
   it should "Native compile a workflow with one level nesting" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("nested", "two_levels.wdl")
     Main.compile(
-      path.toString :: "--force" :: cFlags
+        path.toString :: "--force" :: cFlags
     ) shouldBe a[Main.SuccessfulTermination]
   }
 
   it should "handle various conditionals" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")
     Main.compile(
-      path.toString
-      /*                :: "--verbose"
+        path.toString
+        /*                :: "--verbose"
                 :: "--verboseKey" :: "Native"
                 :: "--verboseKey" :: "GenerateIR"*/
-        :: cFlags
+          :: cFlags
     ) shouldBe a[Main.SuccessfulTermination]
   }
 
   it should "be able to build interfaces to native applets" taggedAs (NativeTestXX, EdgeTest) in {
     val outputPath = "/tmp/dx_extern.wdl"
     Main.dxni(
-      List(
-        "--force",
-        "--quiet",
-        "--folder",
-        "/unit_tests/applets",
-        "--project",
-        dxTestProject.getId,
-        "--language",
-        "wdl_draft2",
-        "--output",
-        outputPath
-      )
+        List(
+            "--force",
+            "--quiet",
+            "--folder",
+            "/unit_tests/applets",
+            "--project",
+            dxTestProject.getId,
+            "--language",
+            "wdl_draft2",
+            "--output",
+            outputPath
+        )
     ) shouldBe a[Main.SuccessfulTermination]
 
     // check that the generated file contains the correct tasks
@@ -200,12 +200,12 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       ParseWomSourceFile(false).scanForTasks(content)
 
     tasks.keys shouldBe (Set(
-      "native_sum",
-      "native_sum_012",
-      "functional_reorg_test",
-      "native_mk_list",
-      "native_diff",
-      "native_concat"
+        "native_sum",
+        "native_sum_012",
+        "functional_reorg_test",
+        "native_mk_list",
+        "native_diff",
+        "native_concat"
     ))
   }
 
@@ -228,9 +228,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val extraPath = pathFromBasename("compiler/extras", "extras_license.json")
 
     val appId = Main.compile(
-      path.toString
-      /*:: "--verbose" :: "--verboseKey" :: "EdgeTest" */
-        :: "--extras" :: extraPath.toString :: cFlags
+        path.toString
+        /*:: "--verbose" :: "--verboseKey" :: "EdgeTest" */
+          :: "--extras" :: extraPath.toString :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
       case _                        => throw new Exception("sanity")
@@ -256,18 +256,18 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val path =
       pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
     Main.compile(
-      path.toString
-      /*                :: "--verbose"
+        path.toString
+        /*                :: "--verbose"
                 :: "--verboseKey" :: "Native"
                 :: "--verboseKey" :: "GenerateIR"*/
-        :: cFlags
+          :: cFlags
     ) shouldBe a[Main.SuccessfulTermination]
   }
 
   it should "make default task timeout 48 hours" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("compiler", "add_timeout.wdl")
     val appId = Main.compile(
-      path.toString :: "--force" :: cFlags
+        path.toString :: "--force" :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
       case _                        => throw new Exception("sanity")
@@ -286,11 +286,11 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case other => throw new Exception(s"Unexpected result ${other}")
     }
     timeout shouldBe JsObject(
-      "*" -> JsObject(
-        "days" -> JsNumber(2),
-        "hours" -> JsNumber(0),
-        "minutes" -> JsNumber(0)
-      )
+        "*" -> JsObject(
+            "days" -> JsNumber(2),
+            "hours" -> JsNumber(0),
+            "minutes" -> JsNumber(0)
+        )
     )
   }
 
@@ -298,8 +298,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val path = pathFromBasename("compiler", "add_timeout_override.wdl")
     val extraPath = pathFromBasename("compiler/extras", "short_timeout.json")
     val appId = Main.compile(
-      path.toString
-        :: "--extras" :: extraPath.toString :: cFlags
+        path.toString
+          :: "--extras" :: extraPath.toString :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
       case _                        => throw new Exception("sanity")
@@ -360,7 +360,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val tmpFile = createExtras(extrasContent)
     // remove locked workflow flag
     val retval = Main.compile(
-      path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+        path.toString :: "-extras" :: tmpFile :: cFlagsReorg
     )
     retval shouldBe a[Main.SuccessfulTermination]
     val wfId: String = retval match {
@@ -397,7 +397,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
     // upload random file
     val (uploadOut, uploadErr) = Utils.execCommand(
-      s"dx upload ${path.toString} --destination /reorg_tests --brief"
+        s"dx upload ${path.toString} --destination /reorg_tests --brief"
     )
     val fileId = uploadOut.trim
     val extrasContent =
@@ -412,7 +412,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val tmpFile = createExtras(extrasContent)
     // remove locked workflow flag
     val retval = Main.compile(
-      path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+        path.toString :: "-extras" :: tmpFile :: cFlagsReorg
     )
 
     retval shouldBe a[Main.SuccessfulTermination]
@@ -453,8 +453,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     // remove compile mode
     val retval = Main.compile(
-      path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg
-        .drop(2)
+        path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg
+          .drop(2)
     )
     retval shouldBe a[Main.SuccessfulTerminationIR]
 

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -20,166 +20,194 @@ import spray.json._
 // dnanexus applets and workflows that are not runnable.
 
 class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
-    private def pathFromBasename(dir: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dir}/${basename}").getPath
-        Paths.get(p)
-    }
+  private def pathFromBasename(dir: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dir}/${basename}").getPath
+    Paths.get(p)
+  }
 
-    val TEST_PROJECT = "dxWDL_playground"
+  val TEST_PROJECT = "dxWDL_playground"
 
-    lazy val dxTestProject =
-        try {
-            DxPath.resolveProject(TEST_PROJECT)
-        } catch {
-            case e : Exception =>
-                throw new Exception(s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
-                                        |the platform""".stripMargin)
-        }
-    lazy val cFlags = List("-compileMode", "NativeWithoutRuntimeAsset",
-                           "-project", dxTestProject.getId,
-                           "-folder", "/unit_tests",
-                           "-force",
-                           "-locked",
-                           "-quiet")
-
-    lazy private val cFlagsReorg = List(
-        "-compileMode", "NativeWithoutRuntimeAsset",
-        "--project", dxTestProject.getId,
-        "-quiet",  "--folder", "/reorg_tests")
-
-    override def beforeAll() : Unit = {
-        // build the directory with the native applets
-        Utils.execCommand(
-            s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/",
-                quiet=true)
-
-        // building necessary applets before starting the tests
-        val native_applets = Vector("native_concat",
-                                    "native_diff",
-                                    "native_mk_list",
-                                    "native_sum",
-                                    "native_sum_012",
-                                    "functional_reorg_test"
+  lazy val dxTestProject =
+    try {
+      DxPath.resolveProject(TEST_PROJECT)
+    } catch {
+      case e: Exception =>
+        throw new Exception(
+          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+                                        |the platform""".stripMargin
         )
-        val topDir = Paths.get(System.getProperty("user.dir"))
-        native_applets.foreach { app =>
-            try {
-                val (stdout, stderr) = Utils.execCommand(
-                    s"dx build $topDir/test/applets/$app --destination ${TEST_PROJECT}:/unit_tests/applets/",
-                    quiet=true)
-            } catch {
-                case _: Throwable =>
-            }
-        }
     }
+  lazy val cFlags = List(
+    "-compileMode",
+    "NativeWithoutRuntimeAsset",
+    "-project",
+    dxTestProject.getId,
+    "-folder",
+    "/unit_tests",
+    "-force",
+    "-locked",
+    "-quiet"
+  )
 
-    private def getAppletId(path: String): String = {
-        val folder = Paths.get(path).getParent().toAbsolutePath().toString()
-        val basename = Paths.get(path).getFileName().toString()
-        val verbose = Verbose(false, true, Set.empty)
-        val results = DxFindDataObjects(Some(10), verbose).apply(
-            dxTestProject,
-            Some(folder),
-            recurse = false,
-            klassRestriction = None,
-            withProperties = Vector.empty,
-            nameConstraints = Vector(basename),
-            withInputOutputSpec = false)
-        results.size shouldBe(1)
-        val desc = results.values.head
-        desc.id
+  lazy private val cFlagsReorg = List(
+    "-compileMode",
+    "NativeWithoutRuntimeAsset",
+    "--project",
+    dxTestProject.getId,
+    "-quiet",
+    "--folder",
+    "/reorg_tests"
+  )
+
+  override def beforeAll(): Unit = {
+    // build the directory with the native applets
+    Utils.execCommand(s"dx mkdir -p ${TEST_PROJECT}:/unit_tests/applets/", quiet = true)
+
+    // building necessary applets before starting the tests
+    val native_applets = Vector(
+      "native_concat",
+      "native_diff",
+      "native_mk_list",
+      "native_sum",
+      "native_sum_012",
+      "functional_reorg_test"
+    )
+    val topDir = Paths.get(System.getProperty("user.dir"))
+    native_applets.foreach { app =>
+      try {
+        val (stdout, stderr) = Utils.execCommand(
+          s"dx build $topDir/test/applets/$app --destination ${TEST_PROJECT}:/unit_tests/applets/",
+          quiet = true
+        )
+      } catch {
+        case _: Throwable =>
+      }
     }
+  }
 
-    private def createExtras(extrasContent: String): String = {
+  private def getAppletId(path: String): String = {
+    val folder   = Paths.get(path).getParent().toAbsolutePath().toString()
+    val basename = Paths.get(path).getFileName().toString()
+    val verbose  = Verbose(false, true, Set.empty)
+    val results = DxFindDataObjects(Some(10), verbose).apply(
+      dxTestProject,
+      Some(folder),
+      recurse = false,
+      klassRestriction = None,
+      withProperties = Vector.empty,
+      nameConstraints = Vector(basename),
+      withInputOutputSpec = false
+    )
+    results.size shouldBe (1)
+    val desc = results.values.head
+    desc.id
+  }
 
-        val tmp_extras = File.createTempFile("reorg-", ".json")
-        tmp_extras.deleteOnExit()
+  private def createExtras(extrasContent: String): String = {
 
-        val bw = new BufferedWriter(new FileWriter(tmp_extras))
-        bw.write(extrasContent)
-        bw.close()
+    val tmp_extras = File.createTempFile("reorg-", ".json")
+    tmp_extras.deleteOnExit()
 
-        tmp_extras.toString
-    }
+    val bw = new BufferedWriter(new FileWriter(tmp_extras))
+    bw.write(extrasContent)
+    bw.close()
 
+    tmp_extras.toString
+  }
 
-
-    it should "Native compile a single WDL task" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "add.wdl")
-        val retval = Main.compile(path.toString
+  it should "Native compile a single WDL task" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "add.wdl")
+    val retval = Main.compile(
+      path.toString
 //                                      :: "--verbose"
-                                      :: cFlags)
-        retval shouldBe a [Main.SuccessfulTermination]
-    }
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTermination]
+  }
 
-    // linear workflow
-    it  should "Native compile a linear WDL workflow without expressions" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
-        val retval = Main.compile(path.toString :: cFlags)
-        retval shouldBe a [Main.SuccessfulTermination]
-    }
+  // linear workflow
+  it should "Native compile a linear WDL workflow without expressions" taggedAs (NativeTestXX) in {
+    val path   = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTermination]
+  }
 
-    it  should "Native compile a linear WDL workflow" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "wf_linear.wdl")
-        val retval = Main.compile(path.toString
-                                      :: cFlags)
-        retval shouldBe a [Main.SuccessfulTermination]
-    }
+  it should "Native compile a linear WDL workflow" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "wf_linear.wdl")
+    val retval = Main.compile(
+      path.toString
+        :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTermination]
+  }
 
-    it should "Native compile a workflow with a scatter without a call" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "scatter_no_call.wdl")
-        Main.compile(
-            path.toString :: cFlags
-        ) shouldBe a [Main.SuccessfulTermination]
-    }
+  it should "Native compile a workflow with a scatter without a call" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "scatter_no_call.wdl")
+    Main.compile(
+      path.toString :: cFlags
+    ) shouldBe a[Main.SuccessfulTermination]
+  }
 
+  it should "Native compile a draft2 workflow" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("draft2", "shapes.wdl")
+    Main.compile(
+      path.toString :: "--force" :: cFlags
+    ) shouldBe a[Main.SuccessfulTermination]
+  }
 
-    it should "Native compile a draft2 workflow" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("draft2", "shapes.wdl")
-        Main.compile(
-            path.toString :: "--force" :: cFlags
-        ) shouldBe a [Main.SuccessfulTermination]
-    }
+  it should "Native compile a workflow with one level nesting" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("nested", "two_levels.wdl")
+    Main.compile(
+      path.toString :: "--force" :: cFlags
+    ) shouldBe a[Main.SuccessfulTermination]
+  }
 
-    it should "Native compile a workflow with one level nesting" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("nested", "two_levels.wdl")
-        Main.compile(
-            path.toString :: "--force" :: cFlags
-        ) shouldBe a [Main.SuccessfulTermination]
-    }
-
-    it should "handle various conditionals" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("draft2", "conditionals_base.wdl")
-        Main.compile(
-            path.toString
-/*                :: "--verbose"
+  it should "handle various conditionals" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("draft2", "conditionals_base.wdl")
+    Main.compile(
+      path.toString
+      /*                :: "--verbose"
                 :: "--verboseKey" :: "Native"
                 :: "--verboseKey" :: "GenerateIR"*/
-                :: cFlags
-        ) shouldBe a [Main.SuccessfulTermination]
-    }
+        :: cFlags
+    ) shouldBe a[Main.SuccessfulTermination]
+  }
 
-    it should "be able to build interfaces to native applets" taggedAs(NativeTestXX, EdgeTest) in {
-        val outputPath = "/tmp/dx_extern.wdl"
-        Main.dxni(
-            List("--force", "--quiet",
-                 "--folder", "/unit_tests/applets",
-                 "--project", dxTestProject.getId,
-                 "--language", "wdl_draft2",
-                 "--output", outputPath)
-        ) shouldBe a [Main.SuccessfulTermination]
+  it should "be able to build interfaces to native applets" taggedAs (NativeTestXX, EdgeTest) in {
+    val outputPath = "/tmp/dx_extern.wdl"
+    Main.dxni(
+      List(
+        "--force",
+        "--quiet",
+        "--folder",
+        "/unit_tests/applets",
+        "--project",
+        dxTestProject.getId,
+        "--language",
+        "wdl_draft2",
+        "--output",
+        outputPath
+      )
+    ) shouldBe a[Main.SuccessfulTermination]
 
-        // check that the generated file contains the correct tasks
-        val content = Source.fromFile(outputPath).getLines.mkString("\n")
+    // check that the generated file contains the correct tasks
+    val content = Source.fromFile(outputPath).getLines.mkString("\n")
 
-        val tasks : Map[String, String] = ParseWomSourceFile(false).scanForTasks(content)
+    val tasks: Map[String, String] = ParseWomSourceFile(false).scanForTasks(content)
 
-        tasks.keys shouldBe(Set("native_sum", "native_sum_012", "functional_reorg_test", "native_mk_list", "native_diff", "native_concat"))
-    }
+    tasks.keys shouldBe (Set(
+      "native_sum",
+      "native_sum_012",
+      "functional_reorg_test",
+      "native_mk_list",
+      "native_diff",
+      "native_concat"
+    ))
+  }
 
-    it should "be able to include license information in details" in {
-        val expected =
-            """
+  it should "be able to include license information in details" in {
+    val expected =
+      """
               |[
               |  {
               |    "author":"Broad Institute",
@@ -192,125 +220,124 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
               |]
             """.stripMargin.parseJson
 
-        val path = pathFromBasename("compiler", "add.wdl")
-        val extraPath = pathFromBasename("compiler/extras",  "extras_license.json")
+    val path      = pathFromBasename("compiler", "add.wdl")
+    val extraPath = pathFromBasename("compiler/extras", "extras_license.json")
 
-        val appId = Main.compile(
-            path.toString
-                /*:: "--verbose" :: "--verboseKey" :: "EdgeTest" */
-                :: "--extras" :: extraPath.toString :: cFlags
-        ) match {
-            case SuccessfulTermination(x) => x
-            case _ => throw new Exception("sanity")
+    val appId = Main.compile(
+      path.toString
+      /*:: "--verbose" :: "--verboseKey" :: "EdgeTest" */
+        :: "--extras" :: extraPath.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case _                        => throw new Exception("sanity")
 
-        }
-
-        val dxApplet = DxApplet.getInstance(appId)
-        val desc = dxApplet.describe(Set(Field.Details))
-        val license = desc.details match {
-            case Some(JsObject(x)) => x.get("upstreamProjects") match {
-                case None => List.empty
-                case Some(s) => s
-
-            }
-            case other => throw new Exception(s"Unexpected result ${other}")
-        }
-
-        license shouldBe expected
     }
 
-    it should "deep nesting" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
-        Main.compile(
-            path.toString
-/*                :: "--verbose"
+    val dxApplet = DxApplet.getInstance(appId)
+    val desc     = dxApplet.describe(Set(Field.Details))
+    val license = desc.details match {
+      case Some(JsObject(x)) =>
+        x.get("upstreamProjects") match {
+          case None    => List.empty
+          case Some(s) => s
+
+        }
+      case other => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    license shouldBe expected
+  }
+
+  it should "deep nesting" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "environment_passing_deep_nesting.wdl")
+    Main.compile(
+      path.toString
+      /*                :: "--verbose"
                 :: "--verboseKey" :: "Native"
                 :: "--verboseKey" :: "GenerateIR"*/
-                :: cFlags
-        ) shouldBe a [Main.SuccessfulTermination]
+        :: cFlags
+    ) shouldBe a[Main.SuccessfulTermination]
+  }
+
+  it should "make default task timeout 48 hours" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "add_timeout.wdl")
+    val appId = Main.compile(
+      path.toString :: "--force" :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case _                        => throw new Exception("sanity")
     }
 
-    it should "make default task timeout 48 hours" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "add_timeout.wdl")
-        val appId = Main.compile(
-            path.toString :: "--force" :: cFlags
-        ) match {
-            case SuccessfulTermination(x) => x
-            case _ => throw new Exception("sanity")
-        }
+    // make sure the timeout is what it should be
+    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
 
-        // make sure the timeout is what it should be
-        val (stdout, stderr) = Utils.execCommand(
-            s"dx describe ${dxTestProject.getId}:${appId} --json")
-
-        val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
-            case Some(JsObject(x)) => x.get("timeoutPolicy") match {
-                case None => throw new Exception("No timeout policy set")
-                case Some(s) => s
-            }
-            case other => throw new Exception(s"Unexpected result ${other}")
+    val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
+      case Some(JsObject(x)) =>
+        x.get("timeoutPolicy") match {
+          case None    => throw new Exception("No timeout policy set")
+          case Some(s) => s
         }
-        timeout shouldBe JsObject("*" -> JsObject(
-                                      "days" -> JsNumber(2),
-                                      "hours" -> JsNumber(0),
-                                      "minutes" -> JsNumber(0)))
+      case other => throw new Exception(s"Unexpected result ${other}")
+    }
+    timeout shouldBe JsObject(
+      "*" -> JsObject("days" -> JsNumber(2), "hours" -> JsNumber(0), "minutes" -> JsNumber(0))
+    )
+  }
+
+  it should "timeout can be overriden from the extras file" taggedAs (NativeTestXX) in {
+    val path      = pathFromBasename("compiler", "add_timeout_override.wdl")
+    val extraPath = pathFromBasename("compiler/extras", "short_timeout.json")
+    val appId = Main.compile(
+      path.toString
+        :: "--extras" :: extraPath.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case _                        => throw new Exception("sanity")
     }
 
-    it should "timeout can be overriden from the extras file" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "add_timeout_override.wdl")
-        val extraPath = pathFromBasename("compiler/extras",  "short_timeout.json")
-        val appId = Main.compile(
-            path.toString
-                :: "--extras" :: extraPath.toString :: cFlags
-        ) match {
-            case SuccessfulTermination(x) => x
-            case _ => throw new Exception("sanity")
+    // make sure the timeout is what it should be
+    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+
+    val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
+      case Some(JsObject(x)) =>
+        x.get("timeoutPolicy") match {
+          case None    => throw new Exception("No timeout policy set")
+          case Some(s) => s
         }
+      case other => throw new Exception(s"Unexpected result ${other}")
+    }
+    timeout shouldBe JsObject("*" -> JsObject("hours" -> JsNumber(3)))
 
-        // make sure the timeout is what it should be
-        val (stdout, stderr) = Utils.execCommand(
-            s"dx describe ${dxTestProject.getId}:${appId} --json")
+  }
 
-        val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
-            case Some(JsObject(x)) => x.get("timeoutPolicy") match {
-                case None => throw new Exception("No timeout policy set")
-                case Some(s) => s
-            }
-            case other => throw new Exception(s"Unexpected result ${other}")
-        }
-        timeout shouldBe JsObject("*" -> JsObject("hours" -> JsNumber(3)))
+  it should "allow choosing GPU instances" taggedAs (NativeTestXX) in {
+    val path = pathFromBasename("compiler", "GPU2.wdl")
 
+    val appId = Main.compile(path.toString :: cFlags) match {
+      case SuccessfulTermination(x) => x
+      case _                        => throw new Exception("sanity")
     }
 
-    it should "allow choosing GPU instances" taggedAs(NativeTestXX) in {
-        val path = pathFromBasename("compiler", "GPU2.wdl")
-
-        val appId = Main.compile(path.toString :: cFlags) match {
-            case SuccessfulTermination(x) => x
-            case _ => throw new Exception("sanity")
-        }
-
-        // make sure the timeout is what it should be
-        val (stdout, stderr) = Utils.execCommand(
-            s"dx describe ${dxTestProject.getId}:${appId} --json")
-        val obj = stdout.parseJson.asJsObject
-        val obj2 = obj.fields("runSpec").asJsObject
-        val obj3 = obj2.fields("systemRequirements").asJsObject
-        val obj4 = obj3.fields("main").asJsObject
-        val instanceType = obj4.fields.get("instanceType") match {
-            case Some(JsString(x)) => x
-            case other => throw new Exception(s"Unexpected result ${other}")
-        }
-
-        //System.out.println(s"instanceType = ${instanceType}")
-        instanceType should include ("_gpu")
+    // make sure the timeout is what it should be
+    val (stdout, stderr) = Utils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val obj              = stdout.parseJson.asJsObject
+    val obj2             = obj.fields("runSpec").asJsObject
+    val obj3             = obj2.fields("systemRequirements").asJsObject
+    val obj4             = obj3.fields("main").asJsObject
+    val instanceType = obj4.fields.get("instanceType") match {
+      case Some(JsString(x)) => x
+      case other             => throw new Exception(s"Unexpected result ${other}")
     }
 
-    it should "Compile a workflow with subworkflows on the platform with the reorg app" taggedAs(EdgeTest) in {
-        val path = pathFromBasename("subworkflows", basename="trains_station.wdl")
-        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
-        val extrasContent =
-            s"""|{
+    //System.out.println(s"instanceType = ${instanceType}")
+    instanceType should include("_gpu")
+  }
+
+  it should "Compile a workflow with subworkflows on the platform with the reorg app" taggedAs (EdgeTest) in {
+    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+    val extrasContent =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appletId}",
                 |    "conf" : null
@@ -318,51 +345,51 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
                 |}
                 |""".stripMargin
 
-        val tmpFile= createExtras(extrasContent)
-        // remove locked workflow flag
-        val retval = Main.compile(
-            path.toString :: "-extras" :: tmpFile :: cFlagsReorg
-        )
-        retval shouldBe a [Main.SuccessfulTermination]
-        val wfId: String = retval match {
-            case Main.SuccessfulTermination(ir) => ir
-            case _ => throw new Exception("sanity")
-        }
-
-        val wf = DxWorkflow.getInstance(wfId)
-        val wfDesc = wf.describe(Set(Field.Stages))
-        val wfStages = wfDesc.stages.get
-
-        // there should be 4 stages: 1) common 2) train_stations 3) outputs 4) reorg
-        wfStages.size shouldBe 4
-        val reorgStage = wfStages.last
-
-        reorgStage.id shouldBe("stage-reorg")
-        reorgStage.executable shouldBe(appletId)
-
-        // There should be 3 inputs, the output from output stage and the custom reorg config file.
-        val reorgInput: JsObject = reorgStage.input match {
-            case JsObject(x) => JsObject(x)
-            case _ => throw new Exception("sanity")
-        }
-
-        // no reorg conf input. only status.
-        reorgInput.fields.size shouldBe 1
-        reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS)
+    val tmpFile = createExtras(extrasContent)
+    // remove locked workflow flag
+    val retval = Main.compile(
+      path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+    )
+    retval shouldBe a[Main.SuccessfulTermination]
+    val wfId: String = retval match {
+      case Main.SuccessfulTermination(ir) => ir
+      case _                              => throw new Exception("sanity")
     }
 
-    // ignore for now as the test will fail in staging
-    it should "Compile a workflow with subworkflows on the platform with the reorg app with config file in the input" in {
-        // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
-        val path = pathFromBasename("subworkflows", basename="trains_station.wdl")
-        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
-        // upload random file
-        val (uploadOut, uploadErr) = Utils.execCommand(
-            s"dx upload ${path.toString} --destination /reorg_tests --brief"
-        )
-        val fileId = uploadOut.trim
-        val extrasContent =
-            s"""|{
+    val wf       = DxWorkflow.getInstance(wfId)
+    val wfDesc   = wf.describe(Set(Field.Stages))
+    val wfStages = wfDesc.stages.get
+
+    // there should be 4 stages: 1) common 2) train_stations 3) outputs 4) reorg
+    wfStages.size shouldBe 4
+    val reorgStage = wfStages.last
+
+    reorgStage.id shouldBe ("stage-reorg")
+    reorgStage.executable shouldBe (appletId)
+
+    // There should be 3 inputs, the output from output stage and the custom reorg config file.
+    val reorgInput: JsObject = reorgStage.input match {
+      case JsObject(x) => JsObject(x)
+      case _           => throw new Exception("sanity")
+    }
+
+    // no reorg conf input. only status.
+    reorgInput.fields.size shouldBe 1
+    reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS)
+  }
+
+  // ignore for now as the test will fail in staging
+  it should "Compile a workflow with subworkflows on the platform with the reorg app with config file in the input" in {
+    // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
+    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+    // upload random file
+    val (uploadOut, uploadErr) = Utils.execCommand(
+      s"dx upload ${path.toString} --destination /reorg_tests --brief"
+    )
+    val fileId = uploadOut.trim
+    val extrasContent =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appletId}",
                 |    "conf" : "dx://$fileId"
@@ -370,39 +397,39 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
                 |}
                 |""".stripMargin
 
-        val tmpFile= createExtras(extrasContent)
-        // remove locked workflow flag
-        val retval = Main.compile(
-            path.toString :: "-extras" :: tmpFile :: cFlagsReorg
-        )
+    val tmpFile = createExtras(extrasContent)
+    // remove locked workflow flag
+    val retval = Main.compile(
+      path.toString :: "-extras" :: tmpFile :: cFlagsReorg
+    )
 
-        retval shouldBe a [Main.SuccessfulTermination]
-        val wfId: String = retval match {
-            case Main.SuccessfulTermination(wfId) => wfId
-            case _ => throw new Exception("sanity")
-        }
-
-        val wf = DxWorkflow.getInstance(wfId)
-        val wfDesc = wf.describe(Set(Field.Stages))
-        val wfStages = wfDesc.stages.get
-        val reorgStage = wfStages.last
-
-        // There should be 3 inputs, the output from output stage and the custom reorg config file.
-        val reorgInput: JsObject = reorgStage.input match {
-            case JsObject(x) => JsObject(x)
-            case _ => throw new Exception("sanity")
-        }
-        // no reorg conf input. only status.
-        reorgInput.fields.size shouldBe 2
-        reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS, Utils.REORG_CONFIG)
+    retval shouldBe a[Main.SuccessfulTermination]
+    val wfId: String = retval match {
+      case Main.SuccessfulTermination(wfId) => wfId
+      case _                                => throw new Exception("sanity")
     }
-    it should "Checks subworkflow with custom reorg app do not contain reorg attribute" in {
-        // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
-        val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
-        val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
-        // upload random file
-        val extrasContent =
-            s"""|{
+
+    val wf         = DxWorkflow.getInstance(wfId)
+    val wfDesc     = wf.describe(Set(Field.Stages))
+    val wfStages   = wfDesc.stages.get
+    val reorgStage = wfStages.last
+
+    // There should be 3 inputs, the output from output stage and the custom reorg config file.
+    val reorgInput: JsObject = reorgStage.input match {
+      case JsObject(x) => JsObject(x)
+      case _           => throw new Exception("sanity")
+    }
+    // no reorg conf input. only status.
+    reorgInput.fields.size shouldBe 2
+    reorgInput.fields.keys shouldBe Set(Utils.REORG_STATUS, Utils.REORG_CONFIG)
+  }
+  it should "Checks subworkflow with custom reorg app do not contain reorg attribute" in {
+    // This works in conjunction with "Compile a workflow with subworkflows on the platform with the reorg app".
+    val path     = pathFromBasename("subworkflows", basename = "trains_station.wdl")
+    val appletId = getAppletId("/unit_tests/applets/functional_reorg_test")
+    // upload random file
+    val extrasContent =
+      s"""|{
                 | "custom_reorg" : {
                 |    "app_id" : "${appletId}",
                 |    "conf" : null
@@ -410,21 +437,21 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
                 |}
                 |""".stripMargin
 
-        val tmpFile = createExtras(extrasContent)
+    val tmpFile = createExtras(extrasContent)
 
-        // remove compile mode
-        val retval = Main.compile(
-            path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg.drop(2)
-        )
-        retval shouldBe a [Main.SuccessfulTerminationIR]
+    // remove compile mode
+    val retval = Main.compile(
+      path.toString :: "-extras" :: tmpFile :: "-compileMode" :: "IR" :: cFlagsReorg.drop(2)
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
 
-        val bundle = retval match {
-            case Main.SuccessfulTerminationIR(bundle) => bundle
-            case _ => throw new Exception("sanity")
-        }
-
-        // this is a subworkflow so there is no reorg_status___ added.
-        val trainsOutputVector: IR.Callable = bundle.allCallables("trains")
-        trainsOutputVector.outputVars.size shouldBe 1
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(bundle) => bundle
+      case _                                    => throw new Exception("sanity")
     }
+
+    // this is a subworkflow so there is no reorg_status___ added.
+    val trainsOutputVector: IR.Callable = bundle.allCallables("trains")
+    trainsOutputVector.outputVars.size shouldBe 1
+  }
 }

--- a/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
@@ -21,8 +21,15 @@ class SortTypeAliasesTest extends FlatSpec with Matchers {
     val (_, _, typeAliases: Map[String, WomType]) =
       ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
-    val defs: Vector[(String, WomType)] = SortTypeAliases(verbose).apply(typeAliases.toVector)
+    val defs: Vector[(String, WomType)] =
+      SortTypeAliases(verbose).apply(typeAliases.toVector)
     val defNames = defs.map { case (name, _) => name }.toVector
-    defNames shouldBe (Vector("Coord", "Bunk", "Foo", "SampleReports", "SampleReportsArray"))
+    defNames shouldBe (Vector(
+      "Coord",
+      "Bunk",
+      "Foo",
+      "SampleReports",
+      "SampleReportsArray"
+    ))
   }
 }

--- a/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
@@ -8,21 +8,21 @@ import dxWDL.base.{Utils, Verbose}
 import dxWDL.util.ParseWomSourceFile
 
 class SortTypeAliasesTest extends FlatSpec with Matchers {
-    private def pathFromBasename(dir: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dir}/${basename}").getPath
-        Paths.get(p)
-    }
+  private def pathFromBasename(dir: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dir}/${basename}").getPath
+    Paths.get(p)
+  }
 
-    val verbose = Verbose(false, true, Set.empty)
+  val verbose = Verbose(false, true, Set.empty)
 
-    it should "sort type aliases properly" in {
-        val path = pathFromBasename("struct", "many_structs.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (_, _, typeAliases: Map[String, WomType]) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+  it should "sort type aliases properly" in {
+    val path         = pathFromBasename("struct", "many_structs.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+    val (_, _, typeAliases: Map[String, WomType]) =
+      ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
-
-        val defs : Vector[(String, WomType)] = SortTypeAliases(verbose).apply(typeAliases.toVector)
-        val defNames = defs.map{ case (name, _) => name }.toVector
-        defNames shouldBe(Vector("Coord", "Bunk", "Foo", "SampleReports", "SampleReportsArray"))
-    }
+    val defs: Vector[(String, WomType)] = SortTypeAliases(verbose).apply(typeAliases.toVector)
+    val defNames                        = defs.map { case (name, _) => name }.toVector
+    defNames shouldBe (Vector("Coord", "Bunk", "Foo", "SampleReports", "SampleReportsArray"))
+  }
 }

--- a/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
@@ -16,13 +16,13 @@ class SortTypeAliasesTest extends FlatSpec with Matchers {
   val verbose = Verbose(false, true, Set.empty)
 
   it should "sort type aliases properly" in {
-    val path         = pathFromBasename("struct", "many_structs.wdl")
+    val path = pathFromBasename("struct", "many_structs.wdl")
     val wfSourceCode = Utils.readFileContent(path)
     val (_, _, typeAliases: Map[String, WomType]) =
       ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
     val defs: Vector[(String, WomType)] = SortTypeAliases(verbose).apply(typeAliases.toVector)
-    val defNames                        = defs.map { case (name, _) => name }.toVector
+    val defNames = defs.map { case (name, _) => name }.toVector
     defNames shouldBe (Vector("Coord", "Bunk", "Foo", "SampleReports", "SampleReportsArray"))
   }
 }

--- a/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
@@ -25,11 +25,11 @@ class SortTypeAliasesTest extends FlatSpec with Matchers {
       SortTypeAliases(verbose).apply(typeAliases.toVector)
     val defNames = defs.map { case (name, _) => name }.toVector
     defNames shouldBe (Vector(
-      "Coord",
-      "Bunk",
-      "Foo",
-      "SampleReports",
-      "SampleReportsArray"
+        "Coord",
+        "Bunk",
+        "Foo",
+        "SampleReports",
+        "SampleReportsArray"
     ))
   }
 }

--- a/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
+++ b/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
@@ -35,13 +35,13 @@ class WdlCodeGenTest extends FlatSpec with Matchers {
 
   it should "handle structs" in {
     val houseType = WomCompositeType(
-      Map(
-        "height" -> WomIntegerType,
-        "num_floors" -> WomIntegerType,
-        "street" -> WomStringType,
-        "city" -> WomStringType
-      ),
-      Some("House")
+        Map(
+            "height" -> WomIntegerType,
+            "num_floors" -> WomIntegerType,
+            "street" -> WomStringType,
+            "city" -> WomStringType
+        ),
+        Some("House")
     )
     genDefaultValue(houseType) shouldBe ("""object {height: 0, num_floors: 0, street: "", city: ""}""")
   }

--- a/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
+++ b/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
@@ -6,7 +6,7 @@ import wom.types._
 import dxWDL.base._
 
 class WdlCodeGenTest extends FlatSpec with Matchers {
-  private val verbose    = Verbose(false, true, Set.empty)
+  private val verbose = Verbose(false, true, Set.empty)
   private val wdlCodeGen = WdlCodeGen(verbose, Map.empty, Language.WDLv1_0)
 
   private def genDefaultValue(t: WomType): String = {
@@ -36,10 +36,10 @@ class WdlCodeGenTest extends FlatSpec with Matchers {
   it should "handle structs" in {
     val houseType = WomCompositeType(
       Map(
-        "height"     -> WomIntegerType,
+        "height" -> WomIntegerType,
         "num_floors" -> WomIntegerType,
-        "street"     -> WomStringType,
-        "city"       -> WomStringType
+        "street" -> WomStringType,
+        "city" -> WomStringType
       ),
       Some("House")
     )

--- a/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
+++ b/src/test/scala/dxWDL/compiler/WdlCodeGenTest.scala
@@ -6,39 +6,43 @@ import wom.types._
 import dxWDL.base._
 
 class WdlCodeGenTest extends FlatSpec with Matchers {
-    private val verbose = Verbose(false, true, Set.empty)
-    private val wdlCodeGen = WdlCodeGen(verbose, Map.empty, Language.WDLv1_0)
+  private val verbose    = Verbose(false, true, Set.empty)
+  private val wdlCodeGen = WdlCodeGen(verbose, Map.empty, Language.WDLv1_0)
 
-    private def genDefaultValue(t : WomType) : String = {
-        val defVal = wdlCodeGen.genDefaultValueOfType(t)
-        defVal.toWomString
-    }
+  private def genDefaultValue(t: WomType): String = {
+    val defVal = wdlCodeGen.genDefaultValueOfType(t)
+    defVal.toWomString
+  }
 
-    it should "Handle primitive types" in {
-        genDefaultValue(WomIntegerType) shouldBe("0")
-        genDefaultValue(WomFloatType) shouldBe("0.0")
-        genDefaultValue(WomStringType) shouldBe("""""""")
-        genDefaultValue(WomSingleFileType) shouldBe(""""dummy.txt"""")
-    }
+  it should "Handle primitive types" in {
+    genDefaultValue(WomIntegerType) shouldBe ("0")
+    genDefaultValue(WomFloatType) shouldBe ("0.0")
+    genDefaultValue(WomStringType) shouldBe ("""""""")
+    genDefaultValue(WomSingleFileType) shouldBe (""""dummy.txt"""")
+  }
 
-    it should "Handle array" in {
-        genDefaultValue(WomArrayType(WomIntegerType)) shouldBe("[]")
-        genDefaultValue(WomArrayType(WomFloatType)) shouldBe("[]")
-    }
+  it should "Handle array" in {
+    genDefaultValue(WomArrayType(WomIntegerType)) shouldBe ("[]")
+    genDefaultValue(WomArrayType(WomFloatType)) shouldBe ("[]")
+  }
 
-    it should "handle maps, pairs, optionals" in {
-        genDefaultValue(WomMapType(WomIntegerType, WomStringType)) shouldBe("""{0: ""}""")
+  it should "handle maps, pairs, optionals" in {
+    genDefaultValue(WomMapType(WomIntegerType, WomStringType)) shouldBe ("""{0: ""}""")
 
-        genDefaultValue(WomPairType(WomIntegerType, WomSingleFileType)) shouldBe("""(0, "dummy.txt")""")
-        genDefaultValue(WomOptionalType(WomFloatType)) shouldBe("0.0")
-    }
+    genDefaultValue(WomPairType(WomIntegerType, WomSingleFileType)) shouldBe ("""(0, "dummy.txt")""")
+    genDefaultValue(WomOptionalType(WomFloatType)) shouldBe ("0.0")
+  }
 
-    it should "handle structs" in {
-        val houseType = WomCompositeType(Map("height" -> WomIntegerType,
-                                             "num_floors" -> WomIntegerType,
-                                             "street" -> WomStringType,
-                                             "city" -> WomStringType),
-                                         Some("House"))
-        genDefaultValue(houseType) shouldBe("""object {height: 0, num_floors: 0, street: "", city: ""}""")
-    }
+  it should "handle structs" in {
+    val houseType = WomCompositeType(
+      Map(
+        "height"     -> WomIntegerType,
+        "num_floors" -> WomIntegerType,
+        "street"     -> WomStringType,
+        "city"       -> WomStringType
+      ),
+      Some("House")
+    )
+    genDefaultValue(houseType) shouldBe ("""object {height: 0, num_floors: 0, street: "", city: ""}""")
+  }
 }

--- a/src/test/scala/dxWDL/compiler/package.scala
+++ b/src/test/scala/dxWDL/compiler/package.scala
@@ -1,6 +1,6 @@
 package dxWDL.compiler
 
 import org.scalatest.Tag
-object EdgeTest     extends Tag("edge")
+object EdgeTest extends Tag("edge")
 object NativeTestXX extends Tag("native")
-object ProdTest     extends Tag("prod")
+object ProdTest extends Tag("prod")

--- a/src/test/scala/dxWDL/compiler/package.scala
+++ b/src/test/scala/dxWDL/compiler/package.scala
@@ -1,7 +1,6 @@
 package dxWDL.compiler
 
 import org.scalatest.Tag
-object EdgeTest extends Tag("edge")
+object EdgeTest     extends Tag("edge")
 object NativeTestXX extends Tag("native")
-object ProdTest extends Tag("prod")
-
+object ProdTest     extends Tag("prod")

--- a/src/test/scala/dxWDL/dx/DxPathTest.scala
+++ b/src/test/scala/dxWDL/dx/DxPathTest.scala
@@ -13,7 +13,7 @@ class DxPathTest extends FlatSpec with Matchers {
     } catch {
       case e: Exception =>
         throw new Exception(
-          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+            s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
                                         |the platform on staging.""".stripMargin
         )
     }

--- a/src/test/scala/dxWDL/dx/DxPathTest.scala
+++ b/src/test/scala/dxWDL/dx/DxPathTest.scala
@@ -44,7 +44,8 @@ class DxPathTest extends FlatSpec with Matchers {
 
   it should "handle files with a colon" in {
     val expectedId = describeDxFilePath(s"${TEST_PROJECT}:/x*.txt")
-    val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${TEST_PROJECT}:/x:x.txt")
+    val dxFile: DxFile =
+      DxPath.resolveDxURLFile(s"dx://${TEST_PROJECT}:/x:x.txt")
     dxFile.getId shouldBe (expectedId)
   }
 }

--- a/src/test/scala/dxWDL/dx/DxPathTest.scala
+++ b/src/test/scala/dxWDL/dx/DxPathTest.scala
@@ -29,21 +29,21 @@ class DxPathTest extends FlatSpec with Matchers {
   }
 
   it should "handle files in a root directory" in {
-    val path           = s"${TEST_PROJECT}:/Readme.md"
-    val expectedId     = describeDxFilePath(path)
+    val path = s"${TEST_PROJECT}:/Readme.md"
+    val expectedId = describeDxFilePath(path)
     val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
     dxFile.getId shouldBe (expectedId)
   }
 
   it should "handle files in a subdirectory directory" in {
-    val path           = s"${TEST_PROJECT}:/test_data/fileA"
-    val expectedId     = describeDxFilePath(path)
+    val path = s"${TEST_PROJECT}:/test_data/fileA"
+    val expectedId = describeDxFilePath(path)
     val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
     dxFile.getId shouldBe (expectedId)
   }
 
   it should "handle files with a colon" in {
-    val expectedId     = describeDxFilePath(s"${TEST_PROJECT}:/x*.txt")
+    val expectedId = describeDxFilePath(s"${TEST_PROJECT}:/x*.txt")
     val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${TEST_PROJECT}:/x:x.txt")
     dxFile.getId shouldBe (expectedId)
   }

--- a/src/test/scala/dxWDL/dx/DxPathTest.scala
+++ b/src/test/scala/dxWDL/dx/DxPathTest.scala
@@ -6,43 +6,45 @@ import dxWDL.base._
 
 class DxPathTest extends FlatSpec with Matchers {
 
-    val TEST_PROJECT = "dxWDL_playground"
-    lazy val dxTestProject : DxProject =
-        try {
-            DxPath.resolveProject(TEST_PROJECT)
-        } catch {
-            case e : Exception =>
-                throw new Exception(s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
-                                        |the platform on staging.""".stripMargin)
-        }
-
-    // describe a file on the platform using the dx-toolkit. This is a baseline for comparison
-    private def describeDxFilePath(path : String) : String = {
-        val (stdout, stderr) = Utils.execCommand(s"dx describe ${path} --json")
-        val id = stdout.parseJson.asJsObject.fields.get("id") match {
-            case Some(JsString(x)) => x.replaceAll("\"", "")
-            case other => throw new Exception(s"Unexpected result ${other}")
-        }
-        id
+  val TEST_PROJECT = "dxWDL_playground"
+  lazy val dxTestProject: DxProject =
+    try {
+      DxPath.resolveProject(TEST_PROJECT)
+    } catch {
+      case e: Exception =>
+        throw new Exception(
+          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+                                        |the platform on staging.""".stripMargin
+        )
     }
 
-    it should "handle files in a root directory" in {
-        val path = s"${TEST_PROJECT}:/Readme.md"
-        val expectedId = describeDxFilePath(path)
-        val dxFile : DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
-        dxFile.getId shouldBe(expectedId)
+  // describe a file on the platform using the dx-toolkit. This is a baseline for comparison
+  private def describeDxFilePath(path: String): String = {
+    val (stdout, stderr) = Utils.execCommand(s"dx describe ${path} --json")
+    val id = stdout.parseJson.asJsObject.fields.get("id") match {
+      case Some(JsString(x)) => x.replaceAll("\"", "")
+      case other             => throw new Exception(s"Unexpected result ${other}")
     }
+    id
+  }
 
-    it should "handle files in a subdirectory directory" in {
-        val path = s"${TEST_PROJECT}:/test_data/fileA"
-        val expectedId = describeDxFilePath(path)
-        val dxFile : DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
-        dxFile.getId shouldBe(expectedId)
-    }
+  it should "handle files in a root directory" in {
+    val path           = s"${TEST_PROJECT}:/Readme.md"
+    val expectedId     = describeDxFilePath(path)
+    val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
+    dxFile.getId shouldBe (expectedId)
+  }
 
-    it should "handle files with a colon" in {
-        val expectedId = describeDxFilePath(s"${TEST_PROJECT}:/x*.txt")
-        val dxFile : DxFile = DxPath.resolveDxURLFile(s"dx://${TEST_PROJECT}:/x:x.txt")
-        dxFile.getId shouldBe(expectedId)
-    }
+  it should "handle files in a subdirectory directory" in {
+    val path           = s"${TEST_PROJECT}:/test_data/fileA"
+    val expectedId     = describeDxFilePath(path)
+    val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${path}")
+    dxFile.getId shouldBe (expectedId)
+  }
+
+  it should "handle files with a colon" in {
+    val expectedId     = describeDxFilePath(s"${TEST_PROJECT}:/x*.txt")
+    val dxFile: DxFile = DxPath.resolveDxURLFile(s"dx://${TEST_PROJECT}:/x:x.txt")
+    dxFile.getId shouldBe (expectedId)
+  }
 }

--- a/src/test/scala/dxWDL/dx/DxTest.scala
+++ b/src/test/scala/dxWDL/dx/DxTest.scala
@@ -18,13 +18,13 @@ class DxTest extends FlatSpec with Matchers {
 
   ignore should "describe a record with details" in {
     val record = DxRecord.getInstance("record-Fgk7V7j0f9JfkYK55P7k3jGY", dxTestProject)
-    val desc   = record.describe(Set(Field.Details))
+    val desc = record.describe(Set(Field.Details))
     System.out.println(desc)
   }
 
   ignore should "describe a file with details" in {
     val record = DxFile.getInstance("file-FJ1qyg80ffP9v6gVPxKz9pQ7", dxTestProject)
-    val desc   = record.describe()
+    val desc = record.describe()
     System.out.println(desc)
   }
 }

--- a/src/test/scala/dxWDL/dx/DxTest.scala
+++ b/src/test/scala/dxWDL/dx/DxTest.scala
@@ -11,7 +11,7 @@ class DxTest extends FlatSpec with Matchers {
     } catch {
       case e: Exception =>
         throw new Exception(
-          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+            s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
                                         |the platform on staging.""".stripMargin
         )
     }

--- a/src/test/scala/dxWDL/dx/DxTest.scala
+++ b/src/test/scala/dxWDL/dx/DxTest.scala
@@ -17,13 +17,15 @@ class DxTest extends FlatSpec with Matchers {
     }
 
   ignore should "describe a record with details" in {
-    val record = DxRecord.getInstance("record-Fgk7V7j0f9JfkYK55P7k3jGY", dxTestProject)
+    val record =
+      DxRecord.getInstance("record-Fgk7V7j0f9JfkYK55P7k3jGY", dxTestProject)
     val desc = record.describe(Set(Field.Details))
     System.out.println(desc)
   }
 
   ignore should "describe a file with details" in {
-    val record = DxFile.getInstance("file-FJ1qyg80ffP9v6gVPxKz9pQ7", dxTestProject)
+    val record =
+      DxFile.getInstance("file-FJ1qyg80ffP9v6gVPxKz9pQ7", dxTestProject)
     val desc = record.describe()
     System.out.println(desc)
   }

--- a/src/test/scala/dxWDL/dx/DxTest.scala
+++ b/src/test/scala/dxWDL/dx/DxTest.scala
@@ -4,26 +4,27 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class DxTest extends FlatSpec with Matchers {
 
-    val TEST_PROJECT = "dxWDL_playground"
-    lazy val dxTestProject : DxProject =
-        try {
-            DxPath.resolveProject(TEST_PROJECT)
-        } catch {
-            case e : Exception =>
-                throw new Exception(s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
-                                        |the platform on staging.""".stripMargin)
-        }
-
-    ignore should "describe a record with details" in {
-        val record = DxRecord.getInstance("record-Fgk7V7j0f9JfkYK55P7k3jGY", dxTestProject)
-        val desc = record.describe(Set(Field.Details))
-        System.out.println(desc)
+  val TEST_PROJECT = "dxWDL_playground"
+  lazy val dxTestProject: DxProject =
+    try {
+      DxPath.resolveProject(TEST_PROJECT)
+    } catch {
+      case e: Exception =>
+        throw new Exception(
+          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+                                        |the platform on staging.""".stripMargin
+        )
     }
 
+  ignore should "describe a record with details" in {
+    val record = DxRecord.getInstance("record-Fgk7V7j0f9JfkYK55P7k3jGY", dxTestProject)
+    val desc   = record.describe(Set(Field.Details))
+    System.out.println(desc)
+  }
 
-    ignore should "describe a file with details" in {
-        val record = DxFile.getInstance("file-FJ1qyg80ffP9v6gVPxKz9pQ7", dxTestProject)
-        val desc = record.describe()
-        System.out.println(desc)
-    }
+  ignore should "describe a file with details" in {
+    val record = DxFile.getInstance("file-FJ1qyg80ffP9v6gVPxKz9pQ7", dxTestProject)
+    val desc   = record.describe()
+    System.out.println(desc)
+  }
 }

--- a/src/test/scala/dxWDL/dx/DxUtilsTest.scala
+++ b/src/test/scala/dxWDL/dx/DxUtilsTest.scala
@@ -11,15 +11,15 @@ class DxUtilsTest extends FlatSpec with Matchers {
     } catch {
       case e: Exception =>
         throw new Exception(
-          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+            s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
                                         |the platform on staging.""".stripMargin
         )
     }
 
   it should "download files as strings" in {
     val results = DxPath.resolveBulk(
-      List(s"dx://${TEST_PROJECT}:/test_data/fileA"),
-      dxTestProject
+        List(s"dx://${TEST_PROJECT}:/test_data/fileA"),
+        dxTestProject
     )
     results.size shouldBe (1)
     val dxobj = results.values.head

--- a/src/test/scala/dxWDL/dx/DxUtilsTest.scala
+++ b/src/test/scala/dxWDL/dx/DxUtilsTest.scala
@@ -4,25 +4,26 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class DxUtilsTest extends FlatSpec with Matchers {
 
-    val TEST_PROJECT = "dxWDL_playground"
-    lazy val dxTestProject : DxProject =
-        try {
-            DxPath.resolveProject(TEST_PROJECT)
-        } catch {
-            case e : Exception =>
-                throw new Exception(s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
-                                        |the platform on staging.""".stripMargin)
-        }
-
-    it should "download files as strings" in {
-        val results = DxPath.resolveBulk(
-            List(s"dx://${TEST_PROJECT}:/test_data/fileA"), dxTestProject)
-        results.size shouldBe(1)
-        val dxobj = results.values.head
-        val dxFile : DxFile = dxobj.asInstanceOf[DxFile]
-
-        val value = DxUtils.downloadString(dxFile, false)
-        value shouldBe("The fibonacci series includes 0,1,1,2,3,5\n")
+  val TEST_PROJECT = "dxWDL_playground"
+  lazy val dxTestProject: DxProject =
+    try {
+      DxPath.resolveProject(TEST_PROJECT)
+    } catch {
+      case e: Exception =>
+        throw new Exception(
+          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+                                        |the platform on staging.""".stripMargin
+        )
     }
+
+  it should "download files as strings" in {
+    val results = DxPath.resolveBulk(List(s"dx://${TEST_PROJECT}:/test_data/fileA"), dxTestProject)
+    results.size shouldBe (1)
+    val dxobj          = results.values.head
+    val dxFile: DxFile = dxobj.asInstanceOf[DxFile]
+
+    val value = DxUtils.downloadString(dxFile, false)
+    value shouldBe ("The fibonacci series includes 0,1,1,2,3,5\n")
+  }
 
 }

--- a/src/test/scala/dxWDL/dx/DxUtilsTest.scala
+++ b/src/test/scala/dxWDL/dx/DxUtilsTest.scala
@@ -19,7 +19,7 @@ class DxUtilsTest extends FlatSpec with Matchers {
   it should "download files as strings" in {
     val results = DxPath.resolveBulk(List(s"dx://${TEST_PROJECT}:/test_data/fileA"), dxTestProject)
     results.size shouldBe (1)
-    val dxobj          = results.values.head
+    val dxobj = results.values.head
     val dxFile: DxFile = dxobj.asInstanceOf[DxFile]
 
     val value = DxUtils.downloadString(dxFile, false)

--- a/src/test/scala/dxWDL/dx/DxUtilsTest.scala
+++ b/src/test/scala/dxWDL/dx/DxUtilsTest.scala
@@ -17,7 +17,10 @@ class DxUtilsTest extends FlatSpec with Matchers {
     }
 
   it should "download files as strings" in {
-    val results = DxPath.resolveBulk(List(s"dx://${TEST_PROJECT}:/test_data/fileA"), dxTestProject)
+    val results = DxPath.resolveBulk(
+      List(s"dx://${TEST_PROJECT}:/test_data/fileA"),
+      dxTestProject
+    )
     results.size shouldBe (1)
     val dxobj = results.values.head
     val dxFile: DxFile = dxobj.asInstanceOf[DxFile]

--- a/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
+++ b/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
@@ -37,9 +37,9 @@ class DxdaManifestTest extends FlatSpec with Matchers {
   // it to what we get from our DxdaManifest code.
   //
   private def describeWithParts(dxFile: DxFile): JsValue = {
-    val cmd              = s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
+    val cmd = s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
     val (stdout, stderr) = Utils.execCommand(cmd)
-    val jsv              = stdout.parseJson
+    val jsv = stdout.parseJson
 
     // remove the "state" field from all the parts
     val fields = jsv.asJsObject.fields.map {
@@ -66,7 +66,7 @@ class DxdaManifestTest extends FlatSpec with Matchers {
       DxPath.resolveBulk(fileDir.keys.toVector, dxTestProject)
     val filesInManifest: Map[String, (DxFile, Path)] = resolvedObjects.map {
       case (dxPath, dataObj) =>
-        val dxFile      = dataObj.asInstanceOf[DxFile]
+        val dxFile = dataObj.asInstanceOf[DxFile]
         val local: Path = fileDir(dxPath)
         dxFile.id -> (dxFile, local)
     }.toMap
@@ -77,13 +77,13 @@ class DxdaManifestTest extends FlatSpec with Matchers {
     // compare to data obtained with dx-toolkit
     val expected: Vector[JsValue] = resolvedObjects.map {
       case (dxPath, dataObj) =>
-        val dxFile      = dataObj.asInstanceOf[DxFile]
+        val dxFile = dataObj.asInstanceOf[DxFile]
         val local: Path = fileDir(dxPath)
-        val jsv         = describeWithParts(dxFile)
+        val jsv = describeWithParts(dxFile)
 
         // add the target folder and name
         val fields = jsv.asJsObject.fields ++ Map(
-          "name"   -> JsString(local.toFile().getName()),
+          "name" -> JsString(local.toFile().getName()),
           "folder" -> JsString(local.toFile().getParent())
         )
         JsObject(fields)

--- a/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
+++ b/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
@@ -37,7 +37,8 @@ class DxdaManifestTest extends FlatSpec with Matchers {
   // it to what we get from our DxdaManifest code.
   //
   private def describeWithParts(dxFile: DxFile): JsValue = {
-    val cmd = s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
+    val cmd =
+      s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
     val (stdout, stderr) = Utils.execCommand(cmd)
     val jsv = stdout.parseJson
 

--- a/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
+++ b/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
@@ -15,7 +15,7 @@ class DxdaManifestTest extends FlatSpec with Matchers {
     } catch {
       case e: Exception =>
         throw new Exception(
-          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+            s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
                                         |the platform on staging.""".stripMargin
         )
     }
@@ -57,9 +57,9 @@ class DxdaManifestTest extends FlatSpec with Matchers {
   it should "create manifests for dxda" in {
 
     val fileDir: Map[String, Path] = Map(
-      s"dx://${TEST_PROJECT}:/test_data/fileA" -> Paths.get("inputs/A"),
-      s"dx://${TEST_PROJECT}:/test_data/fileB" -> Paths.get("inputs/B"),
-      s"dx://${TEST_PROJECT}:/test_data/fileC" -> Paths.get("inputs/C")
+        s"dx://${TEST_PROJECT}:/test_data/fileA" -> Paths.get("inputs/A"),
+        s"dx://${TEST_PROJECT}:/test_data/fileB" -> Paths.get("inputs/B"),
+        s"dx://${TEST_PROJECT}:/test_data/fileC" -> Paths.get("inputs/C")
     )
 
     // resolve the paths
@@ -84,14 +84,14 @@ class DxdaManifestTest extends FlatSpec with Matchers {
 
         // add the target folder and name
         val fields = jsv.asJsObject.fields ++ Map(
-          "name" -> JsString(local.toFile().getName()),
-          "folder" -> JsString(local.toFile().getParent())
+            "name" -> JsString(local.toFile().getName()),
+            "folder" -> JsString(local.toFile().getParent())
         )
         JsObject(fields)
     }.toVector
 
     manifest shouldBe (DxdaManifest(
-      JsObject(dxTestProject.getId -> JsArray(expected))
+        JsObject(dxTestProject.getId -> JsArray(expected))
     ))
   }
 }

--- a/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
+++ b/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
@@ -8,88 +8,89 @@ import dxWDL.base.Utils
 
 class DxdaManifestTest extends FlatSpec with Matchers {
 
-    val TEST_PROJECT = "dxWDL_playground"
-    lazy val dxTestProject : DxProject =
-        try {
-            DxPath.resolveProject(TEST_PROJECT)
-        } catch {
-            case e : Exception =>
-                throw new Exception(s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
-                                        |the platform on staging.""".stripMargin)
-        }
-
-    // convert :
-    //  { "1": {"md5":"71565d7f4dc0760457eb252a31d45964","size":42,"state":"complete"}}
-    // to
-    //  { "1": {"md5":"71565d7f4dc0760457eb252a31d45964","size":42}}
-    //
-    private def cleanPart(jsv: JsValue) : JsValue = {
-        val fields = jsv.asJsObject.fields.filter{ case (k, _) =>
-            k != "state"
-        }.toMap
-        JsObject(fields)
-    }
-
-    // describe a platform file, including its parts, with the dx-toolkit. We can then compare
-    // it to what we get from our DxdaManifest code.
-    //
-    private def describeWithParts(dxFile: DxFile) : JsValue = {
-        val cmd = s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
-        val (stdout, stderr) = Utils.execCommand(cmd)
-        val jsv = stdout.parseJson
-
-        // remove the "state" field from all the parts
-        val fields = jsv.asJsObject.fields.map{
-            case ("parts", parts) =>
-                "parts" -> JsObject(parts.asJsObject.fields.map{
-                                        case (k, v) => k -> cleanPart(v)
-                                    }.toMap)
-            case (k, v) =>
-                k -> v
-        }.toMap
-        JsObject(fields)
-    }
-
-    it should "create manifests for dxda" in {
-
-        val fileDir : Map[String, Path] = Map(
-            s"dx://${TEST_PROJECT}:/test_data/fileA" -> Paths.get("inputs/A") ,
-            s"dx://${TEST_PROJECT}:/test_data/fileB" -> Paths.get("inputs/B"),
-            s"dx://${TEST_PROJECT}:/test_data/fileC" -> Paths.get("inputs/C")
+  val TEST_PROJECT = "dxWDL_playground"
+  lazy val dxTestProject: DxProject =
+    try {
+      DxPath.resolveProject(TEST_PROJECT)
+    } catch {
+      case e: Exception =>
+        throw new Exception(
+          s"""|Could not find project ${TEST_PROJECT}, you probably need to be logged into
+                                        |the platform on staging.""".stripMargin
         )
-
-        // resolve the paths
-        val resolvedObjects : Map[String, DxDataObject] = DxPath.resolveBulk(fileDir.keys.toVector,
-                                                                             dxTestProject)
-        val filesInManifest : Map[String, (DxFile, Path)] = resolvedObjects.map{
-            case (dxPath, dataObj) =>
-                val dxFile = dataObj.asInstanceOf[DxFile]
-                val local : Path = fileDir(dxPath)
-                dxFile.id -> (dxFile, local)
-        }.toMap
-
-        // create a manifest
-        val manifest : DxdaManifest = DxdaManifest.apply(filesInManifest)
-
-
-        // compare to data obtained with dx-toolkit
-        val expected : Vector[JsValue] = resolvedObjects.map{
-            case (dxPath, dataObj) =>
-                val dxFile = dataObj.asInstanceOf[DxFile]
-                val local : Path = fileDir(dxPath)
-                val jsv = describeWithParts(dxFile)
-
-                // add the target folder and name
-                val fields = jsv.asJsObject.fields ++  Map(
-                    "name" -> JsString(local.toFile().getName()),
-                    "folder" -> JsString(local.toFile().getParent())
-                )
-                JsObject(fields)
-        }.toVector
-
-        manifest shouldBe(
-            DxdaManifest(
-                JsObject(dxTestProject.getId -> JsArray(expected))
-            ))
     }
+
+  // convert :
+  //  { "1": {"md5":"71565d7f4dc0760457eb252a31d45964","size":42,"state":"complete"}}
+  // to
+  //  { "1": {"md5":"71565d7f4dc0760457eb252a31d45964","size":42}}
+  //
+  private def cleanPart(jsv: JsValue): JsValue = {
+    val fields = jsv.asJsObject.fields.filter {
+      case (k, _) =>
+        k != "state"
+    }.toMap
+    JsObject(fields)
+  }
+
+  // describe a platform file, including its parts, with the dx-toolkit. We can then compare
+  // it to what we get from our DxdaManifest code.
+  //
+  private def describeWithParts(dxFile: DxFile): JsValue = {
+    val cmd              = s"""dx api ${dxFile.getId} describe '{"fields": { "parts" : true } }'"""
+    val (stdout, stderr) = Utils.execCommand(cmd)
+    val jsv              = stdout.parseJson
+
+    // remove the "state" field from all the parts
+    val fields = jsv.asJsObject.fields.map {
+      case ("parts", parts) =>
+        "parts" -> JsObject(parts.asJsObject.fields.map {
+          case (k, v) => k -> cleanPart(v)
+        }.toMap)
+      case (k, v) =>
+        k -> v
+    }.toMap
+    JsObject(fields)
+  }
+
+  it should "create manifests for dxda" in {
+
+    val fileDir: Map[String, Path] = Map(
+      s"dx://${TEST_PROJECT}:/test_data/fileA" -> Paths.get("inputs/A"),
+      s"dx://${TEST_PROJECT}:/test_data/fileB" -> Paths.get("inputs/B"),
+      s"dx://${TEST_PROJECT}:/test_data/fileC" -> Paths.get("inputs/C")
+    )
+
+    // resolve the paths
+    val resolvedObjects: Map[String, DxDataObject] =
+      DxPath.resolveBulk(fileDir.keys.toVector, dxTestProject)
+    val filesInManifest: Map[String, (DxFile, Path)] = resolvedObjects.map {
+      case (dxPath, dataObj) =>
+        val dxFile      = dataObj.asInstanceOf[DxFile]
+        val local: Path = fileDir(dxPath)
+        dxFile.id -> (dxFile, local)
+    }.toMap
+
+    // create a manifest
+    val manifest: DxdaManifest = DxdaManifest.apply(filesInManifest)
+
+    // compare to data obtained with dx-toolkit
+    val expected: Vector[JsValue] = resolvedObjects.map {
+      case (dxPath, dataObj) =>
+        val dxFile      = dataObj.asInstanceOf[DxFile]
+        val local: Path = fileDir(dxPath)
+        val jsv         = describeWithParts(dxFile)
+
+        // add the target folder and name
+        val fields = jsv.asJsObject.fields ++ Map(
+          "name"   -> JsString(local.toFile().getName()),
+          "folder" -> JsString(local.toFile().getParent())
+        )
+        JsObject(fields)
+    }.toVector
+
+    manifest shouldBe (DxdaManifest(
+      JsObject(dxTestProject.getId -> JsArray(expected))
+    ))
+  }
 }

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -20,7 +20,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
   private val unicornInstance =
     DxInstanceType("mem_ssd_unicorn", 100, 100, 4, 1.00f, Vector(("Ubuntu", "16.04")), false)
   private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
-  private val verbose        = false
+  private val verbose = false
 
   // Note: if the file doesn't exist, this throws a null pointer exception
   private def pathFromBasename(basename: String): Path = {
@@ -68,7 +68,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
         WomMap(t, m1)
 
       case (WomPair(l, r)) =>
-        val left  = addBaseDir(l)
+        val left = addBaseDir(l)
         val right = addBaseDir(r)
         WomPair(left, right)
 
@@ -140,7 +140,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
 
     // Parse the inputs, convert to WOM values. Delay downloading files
     // from the platform, we may not need to access them.
-    val dxIoFunctions  = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
+    val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
     val jobInputOutput = new JobInputOutput(dxIoFunctions, runtimeDebugLevel, womBundle.typeAliases)
     val taskRunner = TaskRunner(
       task,

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -19,13 +19,13 @@ class TaskRunnerTest extends FlatSpec with Matchers {
   private val runtimeDebugLevel = 0
   private val unicornInstance =
     DxInstanceType(
-      "mem_ssd_unicorn",
-      100,
-      100,
-      4,
-      1.00f,
-      Vector(("Ubuntu", "16.04")),
-      false
+        "mem_ssd_unicorn",
+        100,
+        100,
+        4,
+        1.00f,
+        Vector(("Ubuntu", "16.04")),
+        false
     )
   private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
   private val verbose = false
@@ -154,20 +154,20 @@ class TaskRunnerTest extends FlatSpec with Matchers {
     val dxIoFunctions =
       DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
     val jobInputOutput = new JobInputOutput(
-      dxIoFunctions,
-      runtimeDebugLevel,
-      womBundle.typeAliases
+        dxIoFunctions,
+        runtimeDebugLevel,
+        womBundle.typeAliases
     )
     val taskRunner = TaskRunner(
-      task,
-      taskSourceCode,
-      womBundle.typeAliases,
-      instanceTypeDB,
-      dxPathConfig,
-      dxIoFunctions,
-      jobInputOutput,
-      Some(WdlRuntimeAttrs(Map.empty)),
-      0
+        task,
+        taskSourceCode,
+        womBundle.typeAliases,
+        instanceTypeDB,
+        dxPathConfig,
+        dxIoFunctions,
+        jobInputOutput,
+        Some(WdlRuntimeAttrs(Map.empty)),
+        0
     )
     val inputsRelPaths =
       taskRunner.jobInputOutput.loadInputs(JsObject(inputsOrg), task)

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -18,7 +18,15 @@ import dxWDL.util.{DxIoFunctions, DxInstanceType, DxPathConfig, InstanceTypeDB, 
 class TaskRunnerTest extends FlatSpec with Matchers {
   private val runtimeDebugLevel = 0
   private val unicornInstance =
-    DxInstanceType("mem_ssd_unicorn", 100, 100, 4, 1.00f, Vector(("Ubuntu", "16.04")), false)
+    DxInstanceType(
+      "mem_ssd_unicorn",
+      100,
+      100,
+      4,
+      1.00f,
+      Vector(("Ubuntu", "16.04")),
+      false
+    )
   private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
   private val verbose = false
 
@@ -52,7 +60,8 @@ class TaskRunnerTest extends FlatSpec with Matchers {
   private def addBaseDir(womValue: WomValue): WomValue = {
     womValue match {
       // primitive types, pass through
-      case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) => womValue
+      case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) =>
+        womValue
 
       // single file
       case WomSingleFile(s) => WomSingleFile(pathFromBasename(s).toString)
@@ -132,16 +141,23 @@ class TaskRunnerTest extends FlatSpec with Matchers {
 
     val (language, womBundle: WomBundle, allSources, _) =
       ParseWomSourceFile(false).apply(wdlCode, List.empty)
-    val task: CallableTaskDefinition = ParseWomSourceFile(false).getMainTask(womBundle)
+    val task: CallableTaskDefinition =
+      ParseWomSourceFile(false).getMainTask(womBundle)
     assert(allSources.size == 1)
-    val sourceDict = ParseWomSourceFile(false).scanForTasks(allSources.values.head)
+    val sourceDict =
+      ParseWomSourceFile(false).scanForTasks(allSources.values.head)
     assert(sourceDict.size == 1)
     val taskSourceCode = sourceDict.values.head
 
     // Parse the inputs, convert to WOM values. Delay downloading files
     // from the platform, we may not need to access them.
-    val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
-    val jobInputOutput = new JobInputOutput(dxIoFunctions, runtimeDebugLevel, womBundle.typeAliases)
+    val dxIoFunctions =
+      DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
+    val jobInputOutput = new JobInputOutput(
+      dxIoFunctions,
+      runtimeDebugLevel,
+      womBundle.typeAliases
+    )
     val taskRunner = TaskRunner(
       task,
       taskSourceCode,
@@ -153,7 +169,8 @@ class TaskRunnerTest extends FlatSpec with Matchers {
       Some(WdlRuntimeAttrs(Map.empty)),
       0
     )
-    val inputsRelPaths = taskRunner.jobInputOutput.loadInputs(JsObject(inputsOrg), task)
+    val inputsRelPaths =
+      taskRunner.jobInputOutput.loadInputs(JsObject(inputsOrg), task)
     val inputs = inputsRelPaths.map {
       case (inpDef, value) => (inpDef, addBaseDir(value))
     }.toMap
@@ -232,7 +249,8 @@ class TaskRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "read a docker manifest file" in {
-    val buf = """|[
+    val buf =
+      """|[
                      |{"Config":"4b778ee055da936b387080ba034c05a8fad46d8e50ee24f27dcd0d5166c56819.json",
                      |"RepoTags":["ubuntu_18_04_minimal:latest"],
                      |"Layers":[

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -16,222 +16,223 @@ import dxWDL.util.{DxIoFunctions, DxInstanceType, DxPathConfig, InstanceTypeDB, 
 // This tests the compiler Native mode, however, it creates
 // dnanexus applets and workflows that are not runnable.
 class TaskRunnerTest extends FlatSpec with Matchers {
-    private val runtimeDebugLevel = 0
-    private val unicornInstance = DxInstanceType("mem_ssd_unicorn",
-                                                 100,
-                                                 100,
-                                                 4,
-                                                 1.00F,
-                                                 Vector(("Ubuntu", "16.04")),
-                                                 false)
-    private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
-    private val verbose = false
+  private val runtimeDebugLevel = 0
+  private val unicornInstance =
+    DxInstanceType("mem_ssd_unicorn", 100, 100, 4, 1.00f, Vector(("Ubuntu", "16.04")), false)
+  private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
+  private val verbose        = false
 
-    // Note: if the file doesn't exist, this throws a null pointer exception
-    private def pathFromBasename(basename: String) : Path = {
-        val p = getClass.getResource(s"/task_runner/${basename}").getPath
-        Paths.get(p)
-    }
+  // Note: if the file doesn't exist, this throws a null pointer exception
+  private def pathFromBasename(basename: String): Path = {
+    val p = getClass.getResource(s"/task_runner/${basename}").getPath
+    Paths.get(p)
+  }
 
-/*    private def pathFromDirAndBasename(dirname: String, basename: String) : Path = {
+  /*    private def pathFromDirAndBasename(dirname: String, basename: String) : Path = {
         val p = getClass.getResource(s"/${dirname}/${basename}").getPath
         Paths.get(p)
     }*/
 
-    // Recursively go into a womValue, and add a base path to the file.
-    // For example:
-    //   foo.txt ---> /home/joe_heller/foo.txt
-    //
-    // This is used to convert relative paths to test files into absolute paths.
-    // For example, convert:
-    //  {
-    //    "pattern" : "snow",
-    //    "in_file" : "manuscript.txt"
-    //  }
-    // into:
-    //  {
-    //    "pattern" : "snow",
-    //    "in_file" : "/home/joe_heller/dxWDL/src/test/resources/runner_tasks/manuscript.txt"
-    // }
-    //
-    private def addBaseDir(womValue: WomValue) : WomValue = {
-        womValue match {
-            // primitive types, pass through
-            case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) => womValue
+  // Recursively go into a womValue, and add a base path to the file.
+  // For example:
+  //   foo.txt ---> /home/joe_heller/foo.txt
+  //
+  // This is used to convert relative paths to test files into absolute paths.
+  // For example, convert:
+  //  {
+  //    "pattern" : "snow",
+  //    "in_file" : "manuscript.txt"
+  //  }
+  // into:
+  //  {
+  //    "pattern" : "snow",
+  //    "in_file" : "/home/joe_heller/dxWDL/src/test/resources/runner_tasks/manuscript.txt"
+  // }
+  //
+  private def addBaseDir(womValue: WomValue): WomValue = {
+    womValue match {
+      // primitive types, pass through
+      case WomBoolean(_) | WomInteger(_) | WomFloat(_) | WomString(_) => womValue
 
-            // single file
-            case WomSingleFile(s) => WomSingleFile(pathFromBasename(s).toString)
+      // single file
+      case WomSingleFile(s) => WomSingleFile(pathFromBasename(s).toString)
 
-            // Maps
-            case (WomMap(t: WomMapType, m: Map[WomValue, WomValue])) =>
-                val m1 = m.map{ case (k, v) =>
-                    val k1 = addBaseDir(k)
-                    val v1 = addBaseDir(v)
-                    k1 -> v1
-                }
-                WomMap(t, m1)
-
-            case (WomPair(l, r)) =>
-                val left = addBaseDir(l)
-                val right = addBaseDir(r)
-                WomPair(left, right)
-
-            case WomArray(t: WomArrayType, a: Seq[WomValue]) =>
-                val a1 = a.map{ v => addBaseDir(v) }
-                WomArray(t, a1)
-
-            case WomOptionalValue(t,  None) =>
-                WomOptionalValue(t, None)
-            case WomOptionalValue(t, Some(v)) =>
-                val v1 = addBaseDir(v)
-                WomOptionalValue(t, Some(v1))
-
-            case WomObject(m, t) =>
-                val m2 = m.map{ case (k, v) =>
-                    k -> addBaseDir(v)
-                }.toMap
-                WomObject(m2, t)
-
-            case _ =>
-                throw new Exception(s"Unsupported wom value ${womValue}")
+      // Maps
+      case (WomMap(t: WomMapType, m: Map[WomValue, WomValue])) =>
+        val m1 = m.map {
+          case (k, v) =>
+            val k1 = addBaseDir(k)
+            val v1 = addBaseDir(v)
+            k1 -> v1
         }
-    }
+        WomMap(t, m1)
 
+      case (WomPair(l, r)) =>
+        val left  = addBaseDir(l)
+        val right = addBaseDir(r)
+        WomPair(left, right)
 
-    // Parse the WDL source code, and extract the single task that is supposed to be there.
-    // Also return the source script itself, verbatim.
-    private def runTask(wdlName: String) : TaskRunner = {
-        val wdlCode : Path = pathFromBasename(s"${wdlName}.wdl")
+      case WomArray(t: WomArrayType, a: Seq[WomValue]) =>
+        val a1 = a.map { v =>
+          addBaseDir(v)
+        }
+        WomArray(t, a1)
 
-        // load the inputs
-        val inputsOrg : Map[String, JsValue] =
-            try {
-                val inputsFile = pathFromBasename(s"${wdlName}_input.json")
-                assert(Files.exists(inputsFile))
-                Utils.readFileContent(inputsFile)
-                    .parseJson
-                    .asJsObject.fields
-            } catch {
-                case _: Throwable =>
-                    Map.empty
-            }
+      case WomOptionalValue(t, None) =>
+        WomOptionalValue(t, None)
+      case WomOptionalValue(t, Some(v)) =>
+        val v1 = addBaseDir(v)
+        WomOptionalValue(t, Some(v1))
 
-        // load the expected outputs
-        val outputFieldsExpected : Option[Map[String, JsValue]] =
-            try {
-                val outputsFile = pathFromBasename(s"${wdlName}_output.json")
-                assert(Files.exists(outputsFile))
-                Some(Utils.readFileContent(outputsFile)
-                         .parseJson
-                         .asJsObject.fields)
-            } catch {
-                case _: Throwable =>
-                    None
-            }
-
-
-        // Create a clean directory in "/tmp" for the task to use
-        val jobHomeDir : Path = Paths.get("/tmp/dxwdl_applet_test")
-        Utils.deleteRecursive(jobHomeDir.toFile)
-        Utils.safeMkdir(jobHomeDir)
-        val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, verbose)
-        dxPathConfig.createCleanDirs()
-
-        val (language, womBundle: WomBundle, allSources, _) = ParseWomSourceFile(false).apply(wdlCode, List.empty)
-        val task : CallableTaskDefinition = ParseWomSourceFile(false).getMainTask(womBundle)
-        assert(allSources.size == 1)
-        val sourceDict  = ParseWomSourceFile(false).scanForTasks(allSources.values.head)
-        assert(sourceDict.size == 1)
-        val taskSourceCode = sourceDict.values.head
-
-        // Parse the inputs, convert to WOM values. Delay downloading files
-        // from the platform, we may not need to access them.
-        val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
-        val jobInputOutput = new JobInputOutput(dxIoFunctions, runtimeDebugLevel, womBundle.typeAliases)
-        val taskRunner = TaskRunner(task, taskSourceCode, womBundle.typeAliases,
-                                    instanceTypeDB,
-                                    dxPathConfig, dxIoFunctions, jobInputOutput,
-                                    Some(WdlRuntimeAttrs(Map.empty)), 0)
-        val inputsRelPaths = taskRunner.jobInputOutput.loadInputs(JsObject(inputsOrg), task)
-        val inputs = inputsRelPaths.map{
-            case (inpDef, value) => (inpDef, addBaseDir(value))
+      case WomObject(m, t) =>
+        val m2 = m.map {
+          case (k, v) =>
+            k -> addBaseDir(v)
         }.toMap
+        WomObject(m2, t)
 
-        // run the entire task
+      case _ =>
+        throw new Exception(s"Unsupported wom value ${womValue}")
+    }
+  }
 
-        // 1. prolog
-        val (env, dxUrl2path) = taskRunner.prolog(inputs)
+  // Parse the WDL source code, and extract the single task that is supposed to be there.
+  // Also return the source script itself, verbatim.
+  private def runTask(wdlName: String): TaskRunner = {
+    val wdlCode: Path = pathFromBasename(s"${wdlName}.wdl")
 
-        // 2. execute the shell script in a child job
-        val script : Path = dxPathConfig.script
-        if (Files.exists(script)) {
-            val (stdout, stderr) = Utils.execCommand(script.toString, None)
-        }
+    // load the inputs
+    val inputsOrg: Map[String, JsValue] =
+      try {
+        val inputsFile = pathFromBasename(s"${wdlName}_input.json")
+        assert(Files.exists(inputsFile))
+        Utils.readFileContent(inputsFile).parseJson.asJsObject.fields
+      } catch {
+        case _: Throwable =>
+          Map.empty
+      }
 
-        // 3. epilog
-        val outputFields: Map[String, JsValue] = taskRunner.epilog(env, dxUrl2path)
+    // load the expected outputs
+    val outputFieldsExpected: Option[Map[String, JsValue]] =
+      try {
+        val outputsFile = pathFromBasename(s"${wdlName}_output.json")
+        assert(Files.exists(outputsFile))
+        Some(Utils.readFileContent(outputsFile).parseJson.asJsObject.fields)
+      } catch {
+        case _: Throwable =>
+          None
+      }
 
-        outputFieldsExpected match {
-            case None => ()
-            case Some(exp) => outputFields should be(exp)
-        }
+    // Create a clean directory in "/tmp" for the task to use
+    val jobHomeDir: Path = Paths.get("/tmp/dxwdl_applet_test")
+    Utils.deleteRecursive(jobHomeDir.toFile)
+    Utils.safeMkdir(jobHomeDir)
+    val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, verbose)
+    dxPathConfig.createCleanDirs()
 
-        // return the task structure
-        taskRunner
+    val (language, womBundle: WomBundle, allSources, _) =
+      ParseWomSourceFile(false).apply(wdlCode, List.empty)
+    val task: CallableTaskDefinition = ParseWomSourceFile(false).getMainTask(womBundle)
+    assert(allSources.size == 1)
+    val sourceDict = ParseWomSourceFile(false).scanForTasks(allSources.values.head)
+    assert(sourceDict.size == 1)
+    val taskSourceCode = sourceDict.values.head
+
+    // Parse the inputs, convert to WOM values. Delay downloading files
+    // from the platform, we may not need to access them.
+    val dxIoFunctions  = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
+    val jobInputOutput = new JobInputOutput(dxIoFunctions, runtimeDebugLevel, womBundle.typeAliases)
+    val taskRunner = TaskRunner(
+      task,
+      taskSourceCode,
+      womBundle.typeAliases,
+      instanceTypeDB,
+      dxPathConfig,
+      dxIoFunctions,
+      jobInputOutput,
+      Some(WdlRuntimeAttrs(Map.empty)),
+      0
+    )
+    val inputsRelPaths = taskRunner.jobInputOutput.loadInputs(JsObject(inputsOrg), task)
+    val inputs = inputsRelPaths.map {
+      case (inpDef, value) => (inpDef, addBaseDir(value))
+    }.toMap
+
+    // run the entire task
+
+    // 1. prolog
+    val (env, dxUrl2path) = taskRunner.prolog(inputs)
+
+    // 2. execute the shell script in a child job
+    val script: Path = dxPathConfig.script
+    if (Files.exists(script)) {
+      val (stdout, stderr) = Utils.execCommand(script.toString, None)
     }
 
-    it should "execute a simple WDL task" in {
-        runTask("add")
+    // 3. epilog
+    val outputFields: Map[String, JsValue] = taskRunner.epilog(env, dxUrl2path)
+
+    outputFieldsExpected match {
+      case None      => ()
+      case Some(exp) => outputFields should be(exp)
     }
 
-    it should "execute a WDL task with expressions" in {
-        runTask("float_arith")
-    }
+    // return the task structure
+    taskRunner
+  }
 
-    it should "evaluate expressions in runtime section" in {
-        runTask("expressions_runtime_section")
-    }
+  it should "execute a simple WDL task" in {
+    runTask("add")
+  }
 
-    it should "evaluate expressions in runtime section II" in {
-        runTask("expressions_runtime_section_2")
-    }
+  it should "execute a WDL task with expressions" in {
+    runTask("float_arith")
+  }
 
-    it should "evaluate a command section" in {
-        runTask("sub")
-    }
+  it should "evaluate expressions in runtime section" in {
+    runTask("expressions_runtime_section")
+  }
 
-    it should "run ps in a command section" in {
-        runTask("ps")
-    }
+  it should "evaluate expressions in runtime section II" in {
+    runTask("expressions_runtime_section_2")
+  }
 
-    it should "localize a file to a task" in {
-        val taskRunner = runTask("cgrep")
-        taskRunner.commandSectionEmpty should be (false)
-    }
+  it should "evaluate a command section" in {
+    runTask("sub")
+  }
 
-    it should "handle type coercion" in {
-        runTask("cast")
-    }
+  it should "run ps in a command section" in {
+    runTask("ps")
+  }
 
-    it should "handle spaces in file paths" in {
-        runTask("spaces_in_file_paths")
-    }
+  it should "localize a file to a task" in {
+    val taskRunner = runTask("cgrep")
+    taskRunner.commandSectionEmpty should be(false)
+  }
 
-    it should "read_tsv" in {
-        runTask("read_tsv_x")
-    }
+  it should "handle type coercion" in {
+    runTask("cast")
+  }
 
-    it should "write_tsv" in {
-        runTask("write_tsv_x")
-    }
+  it should "handle spaces in file paths" in {
+    runTask("spaces_in_file_paths")
+  }
 
-    it should "optimize task with an empty command section" in {
-        val task = runTask("empty_command_section")
-        task.commandSectionEmpty should be(true)
-    }
+  it should "read_tsv" in {
+    runTask("read_tsv_x")
+  }
 
-    it should "read a docker manifest file" in {
-        val buf = """|[
+  it should "write_tsv" in {
+    runTask("write_tsv_x")
+  }
+
+  it should "optimize task with an empty command section" in {
+    val task = runTask("empty_command_section")
+    task.commandSectionEmpty should be(true)
+  }
+
+  it should "read a docker manifest file" in {
+    val buf = """|[
                      |{"Config":"4b778ee055da936b387080ba034c05a8fad46d8e50ee24f27dcd0d5166c56819.json",
                      |"RepoTags":["ubuntu_18_04_minimal:latest"],
                      |"Layers":[
@@ -247,15 +248,15 @@ class TaskRunnerTest extends FlatSpec with Matchers {
                      |}
                      |]""".stripMargin.trim
 
-        val repo = TaskRunnerUtils.readManifestGetDockerImageName(buf)
-        repo should equal("ubuntu_18_04_minimal:latest")
-    }
+    val repo = TaskRunnerUtils.readManifestGetDockerImageName(buf)
+    repo should equal("ubuntu_18_04_minimal:latest")
+  }
 
-    it should "handle structs" in {
-        runTask("Person2")
-    }
+  it should "handle structs" in {
+    runTask("Person2")
+  }
 
-    it should "handle missing optional files" taggedAs(EdgeTest) in {
-        runTask("missing_optional_output_file")
-    }
+  it should "handle missing optional files" taggedAs (EdgeTest) in {
+    runTask("missing_optional_output_file")
+  }
 }

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -92,7 +92,7 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "second block in a linear workflow" in {
-    val source: Path                  = pathFromBasename("frag_runner", "wf_linear.wdl")
+    val source: Path = pathFromBasename("frag_runner", "wf_linear.wdl")
     val (dxPathConfig, dxIoFunctions) = setup()
 
     val (language, womBundle: WomBundle, allSources, subBundles) =
@@ -104,7 +104,7 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       case Some(wf: WorkflowDefinition) => wf
       case _                            => throw new Exception("sanity")
     }
-    val graph                                   = wf.innerGraph
+    val graph = wf.innerGraph
     val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
     val block = subBlocks(1)
@@ -116,20 +116,20 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       case eNode: ExposedExpressionNode => eNode
     }
     val expr: WomExpression = eNodes(0).womExpression
-    val value: WomValue     = evaluateWomExpression(expr, env, dxIoFunctions)
+    val value: WomValue = evaluateWomExpression(expr, env, dxIoFunctions)
     value should be(WomInteger(9))
   }
 
   it should "evaluate a scatter without a call" in {
-    val path         = pathFromBasename("frag_runner", "scatter_no_call.wdl")
+    val path = pathFromBasename("frag_runner", "scatter_no_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
-    val block                         = subBlocks(0)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    val block = subBlocks(0)
 
-    val env                            = Map.empty[String, WomValue]
+    val env = Map.empty[String, WomValue]
     val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
     results.keys should be(Set("names", "full_name"))
     results should be(
@@ -159,15 +159,15 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "evaluate a conditional without a call" in {
-    val path         = pathFromBasename("frag_runner", "conditional_no_call.wdl")
+    val path = pathFromBasename("frag_runner", "conditional_no_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
-    val block                         = subBlocks(0)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    val block = subBlocks(0)
 
-    val env                            = Map.empty[String, WomValue]
+    val env = Map.empty[String, WomValue]
     val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
     results should be(
       Map(
@@ -181,23 +181,23 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "evaluate a nested conditional/scatter without a call" in {
-    val path         = pathFromBasename("frag_runner", "nested_no_call.wdl")
+    val path = pathFromBasename("frag_runner", "nested_no_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
     results should be(Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None)))
   }
 
   it should "create proper names for scatter results" in {
-    val path                           = pathFromBasename("frag_runner", "strings.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("frag_runner", "strings.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
-    val sctNode                     = wf.innerGraph.scatters.head
+    val sctNode = wf.innerGraph.scatters.head
     val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
     /*System.out.println(s"""|name = ${svNode.identifier.localName.value}
                                |       ${svNode.identifier.workflowLocalName}
@@ -209,12 +209,12 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "Make sure calls cannot be handled by evalExpressions" in {
-    val path         = pathFromBasename("draft2", "shapes.wdl")
+    val path = pathFromBasename("draft2", "shapes.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     // Make sure an exception is thrown if eval-expressions is called with
     // a wdl-call.
@@ -224,12 +224,12 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "handles draft2" in {
-    val path         = pathFromBasename("draft2", "conditionals2.wdl")
+    val path = pathFromBasename("draft2", "conditionals2.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     /*
         val results = fragRunner.evalExpressions(subBlocks(0).nodes,
                                                  Map.empty[String, WomValue])
@@ -238,12 +238,12 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "evaluate expressions that define variables" in {
-    val path         = pathFromBasename("draft2", "conditionals3.wdl")
+    val path = pathFromBasename("draft2", "conditionals3.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
     results.keys should be(Set("powers10", "i1", "i2", "i3"))
@@ -279,10 +279,10 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "evaluate call inputs properly" in {
-    val path                          = pathFromBasename("draft2", "various_calls.wdl")
-    val wfSourceCode                  = Utils.readFileContent(path)
+    val path = pathFromBasename("draft2", "various_calls.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
     val call1 = findCallByName("MaybeInt", wf.innerGraph)
     val callInputs1: Map[String, WomValue] =
@@ -306,10 +306,10 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "evaluate call constant inputs" in {
-    val path                          = pathFromBasename("nested", "two_levels.wdl")
-    val wfSourceCode                  = Utils.readFileContent(path)
+    val path = pathFromBasename("nested", "two_levels.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
     val inc4Call = findCallByName("inc5", wf.innerGraph)
 
@@ -318,12 +318,12 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "expressions with structs" in {
-    val path         = pathFromBasename("frag_runner", "House.wdl")
+    val path = pathFromBasename("frag_runner", "House.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
     results.keys should be(
@@ -332,17 +332,17 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     results("tot") should be(
       WomObject(
         Map(
-          "height"     -> WomInteger(32),
+          "height" -> WomInteger(32),
           "num_floors" -> WomInteger(4),
-          "street"     -> WomString("Alda_Mary"),
-          "city"       -> WomString("Sunnyvale_Santa Clara")
+          "street" -> WomString("Alda_Mary"),
+          "city" -> WomString("Sunnyvale_Santa Clara")
         ),
         WomCompositeType(
           Map(
-            "height"     -> WomIntegerType,
+            "height" -> WomIntegerType,
             "num_floors" -> WomIntegerType,
-            "street"     -> WomStringType,
-            "city"       -> WomStringType
+            "street" -> WomStringType,
+            "city" -> WomStringType
           ),
           Some("House")
         )
@@ -351,22 +351,22 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   }
 
   it should "fill in missing optionals" in {
-    val path         = pathFromBasename("frag_runner", "missing_args.wdl")
+    val path = pathFromBasename("frag_runner", "missing_args.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val results: Map[String, JsValue] =
       fragRunner.apply(Vector(0), Map("y" -> WomInteger(5)), RunnerWfFragmentMode.Launch)
     results shouldBe (Map("retval" -> JsNumber(5)))
   }
 
   it should "evaluate expressions in correct order" taggedAs (EdgeTest) in {
-    val path         = pathFromBasename("frag_runner", "scatter_variable_not_found.wdl")
+    val path = pathFromBasename("frag_runner", "scatter_variable_not_found.wdl")
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val results: Map[String, JsValue] =
       fragRunner.apply(Vector(0), Map.empty, RunnerWfFragmentMode.Launch)
     results.keys should contain("bam_lane1")

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -31,7 +31,15 @@ import dxWDL.util.{
 class WfFragRunnerTest extends FlatSpec with Matchers {
   private val runtimeDebugLevel = 0
   private val unicornInstance =
-    DxInstanceType("mem_ssd_unicorn", 100, 100, 4, 1.00f, Vector(("Ubuntu", "16.04")), false)
+    DxInstanceType(
+      "mem_ssd_unicorn",
+      100,
+      100,
+      4,
+      1.00f,
+      Vector(("Ubuntu", "16.04")),
+      false
+    )
   private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
 
   private def setup(): (DxPathConfig, DxIoFunctions) = {
@@ -39,9 +47,11 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val jobHomeDir: Path = Paths.get("/tmp/dxwdl_applet_test")
     Utils.deleteRecursive(jobHomeDir.toFile)
     Utils.safeMkdir(jobHomeDir)
-    val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, runtimeDebugLevel >= 1)
+    val dxPathConfig =
+      DxPathConfig.apply(jobHomeDir, false, runtimeDebugLevel >= 1)
     dxPathConfig.createCleanDirs()
-    val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
+    val dxIoFunctions =
+      DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
     (dxPathConfig, dxIoFunctions)
   }
 
@@ -53,7 +63,12 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val (wf: WorkflowDefinition, taskDir, typeAliases) =
       ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
     val fragInputOutput =
-      new WfFragInputOutput(dxIoFunctions, null /*dxProject*/, runtimeDebugLevel, typeAliases)
+      new WfFragInputOutput(
+        dxIoFunctions,
+        null /*dxProject*/,
+        runtimeDebugLevel,
+        typeAliases
+      )
     val fragRunner = new WfFragRunner(
       wf,
       taskDir,
@@ -86,7 +101,9 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       expr.evaluateValue(env, dxIoFunctions)
     result match {
       case Invalid(errors) =>
-        throw new Exception(s"Failed to evaluate expression ${expr} with ${errors}")
+        throw new Exception(
+          s"Failed to evaluate expression ${expr} with ${errors}"
+        )
       case Valid(x: WomValue) => x
     }
   }
@@ -110,7 +127,11 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val block = subBlocks(1)
 
     val env: Map[String, WomValue] =
-      Map("x" -> WomInteger(3), "y" -> WomInteger(5), "add.result" -> WomInteger(8))
+      Map(
+        "x" -> WomInteger(3),
+        "y" -> WomInteger(5),
+        "add.result" -> WomInteger(8)
+      )
 
     val eNodes: Vector[ExposedExpressionNode] = block.nodes.collect {
       case eNode: ExposedExpressionNode => eNode
@@ -125,12 +146,14 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     val block = subBlocks(0)
 
     val env = Map.empty[String, WomValue]
-    val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
+    val results: Map[String, WomValue] =
+      fragRunner.evalExpressions(block.nodes, env)
     results.keys should be(Set("names", "full_name"))
     results should be(
       Map(
@@ -163,12 +186,14 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     val block = subBlocks(0)
 
     val env = Map.empty[String, WomValue]
-    val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
+    val results: Map[String, WomValue] =
+      fragRunner.evalExpressions(block.nodes, env)
     results should be(
       Map(
         "flag" -> WomBoolean(true),
@@ -185,17 +210,24 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
-    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
-    results should be(Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None)))
+    val results = fragRunner.evalExpressions(
+      subBlocks(0).nodes,
+      Map.empty[String, WomValue]
+    )
+    results should be(
+      Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None))
+    )
   }
 
   it should "create proper names for scatter results" in {
     val path = pathFromBasename("frag_runner", "strings.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
     val sctNode = wf.innerGraph.scatters.head
     val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
@@ -213,13 +245,17 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     // Make sure an exception is thrown if eval-expressions is called with
     // a wdl-call.
     assertThrows[Exception] {
-      fragRunner.evalExpressions(subBlocks(1).nodes, Map.empty[String, WomValue])
+      fragRunner.evalExpressions(
+        subBlocks(1).nodes,
+        Map.empty[String, WomValue]
+      )
     }
   }
 
@@ -228,7 +264,8 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     /*
         val results = fragRunner.evalExpressions(subBlocks(0).nodes,
@@ -242,14 +279,22 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
-    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
+    val results = fragRunner.evalExpressions(
+      subBlocks(0).nodes,
+      Map.empty[String, WomValue]
+    )
     results.keys should be(Set("powers10", "i1", "i2", "i3"))
-    results("i1") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
+    results("i1") should be(
+      WomOptionalValue(WomIntegerType, Some(WomInteger(1)))
+    )
     results("i2") should be(WomOptionalValue(WomIntegerType, None))
-    results("i3") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(100))))
+    results("i3") should be(
+      WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
+    )
     results("powers10") should be(
       WomArray(
         WomArrayType(WomOptionalType(WomIntegerType)),
@@ -274,7 +319,8 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     callNode match {
       case None              => throw new Exception(s"call ${callName} not found")
       case Some(x: CallNode) => x
-      case Some(other)       => throw new Exception(s"call ${callName} found with wrong class ${other}")
+      case Some(other) =>
+        throw new Exception(s"call ${callName} found with wrong class ${other}")
     }
   }
 
@@ -282,25 +328,34 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val path = pathFromBasename("draft2", "various_calls.wdl")
     val wfSourceCode = Utils.readFileContent(path)
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
     val call1 = findCallByName("MaybeInt", wf.innerGraph)
     val callInputs1: Map[String, WomValue] =
       fragRunner.evalCallInputs(call1, Map("i" -> WomInteger(1)))
-    callInputs1 should be(Map("a" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1)))))
+    callInputs1 should be(
+      Map("a" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
+    )
 
     val call2 = findCallByName("ManyArgs", wf.innerGraph)
     val callInputs2: Map[String, WomValue] = fragRunner.evalCallInputs(
       call2,
       Map(
-        "powers10" -> WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(1), WomInteger(10)))
+        "powers10" -> WomArray(
+          WomArrayType(WomIntegerType),
+          Vector(WomInteger(1), WomInteger(10))
+        )
       )
     )
 
     callInputs2 should be(
       Map(
         "a" -> WomString("hello"),
-        "b" -> WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(1), WomInteger(10)))
+        "b" -> WomArray(
+          WomArrayType(WomIntegerType),
+          Vector(WomInteger(1), WomInteger(10))
+        )
       )
     )
   }
@@ -309,7 +364,8 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val path = pathFromBasename("nested", "two_levels.wdl")
     val wfSourceCode = Utils.readFileContent(path)
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
     val inc4Call = findCallByName("inc5", wf.innerGraph)
 
@@ -322,10 +378,14 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
-    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
+    val results = fragRunner.evalExpressions(
+      subBlocks(0).nodes,
+      Map.empty[String, WomValue]
+    )
     results.keys should be(
       Set("a", "b", "tot_height", "tot_num_floors", "streets", "cities", "tot")
     )
@@ -355,9 +415,14 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val results: Map[String, JsValue] =
-      fragRunner.apply(Vector(0), Map("y" -> WomInteger(5)), RunnerWfFragmentMode.Launch)
+      fragRunner.apply(
+        Vector(0),
+        Map("y" -> WomInteger(5)),
+        RunnerWfFragmentMode.Launch
+      )
     results shouldBe (Map("retval" -> JsNumber(5)))
   }
 
@@ -366,10 +431,13 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val wfSourceCode = Utils.readFileContent(path)
 
     val (dxPathConfig, dxIoFunctions) = setup()
-    val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (wf, fragRunner) =
+      setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val results: Map[String, JsValue] =
       fragRunner.apply(Vector(0), Map.empty, RunnerWfFragmentMode.Launch)
     results.keys should contain("bam_lane1")
-    results("bam_lane1") shouldBe (JsObject("___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)))
+    results("bam_lane1") shouldBe (JsObject(
+      "___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)
+    ))
   }
 }

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -15,336 +15,361 @@ import wom.types._
 
 import dxWDL.base.{RunnerWfFragmentMode, Utils, WdlRuntimeAttrs}
 import dxWDL.dx.ExecLinkInfo
-import dxWDL.util.{Block, DxIoFunctions, DxInstanceType, DxPathConfig, InstanceTypeDB, ParseWomSourceFile}
+import dxWDL.util.{
+  Block,
+  DxIoFunctions,
+  DxInstanceType,
+  DxPathConfig,
+  InstanceTypeDB,
+  ParseWomSourceFile
+}
 
 // This test module requires being logged in to the platform.
 // It compiles WDL scripts without the runtime library.
 // This tests the compiler Native mode, however, it creates
 // dnanexus applets and workflows that are not runnable.
 class WfFragRunnerTest extends FlatSpec with Matchers {
-    private val runtimeDebugLevel = 0
-    private val unicornInstance = DxInstanceType("mem_ssd_unicorn",
-                                                 100,
-                                                 100,
-                                                 4,
-                                                 1.00F,
-                                                 Vector(("Ubuntu", "16.04")),
-                                                 false)
-    private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
+  private val runtimeDebugLevel = 0
+  private val unicornInstance =
+    DxInstanceType("mem_ssd_unicorn", 100, 100, 4, 1.00f, Vector(("Ubuntu", "16.04")), false)
+  private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
 
-    private def setup() : (DxPathConfig, DxIoFunctions) = {
-        // Create a clean directory in "/tmp" for the task to use
-        val jobHomeDir : Path = Paths.get("/tmp/dxwdl_applet_test")
-        Utils.deleteRecursive(jobHomeDir.toFile)
-        Utils.safeMkdir(jobHomeDir)
-        val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, runtimeDebugLevel >= 1)
-        dxPathConfig.createCleanDirs()
-        val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
-        (dxPathConfig, dxIoFunctions)
+  private def setup(): (DxPathConfig, DxIoFunctions) = {
+    // Create a clean directory in "/tmp" for the task to use
+    val jobHomeDir: Path = Paths.get("/tmp/dxwdl_applet_test")
+    Utils.deleteRecursive(jobHomeDir.toFile)
+    Utils.safeMkdir(jobHomeDir)
+    val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, runtimeDebugLevel >= 1)
+    dxPathConfig.createCleanDirs()
+    val dxIoFunctions = DxIoFunctions(Map.empty, dxPathConfig, runtimeDebugLevel)
+    (dxPathConfig, dxIoFunctions)
+  }
+
+  private def setupFragRunner(
+      dxPathConfig: DxPathConfig,
+      dxIoFunctions: DxIoFunctions,
+      wfSourceCode: String
+  ): (WorkflowDefinition, WfFragRunner) = {
+    val (wf: WorkflowDefinition, taskDir, typeAliases) =
+      ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+    val fragInputOutput =
+      new WfFragInputOutput(dxIoFunctions, null /*dxProject*/, runtimeDebugLevel, typeAliases)
+    val fragRunner = new WfFragRunner(
+      wf,
+      taskDir,
+      typeAliases,
+      wfSourceCode,
+      instanceTypeDB,
+      Map.empty[String, ExecLinkInfo],
+      dxPathConfig,
+      dxIoFunctions,
+      JsNull,
+      fragInputOutput,
+      Some(WdlRuntimeAttrs(Map.empty)),
+      runtimeDebugLevel
+    )
+    (wf, fragRunner)
+  }
+
+  // Note: if the file doesn't exist, this throws a null pointer exception
+  def pathFromBasename(dir: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dir}/${basename}").getPath
+    Paths.get(p)
+  }
+
+  def evaluateWomExpression(
+      expr: WomExpression,
+      env: Map[String, WomValue],
+      dxIoFunctions: DxIoFunctions
+  ): WomValue = {
+    val result: ErrorOr[WomValue] =
+      expr.evaluateValue(env, dxIoFunctions)
+    result match {
+      case Invalid(errors) =>
+        throw new Exception(s"Failed to evaluate expression ${expr} with ${errors}")
+      case Valid(x: WomValue) => x
     }
+  }
 
+  it should "second block in a linear workflow" in {
+    val source: Path                  = pathFromBasename("frag_runner", "wf_linear.wdl")
+    val (dxPathConfig, dxIoFunctions) = setup()
 
-    private def setupFragRunner(dxPathConfig: DxPathConfig,
-                                dxIoFunctions: DxIoFunctions,
-                                wfSourceCode: String) : (WorkflowDefinition, WfFragRunner) = {
-        val (wf : WorkflowDefinition, taskDir, typeAliases) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
-        val fragInputOutput = new WfFragInputOutput(dxIoFunctions,
-                                                    null /*dxProject*/,
-                                                    runtimeDebugLevel,
-                                                    typeAliases)
-        val fragRunner = new WfFragRunner(wf, taskDir, typeAliases,
-                                          wfSourceCode,
-                                          instanceTypeDB,
-                                          Map.empty[String, ExecLinkInfo],
-                                          dxPathConfig,
-                                          dxIoFunctions,
-                                          JsNull,
-                                          fragInputOutput,
-                                          Some(WdlRuntimeAttrs(Map.empty)),
-                                          runtimeDebugLevel)
-        (wf, fragRunner)
+    val (language, womBundle: WomBundle, allSources, subBundles) =
+      ParseWomSourceFile(false).apply(source, List.empty)
+    subBundles.size should be(0)
+    val wfSource = allSources.values.head
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
     }
+    val graph                                   = wf.innerGraph
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
-    // Note: if the file doesn't exist, this throws a null pointer exception
-    def pathFromBasename(dir: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dir}/${basename}").getPath
-        Paths.get(p)
+    val block = subBlocks(1)
+
+    val env: Map[String, WomValue] =
+      Map("x" -> WomInteger(3), "y" -> WomInteger(5), "add.result" -> WomInteger(8))
+
+    val eNodes: Vector[ExposedExpressionNode] = block.nodes.collect {
+      case eNode: ExposedExpressionNode => eNode
     }
+    val expr: WomExpression = eNodes(0).womExpression
+    val value: WomValue     = evaluateWomExpression(expr, env, dxIoFunctions)
+    value should be(WomInteger(9))
+  }
 
+  it should "evaluate a scatter without a call" in {
+    val path         = pathFromBasename("frag_runner", "scatter_no_call.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-    def evaluateWomExpression(expr: WomExpression,
-                              env: Map[String, WomValue],
-                              dxIoFunctions : DxIoFunctions) : WomValue = {
-        val result: ErrorOr[WomValue] =
-            expr.evaluateValue(env, dxIoFunctions)
-        result match {
-            case Invalid(errors) => throw new Exception(
-                s"Failed to evaluate expression ${expr} with ${errors}")
-            case Valid(x: WomValue) => x
-        }
-    }
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val block                         = subBlocks(0)
 
-    it should "second block in a linear workflow" in {
-        val source : Path = pathFromBasename("frag_runner", "wf_linear.wdl")
-        val (dxPathConfig, dxIoFunctions) = setup()
+    val env                            = Map.empty[String, WomValue]
+    val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
+    results.keys should be(Set("names", "full_name"))
+    results should be(
+      Map(
+        "names" -> WomArray(
+          WomArrayType(WomStringType),
+          Vector(
+            WomString("Michael"),
+            WomString("Lukas"),
+            WomString("Martin"),
+            WomString("Shelly"),
+            WomString("Amy")
+          )
+        ),
+        "full_name" -> WomArray(
+          WomArrayType(WomStringType),
+          Vector(
+            WomString("Michael_Manhaim"),
+            WomString("Lukas_Manhaim"),
+            WomString("Martin_Manhaim"),
+            WomString("Shelly_Manhaim"),
+            WomString("Amy_Manhaim")
+          )
+        )
+      )
+    )
+  }
 
-        val (language, womBundle: WomBundle, allSources, subBundles) =
-            ParseWomSourceFile(false).apply(source, List.empty)
-        subBundles.size should be(0)
-        val wfSource = allSources.values.head
+  it should "evaluate a conditional without a call" in {
+    val path         = pathFromBasename("frag_runner", "conditional_no_call.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-        val graph = wf.innerGraph
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    val block                         = subBlocks(0)
 
-        val block = subBlocks(1)
+    val env                            = Map.empty[String, WomValue]
+    val results: Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
+    results should be(
+      Map(
+        "flag" -> WomBoolean(true),
+        "cats" -> WomOptionalValue(
+          WomStringType,
+          Some(WomString("Mr. Baggins"))
+        )
+      )
+    )
+  }
 
-        val env : Map[String, WomValue] =
-            Map("x" -> WomInteger(3),
-                "y" -> WomInteger(5),
-                "add.result" -> WomInteger(8))
+  it should "evaluate a nested conditional/scatter without a call" in {
+    val path         = pathFromBasename("frag_runner", "nested_no_call.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val eNodes : Vector[ExposedExpressionNode] = block.nodes.collect{
-            case eNode: ExposedExpressionNode => eNode
-        }
-        val expr : WomExpression = eNodes(0).womExpression
-        val value: WomValue = evaluateWomExpression(expr, env, dxIoFunctions)
-        value should be(WomInteger(9))
-    }
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
 
-    it should "evaluate a scatter without a call" in {
-        val path = pathFromBasename("frag_runner", "scatter_no_call.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
+    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
+    results should be(Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None)))
+  }
 
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        val block = subBlocks(0)
+  it should "create proper names for scatter results" in {
+    val path                           = pathFromBasename("frag_runner", "strings.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
-        val env = Map.empty[String, WomValue]
-        val results : Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
-        results.keys should be(Set("names", "full_name"))
-        results should be(
-            Map(
-                "names" -> WomArray(
-                    WomArrayType(WomStringType),
-                    Vector(WomString("Michael"),
-                           WomString("Lukas"),
-                           WomString("Martin"),
-                           WomString("Shelly"),
-                           WomString("Amy"))),
-                "full_name" -> WomArray(
-                    WomArrayType(WomStringType),
-                    Vector(WomString("Michael_Manhaim"),
-                           WomString("Lukas_Manhaim"),
-                           WomString("Martin_Manhaim"),
-                           WomString("Shelly_Manhaim"),
-                           WomString("Amy_Manhaim")))
-            ))
-    }
-
-    it should "evaluate a conditional without a call" in {
-        val path = pathFromBasename("frag_runner", "conditional_no_call.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        val block = subBlocks(0)
-
-        val env = Map.empty[String, WomValue]
-        val results : Map[String, WomValue] = fragRunner.evalExpressions(block.nodes, env)
-        results should be(
-            Map("flag" -> WomBoolean(true),
-                "cats" -> WomOptionalValue(
-                    WomStringType,
-                    Some(WomString("Mr. Baggins"))
-                )))
-    }
-
-    it should "evaluate a nested conditional/scatter without a call" in {
-        val path = pathFromBasename("frag_runner", "nested_no_call.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-
-        val results = fragRunner.evalExpressions(subBlocks(0).nodes,
-                                                 Map.empty[String, WomValue])
-        results should be (Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType),None)))
-    }
-
-    it should "create proper names for scatter results" in {
-        val path = pathFromBasename("frag_runner", "strings.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
-
-        val sctNode = wf.innerGraph.scatters.head
-        val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
-        /*System.out.println(s"""|name = ${svNode.identifier.localName.value}
+    val sctNode                     = wf.innerGraph.scatters.head
+    val svNode: ScatterVariableNode = sctNode.scatterVariableNodes.head
+    /*System.out.println(s"""|name = ${svNode.identifier.localName.value}
                                |       ${svNode.identifier.workflowLocalName}
                                |       ${svNode.identifier.localName}
                                |""".stripMargin)*/
-        svNode.identifier.localName.value should be("x")
-        svNode.identifier.workflowLocalName should be("x")
-        svNode.identifier.localName.toString should be ("LocalName(x)")
+    svNode.identifier.localName.value should be("x")
+    svNode.identifier.workflowLocalName should be("x")
+    svNode.identifier.localName.toString should be("LocalName(x)")
+  }
+
+  it should "Make sure calls cannot be handled by evalExpressions" in {
+    val path         = pathFromBasename("draft2", "shapes.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+
+    // Make sure an exception is thrown if eval-expressions is called with
+    // a wdl-call.
+    assertThrows[Exception] {
+      fragRunner.evalExpressions(subBlocks(1).nodes, Map.empty[String, WomValue])
     }
+  }
 
-    it should "Make sure calls cannot be handled by evalExpressions" in {
-        val path = pathFromBasename("draft2", "shapes.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
+  it should "handles draft2" in {
+    val path         = pathFromBasename("draft2", "conditionals2.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-
-        // Make sure an exception is thrown if eval-expressions is called with
-        // a wdl-call.
-        assertThrows[Exception] {
-            fragRunner.evalExpressions(subBlocks(1).nodes,
-                                       Map.empty[String, WomValue])
-        }
-    }
-
-    it should "handles draft2" in {
-        val path = pathFromBasename("draft2", "conditionals2.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-/*
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+    /*
         val results = fragRunner.evalExpressions(subBlocks(0).nodes,
                                                  Map.empty[String, WomValue])
  Utils.ignore(results)*/
-        Utils.ignore(subBlocks)
+    Utils.ignore(subBlocks)
+  }
+
+  it should "evaluate expressions that define variables" in {
+    val path         = pathFromBasename("draft2", "conditionals3.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
+
+    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
+    results.keys should be(Set("powers10", "i1", "i2", "i3"))
+    results("i1") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
+    results("i2") should be(WomOptionalValue(WomIntegerType, None))
+    results("i3") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(100))))
+    results("powers10") should be(
+      WomArray(
+        WomArrayType(WomOptionalType(WomIntegerType)),
+        Vector(
+          WomOptionalValue(WomIntegerType, Some(WomInteger(1))),
+          WomOptionalValue(WomIntegerType, None),
+          WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
+        )
+      )
+    )
+  }
+
+  // find the call
+  private def findCallByName(callName: String, graph: Graph): CallNode = {
+    val allCalls = graph.allNodes.collect {
+      case call: CallNode => call
     }
-
-    it should "evaluate expressions that define variables" in {
-        val path = pathFromBasename("draft2", "conditionals3.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-
-        val results = fragRunner.evalExpressions(subBlocks(0).nodes,
-                                                 Map.empty[String, WomValue])
-        results.keys should be(Set("powers10", "i1", "i2", "i3"))
-        results("i1") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
-        results("i2") should be(WomOptionalValue(WomIntegerType, None))
-        results("i3") should be(WomOptionalValue(WomIntegerType, Some(WomInteger(100))))
-        results("powers10") should be(
-            WomArray(WomArrayType(WomOptionalType(WomIntegerType)),
-                     Vector(WomOptionalValue(WomIntegerType, Some(WomInteger(1))),
-                            WomOptionalValue(WomIntegerType, None),
-                            WomOptionalValue(WomIntegerType, Some(WomInteger(100))))))
+    val callNode = allCalls.find {
+      case callNode: CallNode =>
+        callNode.identifier.localName.value == callName
     }
-
-
-    // find the call
-    private def findCallByName(callName: String,
-                               graph: Graph) : CallNode = {
-        val allCalls = graph.allNodes.collect{
-            case call: CallNode => call
-        }
-        val callNode = allCalls.find{
-            case callNode: CallNode =>
-                callNode.identifier.localName.value == callName
-        }
-        callNode match {
-            case None => throw new Exception(s"call ${callName} not found")
-            case Some(x : CallNode) => x
-            case Some(other) => throw new Exception(s"call ${callName} found with wrong class ${other}")
-        }
+    callNode match {
+      case None              => throw new Exception(s"call ${callName} not found")
+      case Some(x: CallNode) => x
+      case Some(other)       => throw new Exception(s"call ${callName} found with wrong class ${other}")
     }
+  }
 
-    it should "evaluate call inputs properly" in {
-        val path = pathFromBasename("draft2", "various_calls.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+  it should "evaluate call inputs properly" in {
+    val path                          = pathFromBasename("draft2", "various_calls.wdl")
+    val wfSourceCode                  = Utils.readFileContent(path)
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
-        val call1 = findCallByName("MaybeInt", wf.innerGraph)
-        val callInputs1: Map[String, WomValue] = fragRunner.evalCallInputs(call1,
-                                                                           Map("i" -> WomInteger(1)))
-        callInputs1 should be(Map("a" -> WomOptionalValue(WomIntegerType,
-                                                          Some(WomInteger(1)))))
+    val call1 = findCallByName("MaybeInt", wf.innerGraph)
+    val callInputs1: Map[String, WomValue] =
+      fragRunner.evalCallInputs(call1, Map("i" -> WomInteger(1)))
+    callInputs1 should be(Map("a" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1)))))
 
-        val call2 = findCallByName("ManyArgs", wf.innerGraph)
-        val callInputs2: Map[String, WomValue] = fragRunner.evalCallInputs(
-            call2,
-            Map("powers10"-> WomArray(WomArrayType(WomIntegerType),
-                                      Vector(WomInteger(1), WomInteger(10)))
-            ))
+    val call2 = findCallByName("ManyArgs", wf.innerGraph)
+    val callInputs2: Map[String, WomValue] = fragRunner.evalCallInputs(
+      call2,
+      Map(
+        "powers10" -> WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(1), WomInteger(10)))
+      )
+    )
 
-        callInputs2 should be(Map("a" -> WomString("hello"),
-                                  "b" -> WomArray(WomArrayType(WomIntegerType),
-                                                  Vector(WomInteger(1), WomInteger(10)))))
-    }
+    callInputs2 should be(
+      Map(
+        "a" -> WomString("hello"),
+        "b" -> WomArray(WomArrayType(WomIntegerType), Vector(WomInteger(1), WomInteger(10)))
+      )
+    )
+  }
 
-    it should "evaluate call constant inputs" in {
-        val path = pathFromBasename("nested", "two_levels.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+  it should "evaluate call constant inputs" in {
+    val path                          = pathFromBasename("nested", "two_levels.wdl")
+    val wfSourceCode                  = Utils.readFileContent(path)
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
 
-        val inc4Call = findCallByName("inc5", wf.innerGraph)
+    val inc4Call = findCallByName("inc5", wf.innerGraph)
 
-        val args = fragRunner.evalCallInputs(inc4Call, Map.empty)
-        args shouldBe (Map("a" -> WomInteger(3)))
-    }
+    val args = fragRunner.evalCallInputs(inc4Call, Map.empty)
+    args shouldBe (Map("a" -> WomInteger(3)))
+  }
 
-    it should "expressions with structs" in {
-        val path = pathFromBasename("frag_runner", "House.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
+  it should "expressions with structs" in {
+    val path         = pathFromBasename("frag_runner", "House.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val (_, _, subBlocks, _)          = Block.split(wf.innerGraph, wfSourceCode)
 
-        val results = fragRunner.evalExpressions(subBlocks(0).nodes,
-                                                 Map.empty[String, WomValue])
-        results.keys should be(Set("a", "b", "tot_height", "tot_num_floors",
-                                   "streets", "cities", "tot"))
-        results("tot") should be(WomObject(Map(
-                                               "height" -> WomInteger(32),
-                                               "num_floors" -> WomInteger(4),
-                                               "street" -> WomString("Alda_Mary"),
-                                               "city" -> WomString("Sunnyvale_Santa Clara")),
-                                           WomCompositeType(Map("height" -> WomIntegerType,
-                                                                "num_floors" -> WomIntegerType,
-                                                                "street" -> WomStringType,
-                                                                "city" -> WomStringType),
-                                                            Some("House"))
-                                 ))
-    }
+    val results = fragRunner.evalExpressions(subBlocks(0).nodes, Map.empty[String, WomValue])
+    results.keys should be(
+      Set("a", "b", "tot_height", "tot_num_floors", "streets", "cities", "tot")
+    )
+    results("tot") should be(
+      WomObject(
+        Map(
+          "height"     -> WomInteger(32),
+          "num_floors" -> WomInteger(4),
+          "street"     -> WomString("Alda_Mary"),
+          "city"       -> WomString("Sunnyvale_Santa Clara")
+        ),
+        WomCompositeType(
+          Map(
+            "height"     -> WomIntegerType,
+            "num_floors" -> WomIntegerType,
+            "street"     -> WomStringType,
+            "city"       -> WomStringType
+          ),
+          Some("House")
+        )
+      )
+    )
+  }
 
-    it should "fill in missing optionals" in {
-        val path = pathFromBasename("frag_runner", "missing_args.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
+  it should "fill in missing optionals" in {
+    val path         = pathFromBasename("frag_runner", "missing_args.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val results: Map[String, JsValue] =
-            fragRunner.apply(Vector(0), Map("y" -> WomInteger(5)), RunnerWfFragmentMode.Launch)
-        results shouldBe (Map("retval" -> JsNumber(5)))
-    }
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val results: Map[String, JsValue] =
+      fragRunner.apply(Vector(0), Map("y" -> WomInteger(5)), RunnerWfFragmentMode.Launch)
+    results shouldBe (Map("retval" -> JsNumber(5)))
+  }
 
-    it should "evaluate expressions in correct order" taggedAs(EdgeTest) in {
-        val path = pathFromBasename("frag_runner", "scatter_variable_not_found.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
+  it should "evaluate expressions in correct order" taggedAs (EdgeTest) in {
+    val path         = pathFromBasename("frag_runner", "scatter_variable_not_found.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
 
-        val (dxPathConfig, dxIoFunctions) = setup()
-        val (wf, fragRunner) = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
-        val results: Map[String, JsValue] =
-            fragRunner.apply(Vector(0), Map.empty, RunnerWfFragmentMode.Launch)
-        results.keys should contain("bam_lane1")
-        results("bam_lane1") shouldBe (JsObject(
-                                           "___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)))
-    }
+    val (dxPathConfig, dxIoFunctions) = setup()
+    val (wf, fragRunner)              = setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
+    val results: Map[String, JsValue] =
+      fragRunner.apply(Vector(0), Map.empty, RunnerWfFragmentMode.Launch)
+    results.keys should contain("bam_lane1")
+    results("bam_lane1") shouldBe (JsObject("___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)))
+  }
 }

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -32,13 +32,13 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
   private val runtimeDebugLevel = 0
   private val unicornInstance =
     DxInstanceType(
-      "mem_ssd_unicorn",
-      100,
-      100,
-      4,
-      1.00f,
-      Vector(("Ubuntu", "16.04")),
-      false
+        "mem_ssd_unicorn",
+        100,
+        100,
+        4,
+        1.00f,
+        Vector(("Ubuntu", "16.04")),
+        false
     )
   private val instanceTypeDB = InstanceTypeDB(true, Vector(unicornInstance))
 
@@ -64,24 +64,24 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
     val fragInputOutput =
       new WfFragInputOutput(
-        dxIoFunctions,
-        null /*dxProject*/,
-        runtimeDebugLevel,
-        typeAliases
+          dxIoFunctions,
+          null /*dxProject*/,
+          runtimeDebugLevel,
+          typeAliases
       )
     val fragRunner = new WfFragRunner(
-      wf,
-      taskDir,
-      typeAliases,
-      wfSourceCode,
-      instanceTypeDB,
-      Map.empty[String, ExecLinkInfo],
-      dxPathConfig,
-      dxIoFunctions,
-      JsNull,
-      fragInputOutput,
-      Some(WdlRuntimeAttrs(Map.empty)),
-      runtimeDebugLevel
+        wf,
+        taskDir,
+        typeAliases,
+        wfSourceCode,
+        instanceTypeDB,
+        Map.empty[String, ExecLinkInfo],
+        dxPathConfig,
+        dxIoFunctions,
+        JsNull,
+        fragInputOutput,
+        Some(WdlRuntimeAttrs(Map.empty)),
+        runtimeDebugLevel
     )
     (wf, fragRunner)
   }
@@ -102,7 +102,7 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     result match {
       case Invalid(errors) =>
         throw new Exception(
-          s"Failed to evaluate expression ${expr} with ${errors}"
+            s"Failed to evaluate expression ${expr} with ${errors}"
         )
       case Valid(x: WomValue) => x
     }
@@ -128,9 +128,9 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
 
     val env: Map[String, WomValue] =
       Map(
-        "x" -> WomInteger(3),
-        "y" -> WomInteger(5),
-        "add.result" -> WomInteger(8)
+          "x" -> WomInteger(3),
+          "y" -> WomInteger(5),
+          "add.result" -> WomInteger(8)
       )
 
     val eNodes: Vector[ExposedExpressionNode] = block.nodes.collect {
@@ -156,28 +156,28 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       fragRunner.evalExpressions(block.nodes, env)
     results.keys should be(Set("names", "full_name"))
     results should be(
-      Map(
-        "names" -> WomArray(
-          WomArrayType(WomStringType),
-          Vector(
-            WomString("Michael"),
-            WomString("Lukas"),
-            WomString("Martin"),
-            WomString("Shelly"),
-            WomString("Amy")
-          )
-        ),
-        "full_name" -> WomArray(
-          WomArrayType(WomStringType),
-          Vector(
-            WomString("Michael_Manhaim"),
-            WomString("Lukas_Manhaim"),
-            WomString("Martin_Manhaim"),
-            WomString("Shelly_Manhaim"),
-            WomString("Amy_Manhaim")
-          )
+        Map(
+            "names" -> WomArray(
+                WomArrayType(WomStringType),
+                Vector(
+                    WomString("Michael"),
+                    WomString("Lukas"),
+                    WomString("Martin"),
+                    WomString("Shelly"),
+                    WomString("Amy")
+                )
+            ),
+            "full_name" -> WomArray(
+                WomArrayType(WomStringType),
+                Vector(
+                    WomString("Michael_Manhaim"),
+                    WomString("Lukas_Manhaim"),
+                    WomString("Martin_Manhaim"),
+                    WomString("Shelly_Manhaim"),
+                    WomString("Amy_Manhaim")
+                )
+            )
         )
-      )
     )
   }
 
@@ -195,13 +195,13 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val results: Map[String, WomValue] =
       fragRunner.evalExpressions(block.nodes, env)
     results should be(
-      Map(
-        "flag" -> WomBoolean(true),
-        "cats" -> WomOptionalValue(
-          WomStringType,
-          Some(WomString("Mr. Baggins"))
+        Map(
+            "flag" -> WomBoolean(true),
+            "cats" -> WomOptionalValue(
+                WomStringType,
+                Some(WomString("Mr. Baggins"))
+            )
         )
-      )
     )
   }
 
@@ -215,11 +215,11 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(
-      subBlocks(0).nodes,
-      Map.empty[String, WomValue]
+        subBlocks(0).nodes,
+        Map.empty[String, WomValue]
     )
     results should be(
-      Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None))
+        Map("z" -> WomOptionalValue(WomMaybeEmptyArrayType(WomIntegerType), None))
     )
   }
 
@@ -253,8 +253,8 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     // a wdl-call.
     assertThrows[Exception] {
       fragRunner.evalExpressions(
-        subBlocks(1).nodes,
-        Map.empty[String, WomValue]
+          subBlocks(1).nodes,
+          Map.empty[String, WomValue]
       )
     }
   }
@@ -284,26 +284,26 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(
-      subBlocks(0).nodes,
-      Map.empty[String, WomValue]
+        subBlocks(0).nodes,
+        Map.empty[String, WomValue]
     )
     results.keys should be(Set("powers10", "i1", "i2", "i3"))
     results("i1") should be(
-      WomOptionalValue(WomIntegerType, Some(WomInteger(1)))
+        WomOptionalValue(WomIntegerType, Some(WomInteger(1)))
     )
     results("i2") should be(WomOptionalValue(WomIntegerType, None))
     results("i3") should be(
-      WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
+        WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
     )
     results("powers10") should be(
-      WomArray(
-        WomArrayType(WomOptionalType(WomIntegerType)),
-        Vector(
-          WomOptionalValue(WomIntegerType, Some(WomInteger(1))),
-          WomOptionalValue(WomIntegerType, None),
-          WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
+        WomArray(
+            WomArrayType(WomOptionalType(WomIntegerType)),
+            Vector(
+                WomOptionalValue(WomIntegerType, Some(WomInteger(1))),
+                WomOptionalValue(WomIntegerType, None),
+                WomOptionalValue(WomIntegerType, Some(WomInteger(100)))
+            )
         )
-      )
     )
   }
 
@@ -335,28 +335,28 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val callInputs1: Map[String, WomValue] =
       fragRunner.evalCallInputs(call1, Map("i" -> WomInteger(1)))
     callInputs1 should be(
-      Map("a" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
+        Map("a" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1))))
     )
 
     val call2 = findCallByName("ManyArgs", wf.innerGraph)
     val callInputs2: Map[String, WomValue] = fragRunner.evalCallInputs(
-      call2,
-      Map(
-        "powers10" -> WomArray(
-          WomArrayType(WomIntegerType),
-          Vector(WomInteger(1), WomInteger(10))
+        call2,
+        Map(
+            "powers10" -> WomArray(
+                WomArrayType(WomIntegerType),
+                Vector(WomInteger(1), WomInteger(10))
+            )
         )
-      )
     )
 
     callInputs2 should be(
-      Map(
-        "a" -> WomString("hello"),
-        "b" -> WomArray(
-          WomArrayType(WomIntegerType),
-          Vector(WomInteger(1), WomInteger(10))
+        Map(
+            "a" -> WomString("hello"),
+            "b" -> WomArray(
+                WomArrayType(WomIntegerType),
+                Vector(WomInteger(1), WomInteger(10))
+            )
         )
-      )
     )
   }
 
@@ -383,30 +383,30 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val results = fragRunner.evalExpressions(
-      subBlocks(0).nodes,
-      Map.empty[String, WomValue]
+        subBlocks(0).nodes,
+        Map.empty[String, WomValue]
     )
     results.keys should be(
-      Set("a", "b", "tot_height", "tot_num_floors", "streets", "cities", "tot")
+        Set("a", "b", "tot_height", "tot_num_floors", "streets", "cities", "tot")
     )
     results("tot") should be(
-      WomObject(
-        Map(
-          "height" -> WomInteger(32),
-          "num_floors" -> WomInteger(4),
-          "street" -> WomString("Alda_Mary"),
-          "city" -> WomString("Sunnyvale_Santa Clara")
-        ),
-        WomCompositeType(
-          Map(
-            "height" -> WomIntegerType,
-            "num_floors" -> WomIntegerType,
-            "street" -> WomStringType,
-            "city" -> WomStringType
-          ),
-          Some("House")
+        WomObject(
+            Map(
+                "height" -> WomInteger(32),
+                "num_floors" -> WomInteger(4),
+                "street" -> WomString("Alda_Mary"),
+                "city" -> WomString("Sunnyvale_Santa Clara")
+            ),
+            WomCompositeType(
+                Map(
+                    "height" -> WomIntegerType,
+                    "num_floors" -> WomIntegerType,
+                    "street" -> WomStringType,
+                    "city" -> WomStringType
+                ),
+                Some("House")
+            )
         )
-      )
     )
   }
 
@@ -419,9 +419,9 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       setupFragRunner(dxPathConfig, dxIoFunctions, wfSourceCode)
     val results: Map[String, JsValue] =
       fragRunner.apply(
-        Vector(0),
-        Map("y" -> WomInteger(5)),
-        RunnerWfFragmentMode.Launch
+          Vector(0),
+          Map("y" -> WomInteger(5)),
+          RunnerWfFragmentMode.Launch
       )
     results shouldBe (Map("retval" -> JsNumber(5)))
   }
@@ -437,7 +437,7 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
       fragRunner.apply(Vector(0), Map.empty, RunnerWfFragmentMode.Launch)
     results.keys should contain("bam_lane1")
     results("bam_lane1") shouldBe (JsObject(
-      "___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)
+        "___" -> JsArray(JsString("1_ACGT_1.bam"), JsNull)
     ))
   }
 }

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -12,366 +12,369 @@ import wom.types._
 import dxWDL.base.Utils
 
 class BlockTest extends FlatSpec with Matchers {
-    private val parseWomSourceFile = ParseWomSourceFile(false)
+  private val parseWomSourceFile = ParseWomSourceFile(false)
 
-    private def pathFromBasename(dir: String, basename: String) : Path = {
-        val p = getClass.getResource(s"/${dir}/${basename}").getPath
-        Paths.get(p)
-    }
+  private def pathFromBasename(dir: String, basename: String): Path = {
+    val p = getClass.getResource(s"/${dir}/${basename}").getPath
+    Paths.get(p)
+  }
 
-    private def closureAll(b: Block) : Map[String, WomType] = {
-        val cls = Block.closure(b)
-        cls.map{ case (name, (womType,_)) => name -> womType}.toMap
-    }
+  private def closureAll(b: Block): Map[String, WomType] = {
+    val cls = Block.closure(b)
+    cls.map { case (name, (womType, _)) => name -> womType }.toMap
+  }
 
-    it should "calculate closure correctly" in {
-        val path = pathFromBasename("util", "block_closure.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+  it should "calculate closure correctly" in {
+    val path                           = pathFromBasename("util", "block_closure.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
 
-        /*System.out.println(s"""|block #0 =
+    /*System.out.println(s"""|block #0 =
                                |${subBlocks(0).prettyPrintApproxWdl}}
                                |""".stripMargin)*/
-        closureAll(subBlocks(0)).keys.toSet should be(Set.empty)
-        closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
-        closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
-        closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
-        closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
+    closureAll(subBlocks(0)).keys.toSet should be(Set.empty)
+    closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
+    closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
+    closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
+    closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
+  }
+
+  it should "calculate outputs correctly" in {
+    val path                           = pathFromBasename("util", "block_closure.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+
+    Block.outputs(subBlocks(1)) should be(Map("inc2.result" -> WomOptionalType(WomIntegerType)))
+    Block.outputs(subBlocks(2)) should be(Map("inc3.result" -> WomOptionalType(WomIntegerType)))
+    Block.outputs(subBlocks(3)) should be(Map("inc4.result" -> WomArrayType(WomIntegerType)))
+    Block.outputs(subBlocks(4)) should be(
+      Map(
+        "x"           -> WomArrayType(WomIntegerType),
+        "inc5.result" -> WomArrayType(WomOptionalType(WomIntegerType))
+      )
+    )
+  }
+
+  it should "calculate outputs correctly II" in {
+    val path                           = pathFromBasename("compiler", "wf_linear.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+
+    Block.outputs(subBlocks(1)) should be(
+      Map("z" -> WomIntegerType, "mul.result" -> WomIntegerType)
+    )
+    closureAll(subBlocks(1)).keys.toSet should be(Set("add.result"))
+  }
+
+  it should "handle block zero" in {
+    val path                              = pathFromBasename("util", "block_zero.wdl")
+    val wfSourceCode                      = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _)    = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inNodes, _, subBlocks, outNodes) = Block.split(wf.innerGraph, wfSourceCode)
+
+    Block.outputs(subBlocks(0)) should be(
+      Map("rain" -> WomIntegerType, "inc.result" -> WomOptionalType(WomIntegerType))
+    )
+  }
+
+  it should "block with two calls or more" in {
+    val path                           = pathFromBasename("util", "block_with_three_calls.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    subBlocks.size should be(1)
+  }
+
+  it should "split a block with an expression after a call" in {
+    val path                           = pathFromBasename("util", "expression_after_call.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    subBlocks.size should be(2)
+  }
+
+  it should "calculate closure correctly for WDL draft-2" in {
+    val path                           = pathFromBasename("draft2", "block_closure.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+
+    closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
+    closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
+    closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
+    closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
+  }
+
+  it should "calculate closure correctly for WDL draft-2 II" in {
+    val path                                    = pathFromBasename("draft2", "shapes.wdl")
+    val wfSourceCode                            = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _)          = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
+
+    closureAll(subBlocks(0)).keys.toSet should be(Set("num"))
+    closureAll(subBlocks(1)).keys.toSet should be(Set.empty)
+  }
+
+  it should "calculate closure for a workflow with expression outputs" in {
+    val path                           = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+
+    val outputNodes = wf.innerGraph.outputNodes
+    val exprOutputNodes: Vector[ExpressionBasedGraphOutputNode] =
+      outputNodes.flatMap { node =>
+        if (Block.isSimpleOutput(node)) None
+        else Some(node.asInstanceOf[ExpressionBasedGraphOutputNode])
+      }.toVector
+    Block.outputClosure(exprOutputNodes) should be(Set("a", "b"))
+  }
+
+  it should "calculate output closure for a workflow" in {
+    val path                           = pathFromBasename("compiler", "cast.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val outputNodes                    = wf.innerGraph.outputNodes.toVector
+    Block.outputClosure(outputNodes) should be(
+      Set("Add.result", "SumArray.result", "SumArray2.result", "JoinMisc.result")
+    )
+  }
+
+  it should "identify simple calls even if they have optionals" in {
+    val path                                    = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
+    val wfSourceCode                            = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _)          = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
+
+    for (i <- 0 to 2) {
+      Block.categorize(subBlocks(i)) shouldBe a[Block.CallDirect]
+    }
+  }
+
+  it should "categorize correctly calls to subworkflows" taggedAs (EdgeTest) in {
+    val path                       = pathFromBasename("subworkflows", "trains.wdl")
+    val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, wfSourceCode) = sources.find {
+      case (key, wdlCode) =>
+        key.endsWith("trains.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("Could not find the workflow in the source")
     }
 
-    it should "calculate outputs correctly" in {
-        val path = pathFromBasename("util", "block_closure.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
 
-        Block.outputs(subBlocks(1)) should be(Map("inc2.result" -> WomOptionalType(WomIntegerType)))
-        Block.outputs(subBlocks(2)) should be(Map("inc3.result" -> WomOptionalType(WomIntegerType)))
-        Block.outputs(subBlocks(3)) should be(Map("inc4.result" -> WomArrayType(WomIntegerType)))
-        Block.outputs(subBlocks(4)) should be(
-            Map("x" -> WomArrayType(WomIntegerType),
-                "inc5.result" -> WomArrayType(WomOptionalType(WomIntegerType)))
-        )
+    Block.categorize(subBlocks(0)) shouldBe a[Block.ScatterOneCall]
+  }
+
+  it should "get subblocks" in {
+    val path                           = pathFromBasename("nested", "two_levels.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (_, womBundle, sources, _)     = parseWomSourceFile.apply(path, List.empty)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+
+    // sort from low to high according to the source lines.
+    val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSourceCode)
+
+    val graph = wf.innerGraph
+
+    val b0 = Block.getSubBlock(Vector(0), graph, callsLoToHi)
+    Block.categorize(b0) shouldBe a[Block.ScatterFullBlock]
+
+    val b1 = Block.getSubBlock(Vector(1), graph, callsLoToHi)
+    Block.categorize(b1) shouldBe a[Block.CondOneCall]
+
+    val b2 = Block.getSubBlock(Vector(2), graph, callsLoToHi)
+    Block.categorize(b2) shouldBe a[Block.CallDirect]
+
+    val b00 = Block.getSubBlock(Vector(0, 0), graph, callsLoToHi)
+    Block.categorize(b00) shouldBe a[Block.CallDirect]
+
+    val b01 = Block.getSubBlock(Vector(0, 1), graph, callsLoToHi)
+    Block.categorize(b01) shouldBe a[Block.CallDirect]
+
+    val b02 = Block.getSubBlock(Vector(0, 2), graph, callsLoToHi)
+    Block.categorize(b02) shouldBe a[Block.CallFragment]
+  }
+
+  it should "handle calls to imported modules II" in {
+    val path                                            = pathFromBasename("draft2", "block_category.wdl")
+    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+
+    val (_, wfSource) = allSources.find {
+      case (name, _) => name.endsWith("block_category.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
     }
+    val graph                                   = wf.innerGraph
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
-    it should "calculate outputs correctly II" in {
-        val path = pathFromBasename("compiler", "wf_linear.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    Block.categorize(subBlocks(0)) shouldBe a[Block.CondOneCall]
+  }
 
-        Block.outputs(subBlocks(1)) should be(Map("z" -> WomIntegerType,
-                                                  "mul.result" -> WomIntegerType))
-        closureAll(subBlocks(1)).keys.toSet should be(Set("add.result"))
+  it should "handle calls to imported modules" in {
+    val path                                            = pathFromBasename("draft2", "conditionals1.wdl")
+    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+
+    val (_, wfSource) = allSources.find {
+      case (name, _) => name.endsWith("conditionals1.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
     }
+    val graph                                   = wf.innerGraph
+    val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
-    it should "handle block zero" in {
-        val path = pathFromBasename("util", "block_zero.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (inNodes, _, subBlocks, outNodes) = Block.split(wf.innerGraph, wfSourceCode)
-
-        Block.outputs(subBlocks(0)) should be(
-            Map("rain" -> WomIntegerType,
-                "inc.result" -> WomOptionalType(WomIntegerType))
-        )
-    }
-
-    it should "block with two calls or more" in {
-        val path = pathFromBasename("util", "block_with_three_calls.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        subBlocks.size should be(1)
-    }
-
-    it should "split a block with an expression after a call" in {
-        val path = pathFromBasename("util", "expression_after_call.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        subBlocks.size should be(2)
-    }
-
-    it should "calculate closure correctly for WDL draft-2" in {
-        val path = pathFromBasename("draft2", "block_closure.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-
-        closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
-        closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
-        closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
-        closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
-    }
-
-    it should "calculate closure correctly for WDL draft-2 II" in {
-        val path = pathFromBasename("draft2", "shapes.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
-
-        closureAll(subBlocks(0)).keys.toSet should be(Set("num"))
-        closureAll(subBlocks(1)).keys.toSet should be(Set.empty)
-    }
-
-    it should "calculate closure for a workflow with expression outputs" in {
-        val path = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-
-        val outputNodes = wf.innerGraph.outputNodes
-        val exprOutputNodes: Vector[ExpressionBasedGraphOutputNode] =
-            outputNodes.flatMap{ node =>
-                if (Block.isSimpleOutput(node)) None
-                else Some(node.asInstanceOf[ExpressionBasedGraphOutputNode])
-            }.toVector
-        Block.outputClosure(exprOutputNodes) should be (Set("a", "b"))
-    }
-
-    it should "calculate output closure for a workflow" in {
-        val path = pathFromBasename("compiler", "cast.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val outputNodes = wf.innerGraph.outputNodes.toVector
-        Block.outputClosure(outputNodes) should be (Set("Add.result",
-                                                        "SumArray.result",
-                                                        "SumArray2.result",
-                                                        "JoinMisc.result"))
-    }
-
-    it should "identify simple calls even if they have optionals" in {
-        val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
-
-        for (i <- 0 to 2) {
-            Block.categorize(subBlocks(i)) shouldBe a [Block.CallDirect]
-        }
-    }
-
-    it should "categorize correctly calls to subworkflows" taggedAs(EdgeTest) in {
-        val path = pathFromBasename("subworkflows", "trains.wdl")
-        val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
-        val (_, wfSourceCode) = sources.find{ case (key, wdlCode) =>
-            key.endsWith("trains.wdl")
-        }.get
-
-        val wf : WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("Could not find the workflow in the source")
-        }
-
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
-
-        Block.categorize(subBlocks(0)) shouldBe a [Block.ScatterOneCall]
-    }
-
-    it should "get subblocks" in {
-        val path = pathFromBasename("nested", "two_levels.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-
-        // sort from low to high according to the source lines.
-        val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSourceCode)
-
-        val graph = wf.innerGraph
-
-        val b0 = Block.getSubBlock(Vector(0), graph, callsLoToHi)
-        Block.categorize(b0) shouldBe a[Block.ScatterFullBlock]
-
-        val b1 = Block.getSubBlock(Vector(1), graph, callsLoToHi)
-        Block.categorize(b1) shouldBe a[Block.CondOneCall]
-
-        val b2 = Block.getSubBlock(Vector(2), graph, callsLoToHi)
-        Block.categorize(b2) shouldBe a[Block.CallDirect]
-
-        val b00 = Block.getSubBlock(Vector(0, 0), graph, callsLoToHi)
-        Block.categorize(b00) shouldBe a[Block.CallDirect]
-
-        val b01 = Block.getSubBlock(Vector(0, 1), graph, callsLoToHi)
-        Block.categorize(b01) shouldBe a[Block.CallDirect]
-
-        val b02 = Block.getSubBlock(Vector(0, 2), graph, callsLoToHi)
-        Block.categorize(b02) shouldBe a[Block.CallFragment]
-    }
-
-    it should "handle calls to imported modules II" in {
-        val path = pathFromBasename("draft2", "block_category.wdl")
-        val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
-
-        val (_, wfSource) = allSources.find {
-            case (name, _) => name.endsWith("block_category.wdl")
-        }.get
-
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-        val graph = wf.innerGraph
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
-
-        Block.categorize(subBlocks(0)) shouldBe a[Block.CondOneCall]
-    }
-
-    it should "handle calls to imported modules" in {
-        val path = pathFromBasename("draft2", "conditionals1.wdl")
-        val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
-
-        val (_, wfSource) = allSources.find {
-            case (name, _) => name.endsWith("conditionals1.wdl")
-        }.get
-
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-        val graph = wf.innerGraph
-        val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
-
-        for (i <- 0 to (subBlocks.length - 1)) {
-            val b = subBlocks(i)
-/*            System.out.println(s"""|BLOCK #${i} = [
+    for (i <- 0 to (subBlocks.length - 1)) {
+      val b = subBlocks(i)
+      /*            System.out.println(s"""|BLOCK #${i} = [
                                    |${b.prettyPrintApproxWdl}
                                    |]
                                    |""".stripMargin)*/
-            val catg = Block.categorize(b)
-            Utils.ignore(catg)
-        }
+      val catg = Block.categorize(b)
+      Utils.ignore(catg)
+    }
+  }
+
+  it should "compile a workflow calling a subworkflow as a direct call" in {
+    val path                                            = pathFromBasename("draft2", "movies.wdl")
+    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+
+    val (_, wfSource) = allSources.find {
+      case (name, _) => name.endsWith("movies.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
     }
 
-    it should "compile a workflow calling a subworkflow as a direct call" in {
-        val path = pathFromBasename("draft2", "movies.wdl")
-        val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    // sort from low to high according to the source lines.
+    val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSource)
 
-        val (_, wfSource) = allSources.find {
-            case (name, _) => name.endsWith("movies.wdl")
-        }.get
+    // Find the fragment block to execute
+    val block = Block.getSubBlock(Vector(0), wf.innerGraph, callsLoToHi)
 
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-
-        // sort from low to high according to the source lines.
-        val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSource)
-
-        // Find the fragment block to execute
-        val block = Block.getSubBlock(Vector(0), wf.innerGraph, callsLoToHi)
-
-        /*
+    /*
         val dbgBlock = block.nodes.map{
             WomPrettyPrintApproxWdl.apply(_)
         }.mkString("\n")
         System.out.println(s"""|Block:
                                |${dbgBlock}
                                |""".stripMargin)
-         */
+     */
 
-        Block.categorize(block) shouldBe a[Block.CallDirect]
+    Block.categorize(block) shouldBe a[Block.CallDirect]
+  }
+
+  it should "sort a block correctly in the presence of conditionals" in {
+    val path                           = pathFromBasename("draft2", "conditionals3.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+    val b0                   = subBlocks(0)
+
+    val exprVec: Vector[ExposedExpressionNode] = b0.nodes.collect {
+      case node: ExposedExpressionNode => node
+    }
+    exprVec.size should be(1)
+    val arrayCalc: ExposedExpressionNode = exprVec.head
+    arrayCalc.womExpression.sourceString should be("[i1, i2, i3]")
+  }
+
+  it should "find the correct number of scatters" in {
+    val path                                     = pathFromBasename("draft2", "conditionals_base.wdl")
+    val (_, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+
+    val (_, wfSource) = allSources.find {
+      case (name, _) => name.endsWith("conditionals_base.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
+    }
+    val nodes = wf.innerGraph.allNodes
+    val scatters: Set[ScatterNode] = nodes.collect {
+      case n: ScatterNode => n
+    }
+    scatters.size should be(1)
+  }
+
+  it should "sort a subblock properly" in {
+    val path                                            = pathFromBasename("draft2", "conditionals4.wdl")
+    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, wfSource) = allSources.find {
+      case (name, _) => name.endsWith("conditionals4.wdl")
+    }.get
+
+    val wf: WorkflowDefinition = womBundle.primaryCallable match {
+      case Some(wf: WorkflowDefinition) => wf
+      case _                            => throw new Exception("sanity")
     }
 
+    // sort from low to high according to the source lines.
+    val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSource)
 
-    it should "sort a block correctly in the presence of conditionals" in {
-        val path = pathFromBasename("draft2", "conditionals3.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        val b0 = subBlocks(0)
-
-        val exprVec : Vector[ExposedExpressionNode] = b0.nodes.collect{
-            case node : ExposedExpressionNode => node
-        }
-        exprVec.size should be(1)
-        val arrayCalc : ExposedExpressionNode = exprVec.head
-        arrayCalc.womExpression.sourceString should be("[i1, i2, i3]")
-    }
-
-    it should "find the correct number of scatters" in {
-        val path = pathFromBasename("draft2", "conditionals_base.wdl")
-        val (_, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
-
-        val (_, wfSource) = allSources.find {
-            case (name, _) => name.endsWith("conditionals_base.wdl")
-        }.get
-
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-        val nodes = wf.innerGraph.allNodes
-        val scatters : Set[ScatterNode] = nodes.collect{
-            case n : ScatterNode => n
-        }
-        scatters.size should be(1)
-    }
-
-    it should "sort a subblock properly" in {
-        val path = pathFromBasename("draft2", "conditionals4.wdl")
-        val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
-        val (_, wfSource) = allSources.find {
-            case (name, _) => name.endsWith("conditionals4.wdl")
-        }.get
-
-        val wf: WorkflowDefinition = womBundle.primaryCallable match {
-            case Some(wf: WorkflowDefinition) => wf
-            case _ => throw new Exception("sanity")
-        }
-
-        // sort from low to high according to the source lines.
-        val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSource)
-
-        // Find the fragment block to execute
-        val b = Block.getSubBlock(Vector(1), wf.innerGraph, callsLoToHi)
-/*        System.out.println(s"""|BLOCK #1 = [
+    // Find the fragment block to execute
+    val b = Block.getSubBlock(Vector(1), wf.innerGraph, callsLoToHi)
+    /*        System.out.println(s"""|BLOCK #1 = [
                                |${b.prettyPrintApproxWdl}
                                |]
  |""".stripMargin) */
-        Utils.ignore(b)
-    }
+    Utils.ignore(b)
+  }
 
-    it should "handle an empty workflow" in {
-        val path = pathFromBasename("util", "empty_workflow.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-        subBlocks.size shouldBe(0)
-    }
+  it should "handle an empty workflow" in {
+    val path                           = pathFromBasename("util", "empty_workflow.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    subBlocks.size shouldBe (0)
+  }
 
-    it should "detect when inputs are used as outputs" in {
-        val path = pathFromBasename("util", "inputs_used_as_outputs.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (inputs, _, _, outputs) = Block.split(wf.innerGraph, wfSourceCode)
-        Block.inputsUsedAsOutputs(inputs, outputs) shouldBe(Set("lane"))
-    }
+  it should "detect when inputs are used as outputs" in {
+    val path                           = pathFromBasename("util", "inputs_used_as_outputs.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputs, _, _, outputs)        = Block.split(wf.innerGraph, wfSourceCode)
+    Block.inputsUsedAsOutputs(inputs, outputs) shouldBe (Set("lane"))
+  }
 
-    it should "create correct inputs for a workflow with an unpassed argument" in{
-        val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (inputs, _, _, _) = Block.split(wf.innerGraph, wfSourceCode)
+  it should "create correct inputs for a workflow with an unpassed argument" in {
+    val path                           = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputs, _, _, _)              = Block.split(wf.innerGraph, wfSourceCode)
 
-        val names = inputs.map{ inDef => inDef.identifier.localName.value}.toSet
-        names shouldBe(Set.empty[String])
-    }
+    val names = inputs.map { inDef =>
+      inDef.identifier.localName.value
+    }.toSet
+    names shouldBe (Set.empty[String])
+  }
 
-    it should "account for arguments that have a default, but are not optional" in {
-        val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
-        val wfSourceCode = Utils.readFileContent(path)
-        val (wf : WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-        val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
+  it should "account for arguments that have a default, but are not optional" in {
+    val path                           = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
+    val wfSourceCode                   = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
 
-        val c0All = Block.closure(subBlocks(0))
-        c0All.keys.toSet should be(Set("unpassed_arg_default"))
+    val c0All = Block.closure(subBlocks(0))
+    c0All.keys.toSet should be(Set("unpassed_arg_default"))
 
-        val c0Optionals = c0All.collect{ case (name, (_, true)) => name }.toSet
-        c0Optionals should be(Set("unpassed_arg_default"))
+    val c0Optionals = c0All.collect { case (name, (_, true)) => name }.toSet
+    c0Optionals should be(Set("unpassed_arg_default"))
 
-        closureAll(subBlocks(1)).keys.toSet should be(Set.empty)
-    }
+    closureAll(subBlocks(1)).keys.toSet should be(Set.empty)
+  }
 }

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -39,7 +39,7 @@ class BlockTest extends FlatSpec with Matchers {
     closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
     closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
     closureAll(subBlocks(4)).keys.toSet should be(
-      Set("rain", "inc1.result", "flag")
+        Set("rain", "inc1.result", "flag")
     )
   }
 
@@ -51,19 +51,19 @@ class BlockTest extends FlatSpec with Matchers {
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(1)) should be(
-      Map("inc2.result" -> WomOptionalType(WomIntegerType))
+        Map("inc2.result" -> WomOptionalType(WomIntegerType))
     )
     Block.outputs(subBlocks(2)) should be(
-      Map("inc3.result" -> WomOptionalType(WomIntegerType))
+        Map("inc3.result" -> WomOptionalType(WomIntegerType))
     )
     Block.outputs(subBlocks(3)) should be(
-      Map("inc4.result" -> WomArrayType(WomIntegerType))
+        Map("inc4.result" -> WomArrayType(WomIntegerType))
     )
     Block.outputs(subBlocks(4)) should be(
-      Map(
-        "x" -> WomArrayType(WomIntegerType),
-        "inc5.result" -> WomArrayType(WomOptionalType(WomIntegerType))
-      )
+        Map(
+            "x" -> WomArrayType(WomIntegerType),
+            "inc5.result" -> WomArrayType(WomOptionalType(WomIntegerType))
+        )
     )
   }
 
@@ -75,7 +75,7 @@ class BlockTest extends FlatSpec with Matchers {
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(1)) should be(
-      Map("z" -> WomIntegerType, "mul.result" -> WomIntegerType)
+        Map("z" -> WomIntegerType, "mul.result" -> WomIntegerType)
     )
     closureAll(subBlocks(1)).keys.toSet should be(Set("add.result"))
   }
@@ -89,10 +89,10 @@ class BlockTest extends FlatSpec with Matchers {
       Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(0)) should be(
-      Map(
-        "rain" -> WomIntegerType,
-        "inc.result" -> WomOptionalType(WomIntegerType)
-      )
+        Map(
+            "rain" -> WomIntegerType,
+            "inc.result" -> WomOptionalType(WomIntegerType)
+        )
     )
   }
 
@@ -125,7 +125,7 @@ class BlockTest extends FlatSpec with Matchers {
     closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
     closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
     closureAll(subBlocks(4)).keys.toSet should be(
-      Set("rain", "inc1.result", "flag")
+        Set("rain", "inc1.result", "flag")
     )
   }
 
@@ -163,12 +163,12 @@ class BlockTest extends FlatSpec with Matchers {
       parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val outputNodes = wf.innerGraph.outputNodes.toVector
     Block.outputClosure(outputNodes) should be(
-      Set(
-        "Add.result",
-        "SumArray.result",
-        "SumArray2.result",
-        "JoinMisc.result"
-      )
+        Set(
+            "Add.result",
+            "SumArray.result",
+            "SumArray2.result",
+            "JoinMisc.result"
+        )
     )
   }
 

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -27,7 +27,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "calculate closure correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     /*System.out.println(s"""|block #0 =
@@ -37,18 +38,27 @@ class BlockTest extends FlatSpec with Matchers {
     closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
     closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
     closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
-    closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
+    closureAll(subBlocks(4)).keys.toSet should be(
+      Set("rain", "inc1.result", "flag")
+    )
   }
 
   it should "calculate outputs correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
-    Block.outputs(subBlocks(1)) should be(Map("inc2.result" -> WomOptionalType(WomIntegerType)))
-    Block.outputs(subBlocks(2)) should be(Map("inc3.result" -> WomOptionalType(WomIntegerType)))
-    Block.outputs(subBlocks(3)) should be(Map("inc4.result" -> WomArrayType(WomIntegerType)))
+    Block.outputs(subBlocks(1)) should be(
+      Map("inc2.result" -> WomOptionalType(WomIntegerType))
+    )
+    Block.outputs(subBlocks(2)) should be(
+      Map("inc3.result" -> WomOptionalType(WomIntegerType))
+    )
+    Block.outputs(subBlocks(3)) should be(
+      Map("inc4.result" -> WomArrayType(WomIntegerType))
+    )
     Block.outputs(subBlocks(4)) should be(
       Map(
         "x" -> WomArrayType(WomIntegerType),
@@ -60,7 +70,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "calculate outputs correctly II" in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(1)) should be(
@@ -72,18 +83,24 @@ class BlockTest extends FlatSpec with Matchers {
   it should "handle block zero" in {
     val path = pathFromBasename("util", "block_zero.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (inNodes, _, subBlocks, outNodes) = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inNodes, _, subBlocks, outNodes) =
+      Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(0)) should be(
-      Map("rain" -> WomIntegerType, "inc.result" -> WomOptionalType(WomIntegerType))
+      Map(
+        "rain" -> WomIntegerType,
+        "inc.result" -> WomOptionalType(WomIntegerType)
+      )
     )
   }
 
   it should "block with two calls or more" in {
     val path = pathFromBasename("util", "block_with_three_calls.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size should be(1)
   }
@@ -91,7 +108,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "split a block with an expression after a call" in {
     val path = pathFromBasename("util", "expression_after_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size should be(2)
   }
@@ -99,20 +117,25 @@ class BlockTest extends FlatSpec with Matchers {
   it should "calculate closure correctly for WDL draft-2" in {
     val path = pathFromBasename("draft2", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
     closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
     closureAll(subBlocks(3)).keys.toSet should be(Set("rain"))
-    closureAll(subBlocks(4)).keys.toSet should be(Set("rain", "inc1.result", "flag"))
+    closureAll(subBlocks(4)).keys.toSet should be(
+      Set("rain", "inc1.result", "flag")
+    )
   }
 
   it should "calculate closure correctly for WDL draft-2 II" in {
     val path = pathFromBasename("draft2", "shapes.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) =
+      Block.split(wf.innerGraph, wfSourceCode)
 
     closureAll(subBlocks(0)).keys.toSet should be(Set("num"))
     closureAll(subBlocks(1)).keys.toSet should be(Set.empty)
@@ -121,7 +144,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "calculate closure for a workflow with expression outputs" in {
     val path = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val outputNodes = wf.innerGraph.outputNodes
     val exprOutputNodes: Vector[ExpressionBasedGraphOutputNode] =
@@ -135,18 +159,26 @@ class BlockTest extends FlatSpec with Matchers {
   it should "calculate output closure for a workflow" in {
     val path = pathFromBasename("compiler", "cast.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val outputNodes = wf.innerGraph.outputNodes.toVector
     Block.outputClosure(outputNodes) should be(
-      Set("Add.result", "SumArray.result", "SumArray2.result", "JoinMisc.result")
+      Set(
+        "Add.result",
+        "SumArray.result",
+        "SumArray2.result",
+        "JoinMisc.result"
+      )
     )
   }
 
   it should "identify simple calls even if they have optionals" in {
     val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) =
+      Block.split(wf.innerGraph, wfSourceCode)
 
     for (i <- 0 to 2) {
       Block.categorize(subBlocks(i)) shouldBe a[Block.CallDirect]
@@ -166,7 +198,8 @@ class BlockTest extends FlatSpec with Matchers {
       case _                            => throw new Exception("Could not find the workflow in the source")
     }
 
-    val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
+    val (inputNodes, _, subBlocks, outputNodes) =
+      Block.split(wf.innerGraph, wfSourceCode)
 
     Block.categorize(subBlocks(0)) shouldBe a[Block.ScatterOneCall]
   }
@@ -175,10 +208,12 @@ class BlockTest extends FlatSpec with Matchers {
     val path = pathFromBasename("nested", "two_levels.wdl")
     val wfSourceCode = Utils.readFileContent(path)
     val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     // sort from low to high according to the source lines.
-    val callsLoToHi = parseWomSourceFile.scanForCalls(wf.innerGraph, wfSourceCode)
+    val callsLoToHi =
+      parseWomSourceFile.scanForCalls(wf.innerGraph, wfSourceCode)
 
     val graph = wf.innerGraph
 
@@ -203,7 +238,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "handle calls to imported modules II" in {
     val path = pathFromBasename("draft2", "block_category.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("block_category.wdl")
@@ -221,7 +257,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "handle calls to imported modules" in {
     val path = pathFromBasename("draft2", "conditionals1.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals1.wdl")
@@ -247,7 +284,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "compile a workflow calling a subworkflow as a direct call" in {
     val path = pathFromBasename("draft2", "movies.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("movies.wdl")
@@ -279,7 +317,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "sort a block correctly in the presence of conditionals" in {
     val path = pathFromBasename("draft2", "conditionals3.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     val b0 = subBlocks(0)
@@ -294,7 +333,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "find the correct number of scatters" in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")
-    val (_, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, womBundle: WomBundle, allSources, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals_base.wdl")
@@ -313,7 +353,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "sort a subblock properly" in {
     val path = pathFromBasename("draft2", "conditionals4.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _) =
+      parseWomSourceFile.apply(path, List.empty)
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals4.wdl")
     }.get
@@ -338,7 +379,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "handle an empty workflow" in {
     val path = pathFromBasename("util", "empty_workflow.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size shouldBe (0)
   }
@@ -346,7 +388,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "detect when inputs are used as outputs" in {
     val path = pathFromBasename("util", "inputs_used_as_outputs.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (inputs, _, _, outputs) = Block.split(wf.innerGraph, wfSourceCode)
     Block.inputsUsedAsOutputs(inputs, outputs) shouldBe (Set("lane"))
   }
@@ -354,7 +397,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "create correct inputs for a workflow with an unpassed argument" in {
     val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (inputs, _, _, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val names = inputs.map { inDef =>
@@ -366,7 +410,8 @@ class BlockTest extends FlatSpec with Matchers {
   it should "account for arguments that have a default, but are not optional" in {
     val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf: WorkflowDefinition, _, _) =
+      parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val c0All = Block.closure(subBlocks(0))

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -25,10 +25,10 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "calculate closure correctly" in {
-    val path                           = pathFromBasename("util", "block_closure.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "block_closure.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     /*System.out.println(s"""|block #0 =
                                |${subBlocks(0).prettyPrintApproxWdl}}
@@ -41,27 +41,27 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "calculate outputs correctly" in {
-    val path                           = pathFromBasename("util", "block_closure.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "block_closure.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(1)) should be(Map("inc2.result" -> WomOptionalType(WomIntegerType)))
     Block.outputs(subBlocks(2)) should be(Map("inc3.result" -> WomOptionalType(WomIntegerType)))
     Block.outputs(subBlocks(3)) should be(Map("inc4.result" -> WomArrayType(WomIntegerType)))
     Block.outputs(subBlocks(4)) should be(
       Map(
-        "x"           -> WomArrayType(WomIntegerType),
+        "x" -> WomArrayType(WomIntegerType),
         "inc5.result" -> WomArrayType(WomOptionalType(WomIntegerType))
       )
     )
   }
 
   it should "calculate outputs correctly II" in {
-    val path                           = pathFromBasename("compiler", "wf_linear.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("compiler", "wf_linear.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(1)) should be(
       Map("z" -> WomIntegerType, "mul.result" -> WomIntegerType)
@@ -70,9 +70,9 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "handle block zero" in {
-    val path                              = pathFromBasename("util", "block_zero.wdl")
-    val wfSourceCode                      = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _)    = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val path = pathFromBasename("util", "block_zero.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (inNodes, _, subBlocks, outNodes) = Block.split(wf.innerGraph, wfSourceCode)
 
     Block.outputs(subBlocks(0)) should be(
@@ -81,26 +81,26 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "block with two calls or more" in {
-    val path                           = pathFromBasename("util", "block_with_three_calls.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "block_with_three_calls.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size should be(1)
   }
 
   it should "split a block with an expression after a call" in {
-    val path                           = pathFromBasename("util", "expression_after_call.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "expression_after_call.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size should be(2)
   }
 
   it should "calculate closure correctly for WDL draft-2" in {
-    val path                           = pathFromBasename("draft2", "block_closure.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("draft2", "block_closure.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     closureAll(subBlocks(1)).keys.toSet should be(Set("flag", "rain"))
     closureAll(subBlocks(2)).keys.toSet should be(Set("flag", "inc1.result"))
@@ -109,9 +109,9 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "calculate closure correctly for WDL draft-2 II" in {
-    val path                                    = pathFromBasename("draft2", "shapes.wdl")
-    val wfSourceCode                            = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _)          = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val path = pathFromBasename("draft2", "shapes.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
 
     closureAll(subBlocks(0)).keys.toSet should be(Set("num"))
@@ -119,8 +119,8 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "calculate closure for a workflow with expression outputs" in {
-    val path                           = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val outputNodes = wf.innerGraph.outputNodes
@@ -133,19 +133,19 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "calculate output closure for a workflow" in {
-    val path                           = pathFromBasename("compiler", "cast.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("compiler", "cast.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val outputNodes                    = wf.innerGraph.outputNodes.toVector
+    val outputNodes = wf.innerGraph.outputNodes.toVector
     Block.outputClosure(outputNodes) should be(
       Set("Add.result", "SumArray.result", "SumArray2.result", "JoinMisc.result")
     )
   }
 
   it should "identify simple calls even if they have optionals" in {
-    val path                                    = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
-    val wfSourceCode                            = Utils.readFileContent(path)
-    val (wf: WorkflowDefinition, _, _)          = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+    val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
     val (inputNodes, _, subBlocks, outputNodes) = Block.split(wf.innerGraph, wfSourceCode)
 
     for (i <- 0 to 2) {
@@ -154,7 +154,7 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "categorize correctly calls to subworkflows" taggedAs (EdgeTest) in {
-    val path                       = pathFromBasename("subworkflows", "trains.wdl")
+    val path = pathFromBasename("subworkflows", "trains.wdl")
     val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
     val (_, wfSourceCode) = sources.find {
       case (key, wdlCode) =>
@@ -172,9 +172,9 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "get subblocks" in {
-    val path                           = pathFromBasename("nested", "two_levels.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
-    val (_, womBundle, sources, _)     = parseWomSourceFile.apply(path, List.empty)
+    val path = pathFromBasename("nested", "two_levels.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
+    val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     // sort from low to high according to the source lines.
@@ -202,7 +202,7 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "handle calls to imported modules II" in {
-    val path                                            = pathFromBasename("draft2", "block_category.wdl")
+    val path = pathFromBasename("draft2", "block_category.wdl")
     val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
@@ -213,14 +213,14 @@ class BlockTest extends FlatSpec with Matchers {
       case Some(wf: WorkflowDefinition) => wf
       case _                            => throw new Exception("sanity")
     }
-    val graph                                   = wf.innerGraph
+    val graph = wf.innerGraph
     val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
     Block.categorize(subBlocks(0)) shouldBe a[Block.CondOneCall]
   }
 
   it should "handle calls to imported modules" in {
-    val path                                            = pathFromBasename("draft2", "conditionals1.wdl")
+    val path = pathFromBasename("draft2", "conditionals1.wdl")
     val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
@@ -231,7 +231,7 @@ class BlockTest extends FlatSpec with Matchers {
       case Some(wf: WorkflowDefinition) => wf
       case _                            => throw new Exception("sanity")
     }
-    val graph                                   = wf.innerGraph
+    val graph = wf.innerGraph
     val (inputNodes, _, subBlocks, outputNodes) = Block.split(graph, wfSource)
 
     for (i <- 0 to (subBlocks.length - 1)) {
@@ -246,7 +246,7 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "compile a workflow calling a subworkflow as a direct call" in {
-    val path                                            = pathFromBasename("draft2", "movies.wdl")
+    val path = pathFromBasename("draft2", "movies.wdl")
     val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
@@ -277,12 +277,12 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "sort a block correctly in the presence of conditionals" in {
-    val path                           = pathFromBasename("draft2", "conditionals3.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("draft2", "conditionals3.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
-    val b0                   = subBlocks(0)
+    val b0 = subBlocks(0)
 
     val exprVec: Vector[ExposedExpressionNode] = b0.nodes.collect {
       case node: ExposedExpressionNode => node
@@ -293,7 +293,7 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "find the correct number of scatters" in {
-    val path                                     = pathFromBasename("draft2", "conditionals_base.wdl")
+    val path = pathFromBasename("draft2", "conditionals_base.wdl")
     val (_, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
@@ -312,7 +312,7 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "sort a subblock properly" in {
-    val path                                            = pathFromBasename("draft2", "conditionals4.wdl")
+    val path = pathFromBasename("draft2", "conditionals4.wdl")
     val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals4.wdl")
@@ -336,26 +336,26 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "handle an empty workflow" in {
-    val path                           = pathFromBasename("util", "empty_workflow.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "empty_workflow.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
     subBlocks.size shouldBe (0)
   }
 
   it should "detect when inputs are used as outputs" in {
-    val path                           = pathFromBasename("util", "inputs_used_as_outputs.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("util", "inputs_used_as_outputs.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (inputs, _, _, outputs)        = Block.split(wf.innerGraph, wfSourceCode)
+    val (inputs, _, _, outputs) = Block.split(wf.innerGraph, wfSourceCode)
     Block.inputsUsedAsOutputs(inputs, outputs) shouldBe (Set("lane"))
   }
 
   it should "create correct inputs for a workflow with an unpassed argument" in {
-    val path                           = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (inputs, _, _, _)              = Block.split(wf.innerGraph, wfSourceCode)
+    val (inputs, _, _, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val names = inputs.map { inDef =>
       inDef.identifier.localName.value
@@ -364,10 +364,10 @@ class BlockTest extends FlatSpec with Matchers {
   }
 
   it should "account for arguments that have a default, but are not optional" in {
-    val path                           = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
-    val wfSourceCode                   = Utils.readFileContent(path)
+    val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
+    val wfSourceCode = Utils.readFileContent(path)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
-    val (_, _, subBlocks, _)           = Block.split(wf.innerGraph, wfSourceCode)
+    val (_, _, subBlocks, _) = Block.split(wf.innerGraph, wfSourceCode)
 
     val c0All = Block.closure(subBlocks(0))
     c0All.keys.toSet should be(Set("unpassed_arg_default"))

--- a/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
+++ b/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
@@ -134,10 +134,10 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
         val price: Float =
           if (pricingInfo) awsOnDemandHourlyPriceTable(internalName)
           else 0
-        val traits   = fields("traits").asJsObject.fields
+        val traits = fields("traits").asJsObject.fields
         val memoryMB = intOfJs(traits("totalMemoryMB"))
-        val diskGB   = intOfJs(traits("ephemeralStorageGB"))
-        val cpu      = intOfJs(traits("numCores"))
+        val diskGB = intOfJs(traits("ephemeralStorageGB"))
+        val cpu = intOfJs(traits("numCores"))
         DxInstanceType(name, memoryMB, diskGB, cpu, price, Vector.empty, false)
     }.toVector
     InstanceTypeDB(pricingInfo, db)
@@ -203,8 +203,8 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     )
   }
 
-  val dbFull     = genTestDB(true)
-  val dbOpaque   = InstanceTypeDB.opaquePrices(dbFull)
+  val dbFull = genTestDB(true)
+  val dbOpaque = InstanceTypeDB.opaquePrices(dbFull)
   val dbNoPrices = genTestDB(false)
 
   it should "Work even without access to pricing information" in {
@@ -219,7 +219,7 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
   }
 
   it should "perform JSON serialization" in {
-    val js  = dbFull.toJson
+    val js = dbFull.toJson
     val db2 = js.asJsObject.convertTo[InstanceTypeDB]
     dbFull should equal(db2)
   }

--- a/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
+++ b/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
@@ -148,13 +148,13 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
   private def useDB(db: InstanceTypeDB): Unit = {
     db.chooseAttrs(None, None, None, None) should equal("mem1_ssd1_x2")
     db.chooseAttrs(Some(3 * 1024), Some(100), Some(5), None) should equal(
-      "mem1_ssd1_x8"
+        "mem1_ssd1_x8"
     )
     db.chooseAttrs(Some(2 * 1024), Some(20), None, None) should equal(
-      "mem1_ssd1_x2"
+        "mem1_ssd1_x2"
     )
     db.chooseAttrs(Some(30 * 1024), Some(128), Some(8), None) should equal(
-      "mem3_ssd1_x8"
+        "mem3_ssd1_x8"
     )
 
     assertThrows[Exception] {
@@ -163,69 +163,69 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     }
 
     db.apply(
-      InstanceTypeDB.parse(
-        None,
-        Some(WomString("3 GB")),
-        Some(WomString("local-disk 10 HDD")),
-        Some(WomString("1")),
-        None
-      )
+        InstanceTypeDB.parse(
+            None,
+            Some(WomString("3 GB")),
+            Some(WomString("local-disk 10 HDD")),
+            Some(WomString("1")),
+            None
+        )
     ) should equal("mem1_ssd1_x2")
     db.apply(
-      InstanceTypeDB.parse(
-        None,
-        Some(WomString("37 GB")),
-        Some(WomString("local-disk 10 HDD")),
-        Some(WomString("6")),
-        None
-      )
+        InstanceTypeDB.parse(
+            None,
+            Some(WomString("37 GB")),
+            Some(WomString("local-disk 10 HDD")),
+            Some(WomString("6")),
+            None
+        )
     ) should equal("mem3_ssd1_x8")
     db.apply(
-      InstanceTypeDB
-        .parse(
-          None,
-          Some(WomString("2 GB")),
-          Some(WomString("local-disk 100 HDD")),
-          None,
-          None
-        )
+        InstanceTypeDB
+          .parse(
+              None,
+              Some(WomString("2 GB")),
+              Some(WomString("local-disk 100 HDD")),
+              None,
+              None
+          )
     ) should equal("mem1_ssd1_x8")
     db.apply(
-      InstanceTypeDB
-        .parse(
-          None,
-          Some(WomString("2.1GB")),
-          Some(WomString("local-disk 100 HDD")),
-          None,
-          None
-        )
+        InstanceTypeDB
+          .parse(
+              None,
+              Some(WomString("2.1GB")),
+              Some(WomString("local-disk 100 HDD")),
+              None,
+              None
+          )
     ) should equal("mem1_ssd1_x8")
 
     db.apply(
-      InstanceTypeDB
-        .parse(Some(WomString("mem3_ssd1_x8")), None, None, None, None)
+        InstanceTypeDB
+          .parse(Some(WomString("mem3_ssd1_x8")), None, None, None, None)
     ) should equal(
-      "mem3_ssd1_x8"
+        "mem3_ssd1_x8"
     )
 
     db.apply(
-      InstanceTypeDB.parse(
-        None,
-        Some(WomString("235 GB")),
-        Some(WomString("local-disk 550 HDD")),
-        Some(WomString("32")),
-        None
-      )
+        InstanceTypeDB.parse(
+            None,
+            Some(WomString("235 GB")),
+            Some(WomString("local-disk 550 HDD")),
+            Some(WomString("32")),
+            None
+        )
     ) should equal("mem3_ssd1_x32")
     db.apply(
-      InstanceTypeDB
-        .parse(Some(WomString("mem3_ssd1_x32")), None, None, None, None)
+        InstanceTypeDB
+          .parse(Some(WomString("mem3_ssd1_x32")), None, None, None, None)
     ) should equal(
-      "mem3_ssd1_x32"
+        "mem3_ssd1_x32"
     )
 
     db.apply(InstanceTypeDB.parse(None, None, None, Some(WomString("8")), None)) should equal(
-      "mem1_ssd1_x8"
+        "mem1_ssd1_x8"
     )
   }
 
@@ -238,7 +238,7 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     dbNoPrices.chooseAttrs(None, None, None, None) should equal("mem1_ssd1_x2")
 
     dbNoPrices.chooseAttrs(Some(1000), None, Some(3), None) should equal(
-      "mem1_ssd1_x4"
+        "mem1_ssd1_x4"
     )
   }
 
@@ -278,11 +278,11 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     // memory specification
     InstanceTypeDB.parse(None, Some(WomString("230MB")), None, None, None) shouldBe
       InstanceTypeReq(
-        None,
-        Some((230 * 1000 * 1000) / (1024 * 1024).toInt),
-        None,
-        None,
-        None
+          None,
+          Some((230 * 1000 * 1000) / (1024 * 1024).toInt),
+          None,
+          None,
+          None
       )
 
     InstanceTypeDB.parse(None, Some(WomString("230MiB")), None, None, None) shouldBe
@@ -290,11 +290,11 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     InstanceTypeDB.parse(None, Some(WomString("230GB")), None, None, None) shouldBe
       InstanceTypeReq(
-        None,
-        Some(((230d * 1000d * 1000d * 1000d) / (1024d * 1024d)).toInt),
-        None,
-        None,
-        None
+          None,
+          Some(((230d * 1000d * 1000d * 1000d) / (1024d * 1024d)).toInt),
+          None,
+          None,
+          None
       )
 
     InstanceTypeDB.parse(None, Some(WomString("230GiB")), None, None, None) shouldBe
@@ -302,11 +302,11 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     InstanceTypeDB.parse(None, Some(WomString("1000 TB")), None, None, None) shouldBe
       InstanceTypeReq(
-        None,
-        Some(((1000d * 1000d * 1000d * 1000d * 1000d) / (1024d * 1024d)).toInt),
-        None,
-        None,
-        None
+          None,
+          Some(((1000d * 1000d * 1000d * 1000d * 1000d) / (1024d * 1024d)).toInt),
+          None,
+          None,
+          None
       )
 
     InstanceTypeDB.parse(None, Some(WomString("1000 TiB")), None, None, None) shouldBe
@@ -314,11 +314,11 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     assertThrows[Exception] {
       InstanceTypeDB.parse(
-        None,
-        Some(WomString("230 44 34 GB")),
-        None,
-        None,
-        None
+          None,
+          Some(WomString("230 44 34 GB")),
+          None,
+          None,
+          None
       )
     }
     assertThrows[Exception] {
@@ -337,20 +337,20 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     // disk spec
     assertThrows[Exception] {
       InstanceTypeDB.parse(
-        None,
-        None,
-        Some(WomString("just give me a disk")),
-        None,
-        None
+          None,
+          None,
+          Some(WomString("just give me a disk")),
+          None,
+          None
       )
     }
     assertThrows[Exception] {
       InstanceTypeDB.parse(
-        None,
-        None,
-        Some(WomString("local-disk xxxx")),
-        None,
-        None
+          None,
+          None,
+          Some(WomString("local-disk xxxx")),
+          None,
+          None
       )
     }
     assertThrows[Exception] {
@@ -362,18 +362,18 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       InstanceTypeDB.parse(None, None, None, Some(WomString("xxyy")), None)
     }
     InstanceTypeDB.parse(None, None, None, Some(WomInteger(1)), None) shouldBe InstanceTypeReq(
-      None,
-      None,
-      None,
-      Some(1),
-      None
+        None,
+        None,
+        None,
+        Some(1),
+        None
     )
     InstanceTypeDB.parse(None, None, None, Some(WomFloat(1.2)), None) shouldBe InstanceTypeReq(
-      None,
-      None,
-      None,
-      Some(1),
-      None
+        None,
+        None,
+        None,
+        Some(1),
+        None
     )
 
     assertThrows[Exception] {
@@ -382,11 +382,11 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     // gpu
     InstanceTypeDB.parse(
-      None,
-      Some(WomString("1000 TiB")),
-      None,
-      None,
-      Some(WomBoolean(true))
+        None,
+        Some(WomString("1000 TiB")),
+        None,
+        None,
+        Some(WomBoolean(true))
     ) shouldBe
       InstanceTypeReq(None, Some(1000 * 1024 * 1024), None, None, Some(true))
 
@@ -396,60 +396,60 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
   it should "work on large instances (JIRA-1258)" in {
     val db = InstanceTypeDB(
-      true,
-      Vector(
-        DxInstanceType(
-          "mem3_ssd1_x32",
-          245751,
-          32,
-          597,
-          13.0.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
-        ),
-        DxInstanceType(
-          "mem4_ssd1_x128",
-          1967522,
-          128,
-          3573,
-          14.0.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
+        true,
+        Vector(
+            DxInstanceType(
+                "mem3_ssd1_x32",
+                245751,
+                32,
+                597,
+                13.0.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            ),
+            DxInstanceType(
+                "mem4_ssd1_x128",
+                1967522,
+                128,
+                3573,
+                14.0.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            )
         )
-      )
     )
 
     db.chooseAttrs(Some(239 * 1024), Some(18), Some(32), None) should equal(
-      "mem3_ssd1_x32"
+        "mem3_ssd1_x32"
     )
     db.chooseAttrs(Some(240 * 1024), Some(18), Some(32), None) should equal(
-      "mem4_ssd1_x128"
+        "mem4_ssd1_x128"
     )
   }
 
   it should "prefer v2 instances over v1's" in {
     val db = InstanceTypeDB(
-      true,
-      Vector(
-        DxInstanceType(
-          "mem1_ssd1_v2_x4",
-          8000,
-          80,
-          4,
-          0.2.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
-        ),
-        DxInstanceType(
-          "mem1_ssd1_x4",
-          8000,
-          80,
-          4,
-          0.2.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
+        true,
+        Vector(
+            DxInstanceType(
+                "mem1_ssd1_v2_x4",
+                8000,
+                80,
+                4,
+                0.2.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            ),
+            DxInstanceType(
+                "mem1_ssd1_x4",
+                8000,
+                80,
+                4,
+                0.2.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            )
         )
-      )
     )
 
     db.chooseAttrs(None, None, Some(4), None) should equal("mem1_ssd1_v2_x4")
@@ -457,40 +457,40 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
   it should "respect requests for GPU instances" taggedAs (EdgeTest) in {
     val db = InstanceTypeDB(
-      true,
-      Vector(
-        DxInstanceType(
-          "mem1_ssd1_v2_x4",
-          8000,
-          80,
-          4,
-          0.2.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
-        ),
-        DxInstanceType(
-          "mem1_ssd1_x4",
-          8000,
-          80,
-          4,
-          0.2.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          false
-        ),
-        DxInstanceType(
-          "mem3_ssd1_gpu_x8",
-          30000,
-          100,
-          8,
-          1.0.toFloat,
-          Vector(("Ubuntu", "16.04")),
-          true
+        true,
+        Vector(
+            DxInstanceType(
+                "mem1_ssd1_v2_x4",
+                8000,
+                80,
+                4,
+                0.2.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            ),
+            DxInstanceType(
+                "mem1_ssd1_x4",
+                8000,
+                80,
+                4,
+                0.2.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                false
+            ),
+            DxInstanceType(
+                "mem3_ssd1_gpu_x8",
+                30000,
+                100,
+                8,
+                1.0.toFloat,
+                Vector(("Ubuntu", "16.04")),
+                true
+            )
         )
-      )
     )
 
     db.chooseAttrs(None, None, Some(4), Some(true)) should equal(
-      "mem3_ssd1_gpu_x8"
+        "mem3_ssd1_gpu_x8"
     )
 
     assertThrows[Exception] {

--- a/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
+++ b/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
@@ -112,7 +112,8 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       }
     }
     val awsOnDemandHourlyPriceTable: Map[String, Float] = {
-      val fields: Map[String, JsValue] = awsOnDemandHourlyPrice.parseJson.asJsObject.fields
+      val fields: Map[String, JsValue] =
+        awsOnDemandHourlyPrice.parseJson.asJsObject.fields
       fields.map {
         case (name, v) =>
           val price: Float = v match {
@@ -123,7 +124,8 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       }.toMap
     }
 
-    val allInstances: Map[String, JsValue] = instanceList.parseJson.asJsObject.fields
+    val allInstances: Map[String, JsValue] =
+      instanceList.parseJson.asJsObject.fields
     val db = allInstances.map {
       case (name, v) =>
         val fields: Map[String, JsValue] = v.asJsObject.fields
@@ -145,9 +147,15 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
   private def useDB(db: InstanceTypeDB): Unit = {
     db.chooseAttrs(None, None, None, None) should equal("mem1_ssd1_x2")
-    db.chooseAttrs(Some(3 * 1024), Some(100), Some(5), None) should equal("mem1_ssd1_x8")
-    db.chooseAttrs(Some(2 * 1024), Some(20), None, None) should equal("mem1_ssd1_x2")
-    db.chooseAttrs(Some(30 * 1024), Some(128), Some(8), None) should equal("mem3_ssd1_x8")
+    db.chooseAttrs(Some(3 * 1024), Some(100), Some(5), None) should equal(
+      "mem1_ssd1_x8"
+    )
+    db.chooseAttrs(Some(2 * 1024), Some(20), None, None) should equal(
+      "mem1_ssd1_x2"
+    )
+    db.chooseAttrs(Some(30 * 1024), Some(128), Some(8), None) should equal(
+      "mem3_ssd1_x8"
+    )
 
     assertThrows[Exception] {
       // no instance with 1024 CPUs
@@ -174,14 +182,29 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     ) should equal("mem3_ssd1_x8")
     db.apply(
       InstanceTypeDB
-        .parse(None, Some(WomString("2 GB")), Some(WomString("local-disk 100 HDD")), None, None)
+        .parse(
+          None,
+          Some(WomString("2 GB")),
+          Some(WomString("local-disk 100 HDD")),
+          None,
+          None
+        )
     ) should equal("mem1_ssd1_x8")
     db.apply(
       InstanceTypeDB
-        .parse(None, Some(WomString("2.1GB")), Some(WomString("local-disk 100 HDD")), None, None)
+        .parse(
+          None,
+          Some(WomString("2.1GB")),
+          Some(WomString("local-disk 100 HDD")),
+          None,
+          None
+        )
     ) should equal("mem1_ssd1_x8")
 
-    db.apply(InstanceTypeDB.parse(Some(WomString("mem3_ssd1_x8")), None, None, None, None)) should equal(
+    db.apply(
+      InstanceTypeDB
+        .parse(Some(WomString("mem3_ssd1_x8")), None, None, None, None)
+    ) should equal(
       "mem3_ssd1_x8"
     )
 
@@ -194,7 +217,10 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
         None
       )
     ) should equal("mem3_ssd1_x32")
-    db.apply(InstanceTypeDB.parse(Some(WomString("mem3_ssd1_x32")), None, None, None, None)) should equal(
+    db.apply(
+      InstanceTypeDB
+        .parse(Some(WomString("mem3_ssd1_x32")), None, None, None, None)
+    ) should equal(
       "mem3_ssd1_x32"
     )
 
@@ -211,7 +237,9 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     // parameters are:          RAM,     disk,     cores
     dbNoPrices.chooseAttrs(None, None, None, None) should equal("mem1_ssd1_x2")
 
-    dbNoPrices.chooseAttrs(Some(1000), None, Some(3), None) should equal("mem1_ssd1_x4")
+    dbNoPrices.chooseAttrs(Some(1000), None, Some(3), None) should equal(
+      "mem1_ssd1_x4"
+    )
   }
 
   it should "Choose reasonable platform instance types" in {
@@ -249,7 +277,13 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     // memory specification
     InstanceTypeDB.parse(None, Some(WomString("230MB")), None, None, None) shouldBe
-      InstanceTypeReq(None, Some((230 * 1000 * 1000) / (1024 * 1024).toInt), None, None, None)
+      InstanceTypeReq(
+        None,
+        Some((230 * 1000 * 1000) / (1024 * 1024).toInt),
+        None,
+        None,
+        None
+      )
 
     InstanceTypeDB.parse(None, Some(WomString("230MiB")), None, None, None) shouldBe
       InstanceTypeReq(None, Some(230), None, None, None)
@@ -279,7 +313,13 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       InstanceTypeReq(None, Some(1000 * 1024 * 1024), None, None, None)
 
     assertThrows[Exception] {
-      InstanceTypeDB.parse(None, Some(WomString("230 44 34 GB")), None, None, None)
+      InstanceTypeDB.parse(
+        None,
+        Some(WomString("230 44 34 GB")),
+        None,
+        None,
+        None
+      )
     }
     assertThrows[Exception] {
       InstanceTypeDB.parse(None, Some(WomString("230.x GB")), None, None, None)
@@ -296,10 +336,22 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
 
     // disk spec
     assertThrows[Exception] {
-      InstanceTypeDB.parse(None, None, Some(WomString("just give me a disk")), None, None)
+      InstanceTypeDB.parse(
+        None,
+        None,
+        Some(WomString("just give me a disk")),
+        None,
+        None
+      )
     }
     assertThrows[Exception] {
-      InstanceTypeDB.parse(None, None, Some(WomString("local-disk xxxx")), None, None)
+      InstanceTypeDB.parse(
+        None,
+        None,
+        Some(WomString("local-disk xxxx")),
+        None,
+        None
+      )
     }
     assertThrows[Exception] {
       InstanceTypeDB.parse(None, None, Some(WomInteger(1024)), None, None)
@@ -329,7 +381,13 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     }
 
     // gpu
-    InstanceTypeDB.parse(None, Some(WomString("1000 TiB")), None, None, Some(WomBoolean(true))) shouldBe
+    InstanceTypeDB.parse(
+      None,
+      Some(WomString("1000 TiB")),
+      None,
+      None,
+      Some(WomBoolean(true))
+    ) shouldBe
       InstanceTypeReq(None, Some(1000 * 1024 * 1024), None, None, Some(true))
 
     InstanceTypeDB.parse(None, None, None, None, Some(WomBoolean(false))) shouldBe
@@ -361,8 +419,12 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       )
     )
 
-    db.chooseAttrs(Some(239 * 1024), Some(18), Some(32), None) should equal("mem3_ssd1_x32")
-    db.chooseAttrs(Some(240 * 1024), Some(18), Some(32), None) should equal("mem4_ssd1_x128")
+    db.chooseAttrs(Some(239 * 1024), Some(18), Some(32), None) should equal(
+      "mem3_ssd1_x32"
+    )
+    db.chooseAttrs(Some(240 * 1024), Some(18), Some(32), None) should equal(
+      "mem4_ssd1_x128"
+    )
   }
 
   it should "prefer v2 instances over v1's" in {
@@ -378,7 +440,15 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
           Vector(("Ubuntu", "16.04")),
           false
         ),
-        DxInstanceType("mem1_ssd1_x4", 8000, 80, 4, 0.2.toFloat, Vector(("Ubuntu", "16.04")), false)
+        DxInstanceType(
+          "mem1_ssd1_x4",
+          8000,
+          80,
+          4,
+          0.2.toFloat,
+          Vector(("Ubuntu", "16.04")),
+          false
+        )
       )
     )
 
@@ -419,7 +489,9 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
       )
     )
 
-    db.chooseAttrs(None, None, Some(4), Some(true)) should equal("mem3_ssd1_gpu_x8")
+    db.chooseAttrs(None, None, Some(4), Some(true)) should equal(
+      "mem3_ssd1_gpu_x8"
+    )
 
     assertThrows[Exception] {
       // No non-GPU instance has 8 cpus

--- a/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
+++ b/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
@@ -125,8 +125,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) =
       parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
-      "type" -> MetaValueElementString("native"),
-      "id" -> MetaValueElementString("applet-xxxx")
+        "type" -> MetaValueElementString("native"),
+        "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 
@@ -154,8 +154,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) =
       parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
-      "type" -> MetaValueElementString("native"),
-      "id" -> MetaValueElementString("applet-xxxx")
+        "type" -> MetaValueElementString("native"),
+        "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 
@@ -207,8 +207,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) =
       parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
-      "type" -> MetaValueElementString("native"),
-      "id" -> MetaValueElementString("applet-xxxx")
+        "type" -> MetaValueElementString("native"),
+        "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 }

--- a/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
+++ b/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
@@ -8,31 +8,31 @@ import wom.callable.MetaValueElement._
 // These tests involve compilation -without- access to the platform.
 //
 class ParseWomSourceFileTest extends FlatSpec with Matchers {
-    private val parseWomSourceFile = ParseWomSourceFile(false)
+  private val parseWomSourceFile = ParseWomSourceFile(false)
 
-    private def normalize(s: String) : String = {
-        s.replaceAll("(?s)\\s+", " ").trim
-    }
+  private def normalize(s: String): String = {
+    s.replaceAll("(?s)\\s+", " ").trim
+  }
 
-    it should "find task sources" in {
-        val srcCode =
-            """|task hello {
+  it should "find task sources" in {
+    val srcCode =
+      """|task hello {
                |   Milo is selling the mess hall chairs!
                |}
                |""".stripMargin
 
-        val taskDir = parseWomSourceFile.scanForTasks(srcCode)
-        taskDir.size should equal(1)
-        val helloTask = taskDir.get("hello")
-        inside (helloTask) {
-            case Some(x) =>
-                normalize(x) should equal(normalize(srcCode))
-        }
+    val taskDir = parseWomSourceFile.scanForTasks(srcCode)
+    taskDir.size should equal(1)
+    val helloTask = taskDir.get("hello")
+    inside(helloTask) {
+      case Some(x) =>
+        normalize(x) should equal(normalize(srcCode))
     }
+  }
 
-    it should "find task source in complex WDL task" in {
-        val srcCode =
-            """|task sub {
+  it should "find task source in complex WDL task" in {
+    val srcCode =
+      """|task sub {
                |   Int a
                |   Int b
                |   command {
@@ -41,18 +41,18 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val taskDir = parseWomSourceFile.scanForTasks(srcCode)
-        taskDir.size should equal(1)
-        val subTask = taskDir.get("sub")
-        inside (subTask) {
-            case Some(x) =>
-                normalize(x) should equal(normalize(srcCode))
-        }
+    val taskDir = parseWomSourceFile.scanForTasks(srcCode)
+    taskDir.size should equal(1)
+    val subTask = taskDir.get("sub")
+    inside(subTask) {
+      case Some(x) =>
+        normalize(x) should equal(normalize(srcCode))
     }
+  }
 
-    it should "find sources in a script with two tasks" in {
-        val srcCode =
-            """|task sub {
+  it should "find sources in a script with two tasks" in {
+    val srcCode =
+      """|task sub {
                |   Int a
                |   Int b
                |   command {
@@ -66,22 +66,22 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val taskDir = parseWomSourceFile.scanForTasks(srcCode)
-        taskDir.size should equal(2)
-        inside (taskDir.get("sub")) {
-            case Some(x) =>
-                x should include ("ls -lR")
-        }
-        inside (taskDir.get("major")) {
-            case Some(x) =>
-                x should include ("tree")
-                x should include ("{ }")
-        }
+    val taskDir = parseWomSourceFile.scanForTasks(srcCode)
+    taskDir.size should equal(2)
+    inside(taskDir.get("sub")) {
+      case Some(x) =>
+        x should include("ls -lR")
     }
+    inside(taskDir.get("major")) {
+      case Some(x) =>
+        x should include("tree")
+        x should include("{ }")
+    }
+  }
 
-    it should "find source task in a WDL 1.0 script" in {
-        val srcCode =
-            """|version 1.0
+  it should "find source task in a WDL 1.0 script" in {
+    val srcCode =
+      """|version 1.0
                |
                |task Add {
                |    input {
@@ -97,17 +97,17 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val taskDir = parseWomSourceFile.scanForTasks(srcCode)
-        taskDir.size should equal(1)
-        inside (taskDir.get("Add")) {
-            case Some(x) =>
-                x should include ("echo $((${a} + ${b}))")
-        }
+    val taskDir = parseWomSourceFile.scanForTasks(srcCode)
+    taskDir.size should equal(1)
+    inside(taskDir.get("Add")) {
+      case Some(x) =>
+        x should include("echo $((${a} + ${b}))")
     }
+  }
 
-    it should "parse the meta section in wdl draft2" in {
-        val srcCode =
-            """|task native_sum_012 {
+  it should "parse the meta section in wdl draft2" in {
+    val srcCode =
+      """|task native_sum_012 {
                |  Int? a
                |  Int? b
                |  command {}
@@ -122,14 +122,16 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-        val (task : CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
-        task.meta shouldBe (Map("type" -> MetaValueElementString("native"),
-                                "id" -> MetaValueElementString("applet-xxxx")))
-    }
+    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    task.meta shouldBe (Map(
+      "type" -> MetaValueElementString("native"),
+      "id"   -> MetaValueElementString("applet-xxxx")
+    ))
+  }
 
-    it should "parse the meta section in wdl 1.0" in {
-        val srcCode =
-            """|version 1.0
+  it should "parse the meta section in wdl 1.0" in {
+    val srcCode =
+      """|version 1.0
                |
                |task native_sum_012 {
                |  input {
@@ -148,17 +150,19 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-        val (task : CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
-        task.meta shouldBe (Map("type" -> MetaValueElementString("native"),
-                                "id" -> MetaValueElementString("applet-xxxx")))
-    }
+    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    task.meta shouldBe (Map(
+      "type" -> MetaValueElementString("native"),
+      "id"   -> MetaValueElementString("applet-xxxx")
+    ))
+  }
 
-    // The scanForTasks method takes apart the source WOM code, and then puts
-    // it back together. Check that it isn't discarding the pipe characters ('|'),
-    // or anything else.
-    it should "not omit symbols in the command section" in {
-        val srcCode =
-            """|task echo_line_split {
+  // The scanForTasks method takes apart the source WOM code, and then puts
+  // it back together. Check that it isn't discarding the pipe characters ('|'),
+  // or anything else.
+  it should "not omit symbols in the command section" in {
+    val srcCode =
+      """|task echo_line_split {
                |
                |  command {
                |  echo 1 hello world | sed 's/world/wdl/'
@@ -171,15 +175,15 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |  }
                |}""".stripMargin
 
-        val taskDir = parseWomSourceFile.scanForTasks(srcCode)
-        taskDir.size should equal(1)
-        val taskSourceCode : String = taskDir.values.head
-        taskSourceCode shouldBe(srcCode)
-    }
+    val taskDir = parseWomSourceFile.scanForTasks(srcCode)
+    taskDir.size should equal(1)
+    val taskSourceCode: String = taskDir.values.head
+    taskSourceCode shouldBe (srcCode)
+  }
 
-    it should "parse the meta section in wdl 1.1/development" taggedAs(EdgeTest) in {
-        val srcCode =
-            """|version development
+  it should "parse the meta section in wdl 1.1/development" taggedAs (EdgeTest) in {
+    val srcCode =
+      """|version development
                |
                |task add {
                |  input {
@@ -198,8 +202,10 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-        val (task : CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
-        task.meta shouldBe (Map("type" -> MetaValueElementString("native"),
-                                "id" -> MetaValueElementString("applet-xxxx")))
-    }
+    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    task.meta shouldBe (Map(
+      "type" -> MetaValueElementString("native"),
+      "id"   -> MetaValueElementString("applet-xxxx")
+    ))
+  }
 }

--- a/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
+++ b/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
@@ -122,7 +122,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: CallableTaskDefinition, _) =
+      parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
       "id" -> MetaValueElementString("applet-xxxx")
@@ -150,7 +151,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: CallableTaskDefinition, _) =
+      parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
       "id" -> MetaValueElementString("applet-xxxx")
@@ -202,7 +204,8 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
                |
                |""".stripMargin
 
-    val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: CallableTaskDefinition, _) =
+      parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
       "id" -> MetaValueElementString("applet-xxxx")

--- a/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
+++ b/src/test/scala/dxWDL/util/ParseWomSourceFileTest.scala
@@ -125,7 +125,7 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
-      "id"   -> MetaValueElementString("applet-xxxx")
+      "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 
@@ -153,7 +153,7 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
-      "id"   -> MetaValueElementString("applet-xxxx")
+      "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 
@@ -205,7 +205,7 @@ class ParseWomSourceFileTest extends FlatSpec with Matchers {
     val (task: CallableTaskDefinition, _) = parseWomSourceFile.parseWdlTask(srcCode)
     task.meta shouldBe (Map(
       "type" -> MetaValueElementString("native"),
-      "id"   -> MetaValueElementString("applet-xxxx")
+      "id" -> MetaValueElementString("applet-xxxx")
     ))
   }
 }

--- a/src/test/scala/dxWDL/util/TypeEvalTest.scala
+++ b/src/test/scala/dxWDL/util/TypeEvalTest.scala
@@ -19,12 +19,12 @@ class TypeEvalTest extends FlatSpec with Matchers {
     val languageFactory = new WdlDraft3LanguageFactory(ConfigFactory.empty())
     val bundle =
       languageFactory.getWomBundle(
-        sourceCode,
-        None,
-        "{}",
-        List.empty,
-        List(languageFactory),
-        false
+          sourceCode,
+          None,
+          "{}",
+          List.empty,
+          List(languageFactory),
+          false
       )
     bundle match {
       case Right(bn) =>
@@ -91,7 +91,7 @@ class TypeEvalTest extends FlatSpec with Matchers {
       case Some(call) => call
     }
     call.getClass.toString should equal(
-      "class wom.callable.CallableTaskDefinition"
+        "class wom.callable.CallableTaskDefinition"
     )
 
     call.inputs.foreach {

--- a/src/test/scala/dxWDL/util/TypeEvalTest.scala
+++ b/src/test/scala/dxWDL/util/TypeEvalTest.scala
@@ -15,19 +15,20 @@ import dxWDL.base.AppInternalException
 
 class TypeEvalTest extends FlatSpec with Matchers {
 
-    def parseWdlCode(sourceCode: String) : WomBundle = {
-        val languageFactory = new WdlDraft3LanguageFactory(ConfigFactory.empty())
-        val bundle = languageFactory.getWomBundle(sourceCode, None, "{}", List.empty, List(languageFactory), false)
-        bundle match {
-            case Right(bn) =>
-                bn
-            case Left(errors) =>
-                throw new Exception(errors.toString)
-        }
+  def parseWdlCode(sourceCode: String): WomBundle = {
+    val languageFactory = new WdlDraft3LanguageFactory(ConfigFactory.empty())
+    val bundle =
+      languageFactory.getWomBundle(sourceCode, None, "{}", List.empty, List(languageFactory), false)
+    bundle match {
+      case Right(bn) =>
+        bn
+      case Left(errors) =>
+        throw new Exception(errors.toString)
     }
+  }
 
-    val wdlCode =
-        """|version 1.0
+  val wdlCode =
+    """|version 1.0
            |
            |task Add {
            |  input {
@@ -56,38 +57,37 @@ class TypeEvalTest extends FlatSpec with Matchers {
            |}
            |""".stripMargin
 
-
-    // Figure out the type of an expression
-    def evalType(expr: WomExpression,
-                 inputTypes: Map[String, WomType]) : WomType = {
-        val result: ErrorOr[WomType] = expr.evaluateType(inputTypes)
-        result match {
-            case Invalid(_) =>
-                throw new Exception(s"could not evaluate type of expression ${expr}")
-            case Valid(t: WomType) => t
-        }
+  // Figure out the type of an expression
+  def evalType(expr: WomExpression, inputTypes: Map[String, WomType]): WomType = {
+    val result: ErrorOr[WomType] = expr.evaluateType(inputTypes)
+    result match {
+      case Invalid(_) =>
+        throw new Exception(s"could not evaluate type of expression ${expr}")
+      case Valid(t: WomType) => t
     }
+  }
 
-    it should "correctly evaluate expression types in call" in {
-        val bundle = parseWdlCode(wdlCode)
-        val wf: WorkflowDefinition = bundle.primaryCallable match {
-            case Some(w : WorkflowDefinition) => w
-            case _ => throw new Exception("not a workflow")
-        }
-        wf.name should equal("foo")
+  it should "correctly evaluate expression types in call" in {
+    val bundle = parseWdlCode(wdlCode)
+    val wf: WorkflowDefinition = bundle.primaryCallable match {
+      case Some(w: WorkflowDefinition) => w
+      case _                           => throw new Exception("not a workflow")
+    }
+    wf.name should equal("foo")
 
-        val call:Callable = bundle.allCallables.get("Add") match {
-            case None => throw new AppInternalException(s"Call Add not found in WDL file")
-            case Some(call) => call
-        }
-        call.getClass.toString should equal("class wom.callable.CallableTaskDefinition")
+    val call: Callable = bundle.allCallables.get("Add") match {
+      case None       => throw new AppInternalException(s"Call Add not found in WDL file")
+      case Some(call) => call
+    }
+    call.getClass.toString should equal("class wom.callable.CallableTaskDefinition")
 
-        call.inputs.foreach { case inputDef =>
-            /*val t:WomType = evalType(expr, typeEnv)
+    call.inputs.foreach {
+      case inputDef =>
+      /*val t:WomType = evalType(expr, typeEnv)
              t should equal(WomIntegerType)*/
-            //System.out.println(s"inputDef=${inputDef}")
-        }
-/*        System.out.println()
+      //System.out.println(s"inputDef=${inputDef}")
+    }
+    /*        System.out.println()
 
         wf.graph.nodes.foreach{
             case node =>
@@ -95,23 +95,21 @@ class TypeEvalTest extends FlatSpec with Matchers {
         }
         System.out.println() */
 
-        val addCallNode : CallNode = wf.graph.calls.head
-        addCallNode match {
-            case cn : CommandCallNode =>
-                ()
-                /*System.out.println(
+    val addCallNode: CallNode = wf.graph.calls.head
+    addCallNode match {
+      case cn: CommandCallNode =>
+        ()
+      /*System.out.println(
                     s"""|CommandCallNode
                         |  identifier = ${cn.identifier}
                         |  inputPorts = ${cn.inputPorts}
                         |  inputDefMap = ${cn.inputDefinitionMappings}
                         |""".stripMargin)*/
-            case _ =>
-                throw new Exception("sanity")
-        }
+      case _ =>
+        throw new Exception("sanity")
     }
-
-
-/*
+  }
+  /*
     val wdlCode2 =
         """|task Copy {
            |  File src

--- a/src/test/scala/dxWDL/util/TypeEvalTest.scala
+++ b/src/test/scala/dxWDL/util/TypeEvalTest.scala
@@ -18,7 +18,14 @@ class TypeEvalTest extends FlatSpec with Matchers {
   def parseWdlCode(sourceCode: String): WomBundle = {
     val languageFactory = new WdlDraft3LanguageFactory(ConfigFactory.empty())
     val bundle =
-      languageFactory.getWomBundle(sourceCode, None, "{}", List.empty, List(languageFactory), false)
+      languageFactory.getWomBundle(
+        sourceCode,
+        None,
+        "{}",
+        List.empty,
+        List(languageFactory),
+        false
+      )
     bundle match {
       case Right(bn) =>
         bn
@@ -58,7 +65,10 @@ class TypeEvalTest extends FlatSpec with Matchers {
            |""".stripMargin
 
   // Figure out the type of an expression
-  def evalType(expr: WomExpression, inputTypes: Map[String, WomType]): WomType = {
+  def evalType(
+      expr: WomExpression,
+      inputTypes: Map[String, WomType]
+  ): WomType = {
     val result: ErrorOr[WomType] = expr.evaluateType(inputTypes)
     result match {
       case Invalid(_) =>
@@ -76,10 +86,13 @@ class TypeEvalTest extends FlatSpec with Matchers {
     wf.name should equal("foo")
 
     val call: Callable = bundle.allCallables.get("Add") match {
-      case None       => throw new AppInternalException(s"Call Add not found in WDL file")
+      case None =>
+        throw new AppInternalException(s"Call Add not found in WDL file")
       case Some(call) => call
     }
-    call.getClass.toString should equal("class wom.callable.CallableTaskDefinition")
+    call.getClass.toString should equal(
+      "class wom.callable.CallableTaskDefinition"
+    )
 
     call.inputs.foreach {
       case inputDef =>

--- a/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
+++ b/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
@@ -18,8 +18,10 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
 
   def check(elem: Element, wvlConverter: WdlVarLinksConverter): Unit = {
     val prefix = "XXX_"
-    val wvl: WdlVarLinks = wvlConverter.importFromWDL(elem.womType, elem.womValue)
-    val allDxFields1: List[(String, JsValue)] = wvlConverter.genFields(wvl, prefix + elem.name)
+    val wvl: WdlVarLinks =
+      wvlConverter.importFromWDL(elem.womType, elem.womValue)
+    val allDxFields1: List[(String, JsValue)] =
+      wvlConverter.genFields(wvl, prefix + elem.name)
     val allDxFields2 = allDxFields1.filter {
       case (key, v) => !key.endsWith(Utils.FLAT_FILES_SUFFIX)
     }
@@ -27,7 +29,8 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     val (name2, jsv) = allDxFields2.head
 
     name2 should be(prefix + elem.name)
-    val (womValue2, _) = wvlConverter.unpackJobInput(elem.name, elem.womType, jsv)
+    val (womValue2, _) =
+      wvlConverter.unpackJobInput(elem.name, elem.womType, jsv)
     womValue2 should be(elem.womValue)
   }
 
@@ -59,9 +62,14 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
       // pairs
       makeElement(makePair(24.1, "Fiji is an island in the pacific ocean")),
       makeElement(
-        WomArray(WomArrayType(WomBooleanType), Vector(WomBoolean(true), WomBoolean(false)))
+        WomArray(
+          WomArrayType(WomBooleanType),
+          Vector(WomBoolean(true), WomBoolean(false))
+        )
       ),
-      makeElement(WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))),
+      makeElement(
+        WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))
+      ),
       // maps
       makeElement(
         WomMap(
@@ -77,7 +85,10 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
       makeElement(
         WomMap(
           WomMapType(WomIntegerType, WomPairType(WomFloatType, WomStringType)),
-          Map(WomInteger(1) -> makePair(1.3, "triangle"), WomInteger(11) -> makePair(3.14, "pi"))
+          Map(
+            WomInteger(1) -> makePair(1.3, "triangle"),
+            WomInteger(11) -> makePair(3.14, "pi")
+          )
         )
       )
     )
@@ -89,10 +100,19 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
 
   it should "handle structs" in {
     val personType =
-      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+      WomCompositeType(
+        Map("name" -> WomStringType, "age" -> WomIntegerType),
+        Some("Person")
+      )
 
-    val jeff = WomObject(Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)), personType)
-    val janice = WomObject(Map("name" -> WomString("Janice"), "age" -> WomInteger(25)), personType)
+    val jeff = WomObject(
+      Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)),
+      personType
+    )
+    val janice = WomObject(
+      Map("name" -> WomString("Janice"), "age" -> WomInteger(25)),
+      personType
+    )
 
     val testCases = List(makeElement(jeff), makeElement(janice))
 
@@ -114,30 +134,52 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
   it should "handle nested structs" taggedAs (EdgeTest) in {
     // People
     val personType =
-      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
+      WomCompositeType(
+        Map("name" -> WomStringType, "age" -> WomIntegerType),
+        Some("Person")
+      )
 
-    val lucy = WomObject(Map("name" -> WomString("Lucy"), "age" -> WomInteger(37)), personType)
-    val lear = WomObject(Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)), personType)
+    val lucy = WomObject(
+      Map("name" -> WomString("Lucy"), "age" -> WomInteger(37)),
+      personType
+    )
+    val lear = WomObject(
+      Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)),
+      personType
+    )
 
     // Houses
     val houseType = WomCompositeType(
-      Map("person" -> personType, "zipcode" -> WomIntegerType, "type" -> WomStringType),
+      Map(
+        "person" -> personType,
+        "zipcode" -> WomIntegerType,
+        "type" -> WomStringType
+      ),
       Some("House")
     )
 
     val learCastle = WomObject(
-      Map("person" -> lear, "zipcode" -> WomInteger(1), "type" -> WomString("Castle")),
+      Map(
+        "person" -> lear,
+        "zipcode" -> WomInteger(1),
+        "type" -> WomString("Castle")
+      ),
       houseType
     )
 
     val lucyHouse = WomObject(
-      Map("person" -> lucy, "zipcode" -> WomInteger(94043), "type" -> WomString("town house")),
+      Map(
+        "person" -> lucy,
+        "zipcode" -> WomInteger(94043),
+        "type" -> WomString("town house")
+      ),
       houseType
     )
 
     val testCases = List(makeElement(learCastle), makeElement(lucyHouse))
 
-    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val typeAliases: Map[String, WomType] =
+      Map("Person" -> personType, "House" -> houseType)
     val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
     testCases.foreach { elem =>
       check(elem, wvlConverter)

--- a/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
+++ b/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
@@ -38,12 +38,12 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
 
     val testCases = List(
-      // primitives
-      makeElement(WomBoolean(true)),
-      makeElement(WomInteger(19)),
-      makeElement(WomFloat(2.718)),
-      makeElement(WomString("water and ice")),
-      makeElement(WomSingleFile("/usr/var/local/bin/gcc"))
+        // primitives
+        makeElement(WomBoolean(true)),
+        makeElement(WomInteger(19)),
+        makeElement(WomFloat(2.718)),
+        makeElement(WomString("water and ice")),
+        makeElement(WomSingleFile("/usr/var/local/bin/gcc"))
     )
 
     testCases.foreach { elem =>
@@ -59,38 +59,38 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     }
 
     val testCases = List(
-      // pairs
-      makeElement(makePair(24.1, "Fiji is an island in the pacific ocean")),
-      makeElement(
-        WomArray(
-          WomArrayType(WomBooleanType),
-          Vector(WomBoolean(true), WomBoolean(false))
+        // pairs
+        makeElement(makePair(24.1, "Fiji is an island in the pacific ocean")),
+        makeElement(
+            WomArray(
+                WomArrayType(WomBooleanType),
+                Vector(WomBoolean(true), WomBoolean(false))
+            )
+        ),
+        makeElement(
+            WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))
+        ),
+        // maps
+        makeElement(
+            WomMap(
+                WomMapType(WomStringType, WomBooleanType),
+                Map(
+                    WomString("A") -> WomBoolean(true),
+                    WomString("C") -> WomBoolean(false),
+                    WomString("G") -> WomBoolean(true),
+                    WomString("H") -> WomBoolean(false)
+                )
+            )
+        ),
+        makeElement(
+            WomMap(
+                WomMapType(WomIntegerType, WomPairType(WomFloatType, WomStringType)),
+                Map(
+                    WomInteger(1) -> makePair(1.3, "triangle"),
+                    WomInteger(11) -> makePair(3.14, "pi")
+                )
+            )
         )
-      ),
-      makeElement(
-        WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))
-      ),
-      // maps
-      makeElement(
-        WomMap(
-          WomMapType(WomStringType, WomBooleanType),
-          Map(
-            WomString("A") -> WomBoolean(true),
-            WomString("C") -> WomBoolean(false),
-            WomString("G") -> WomBoolean(true),
-            WomString("H") -> WomBoolean(false)
-          )
-        )
-      ),
-      makeElement(
-        WomMap(
-          WomMapType(WomIntegerType, WomPairType(WomFloatType, WomStringType)),
-          Map(
-            WomInteger(1) -> makePair(1.3, "triangle"),
-            WomInteger(11) -> makePair(3.14, "pi")
-          )
-        )
-      )
     )
 
     testCases.foreach { elem =>
@@ -101,17 +101,17 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
   it should "handle structs" in {
     val personType =
       WomCompositeType(
-        Map("name" -> WomStringType, "age" -> WomIntegerType),
-        Some("Person")
+          Map("name" -> WomStringType, "age" -> WomIntegerType),
+          Some("Person")
       )
 
     val jeff = WomObject(
-      Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)),
-      personType
+        Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)),
+        personType
     )
     val janice = WomObject(
-      Map("name" -> WomString("Janice"), "age" -> WomInteger(25)),
-      personType
+        Map("name" -> WomString("Janice"), "age" -> WomInteger(25)),
+        personType
     )
 
     val testCases = List(makeElement(jeff), makeElement(janice))
@@ -135,45 +135,45 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     // People
     val personType =
       WomCompositeType(
-        Map("name" -> WomStringType, "age" -> WomIntegerType),
-        Some("Person")
+          Map("name" -> WomStringType, "age" -> WomIntegerType),
+          Some("Person")
       )
 
     val lucy = WomObject(
-      Map("name" -> WomString("Lucy"), "age" -> WomInteger(37)),
-      personType
+        Map("name" -> WomString("Lucy"), "age" -> WomInteger(37)),
+        personType
     )
     val lear = WomObject(
-      Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)),
-      personType
+        Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)),
+        personType
     )
 
     // Houses
     val houseType = WomCompositeType(
-      Map(
-        "person" -> personType,
-        "zipcode" -> WomIntegerType,
-        "type" -> WomStringType
-      ),
-      Some("House")
+        Map(
+            "person" -> personType,
+            "zipcode" -> WomIntegerType,
+            "type" -> WomStringType
+        ),
+        Some("House")
     )
 
     val learCastle = WomObject(
-      Map(
-        "person" -> lear,
-        "zipcode" -> WomInteger(1),
-        "type" -> WomString("Castle")
-      ),
-      houseType
+        Map(
+            "person" -> lear,
+            "zipcode" -> WomInteger(1),
+            "type" -> WomString("Castle")
+        ),
+        houseType
     )
 
     val lucyHouse = WomObject(
-      Map(
-        "person" -> lucy,
-        "zipcode" -> WomInteger(94043),
-        "type" -> WomString("town house")
-      ),
-      houseType
+        Map(
+            "person" -> lucy,
+            "zipcode" -> WomInteger(94043),
+            "type" -> WomString("town house")
+        ),
+        houseType
     )
 
     val testCases = List(makeElement(learCastle), makeElement(lucyHouse))

--- a/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
+++ b/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
@@ -9,152 +9,138 @@ import dxWDL.base.{Utils, Verbose}
 
 class WdlVarLinksTest extends FlatSpec with Matchers {
 
-    private val verbose = Verbose(false, false, Set.empty)
+  private val verbose = Verbose(false, false, Set.empty)
 
-    case class Element(name: String,
-                       womType: WomType,
-                       womValue: WomValue)
+  case class Element(name: String, womType: WomType, womValue: WomValue)
 
-    def makeElement(womValue: WomValue) : Element =
-        Element("A", womValue.womType, womValue)
+  def makeElement(womValue: WomValue): Element =
+    Element("A", womValue.womType, womValue)
 
-    def check(elem: Element,
-              wvlConverter: WdlVarLinksConverter) : Unit = {
-        val prefix = "XXX_"
-        val wvl : WdlVarLinks = wvlConverter.importFromWDL(elem.womType, elem.womValue)
-        val allDxFields1 : List[(String, JsValue)] = wvlConverter.genFields(wvl, prefix + elem.name)
-        val allDxFields2 = allDxFields1.filter{
-            case (key, v) => !key.endsWith(Utils.FLAT_FILES_SUFFIX)
-        }
-        allDxFields2.size should be(1)
-        val (name2, jsv) = allDxFields2.head
+  def check(elem: Element, wvlConverter: WdlVarLinksConverter): Unit = {
+    val prefix                                = "XXX_"
+    val wvl: WdlVarLinks                      = wvlConverter.importFromWDL(elem.womType, elem.womValue)
+    val allDxFields1: List[(String, JsValue)] = wvlConverter.genFields(wvl, prefix + elem.name)
+    val allDxFields2 = allDxFields1.filter {
+      case (key, v) => !key.endsWith(Utils.FLAT_FILES_SUFFIX)
+    }
+    allDxFields2.size should be(1)
+    val (name2, jsv) = allDxFields2.head
 
-        name2 should be(prefix + elem.name)
-        val (womValue2,_) = wvlConverter.unpackJobInput(elem.name, elem.womType, jsv)
-        womValue2 should be(elem.womValue)
+    name2 should be(prefix + elem.name)
+    val (womValue2, _) = wvlConverter.unpackJobInput(elem.name, elem.womType, jsv)
+    womValue2 should be(elem.womValue)
+  }
+
+  it should "handle primitive WDL elements" in {
+    val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
+
+    val testCases = List(
+      // primitives
+      makeElement(WomBoolean(true)),
+      makeElement(WomInteger(19)),
+      makeElement(WomFloat(2.718)),
+      makeElement(WomString("water and ice")),
+      makeElement(WomSingleFile("/usr/var/local/bin/gcc"))
+    )
+
+    testCases.foreach { elem =>
+      check(elem, wvlConverter)
+    }
+  }
+
+  it should "handle compound WDL types" in {
+    val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
+
+    def makePair(x: Double, s: String): WomValue = {
+      WomPair(WomFloat(x), WomString(s))
     }
 
-    it should "handle primitive WDL elements" in {
-        val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
-
-        val testCases = List(
-            // primitives
-            makeElement(WomBoolean(true)),
-            makeElement(WomInteger(19)),
-            makeElement(WomFloat(2.718)),
-            makeElement(WomString("water and ice")),
-            makeElement(WomSingleFile("/usr/var/local/bin/gcc")),
+    val testCases = List(
+      // pairs
+      makeElement(makePair(24.1, "Fiji is an island in the pacific ocean")),
+      makeElement(
+        WomArray(WomArrayType(WomBooleanType), Vector(WomBoolean(true), WomBoolean(false)))
+      ),
+      makeElement(WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))),
+      // maps
+      makeElement(
+        WomMap(
+          WomMapType(WomStringType, WomBooleanType),
+          Map(
+            WomString("A") -> WomBoolean(true),
+            WomString("C") -> WomBoolean(false),
+            WomString("G") -> WomBoolean(true),
+            WomString("H") -> WomBoolean(false)
+          )
         )
-
-        testCases.foreach{ elem =>
-            check(elem, wvlConverter)
-        }
-    }
-
-    it should "handle compound WDL types" in {
-        val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
-
-        def makePair(x: Double, s: String) : WomValue = {
-            WomPair(WomFloat(x), WomString(s))
-        }
-
-        val testCases = List(
-            // pairs
-            makeElement(makePair(24.1, "Fiji is an island in the pacific ocean")),
-
-            makeElement(WomArray(WomArrayType(WomBooleanType),
-                                 Vector(WomBoolean(true), WomBoolean(false)))),
-
-            makeElement(WomOptionalValue(WomSingleFileType, Some(WomSingleFile("ddd")))),
-
-            // maps
-            makeElement(WomMap(
-                            WomMapType(WomStringType, WomBooleanType),
-                            Map(WomString("A") -> WomBoolean(true),
-                                WomString("C") -> WomBoolean(false),
-                                WomString("G") -> WomBoolean(true),
-                                WomString("H") -> WomBoolean(false))
-                        )),
-            makeElement(WomMap(
-                            WomMapType(WomIntegerType, WomPairType(WomFloatType, WomStringType)),
-                            Map(WomInteger(1) -> makePair(1.3, "triangle"),
-                                WomInteger(11) -> makePair(3.14, "pi"))
-                        )),
-
+      ),
+      makeElement(
+        WomMap(
+          WomMapType(WomIntegerType, WomPairType(WomFloatType, WomStringType)),
+          Map(WomInteger(1) -> makePair(1.3, "triangle"), WomInteger(11) -> makePair(3.14, "pi"))
         )
+      )
+    )
 
-        testCases.foreach{ elem =>
-            check(elem, wvlConverter)
-        }
+    testCases.foreach { elem =>
+      check(elem, wvlConverter)
     }
+  }
 
-    it should "handle structs" in {
-        val personType = WomCompositeType(Map("name" -> WomStringType,
-                                              "age" -> WomIntegerType),
-                                          Some("Person"))
+  it should "handle structs" in {
+    val personType =
+      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
 
-        val jeff = WomObject(Map("name" -> WomString("Jeoffrey"),
-                                 "age" -> WomInteger(16)),
-                             personType)
-        val janice = WomObject(Map("name" -> WomString("Janice"),
-                                   "age" -> WomInteger(25)),
-                               personType)
+    val jeff   = WomObject(Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)), personType)
+    val janice = WomObject(Map("name" -> WomString("Janice"), "age"   -> WomInteger(25)), personType)
 
-        val testCases = List(makeElement(jeff) ,
-                             makeElement(janice))
+    val testCases = List(makeElement(jeff), makeElement(janice))
 
-        // no definitions for struct Person, should fail
-        // val wvlConverterEmpty = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
-        // testCases.foreach{ elem =>
-        // assertThrows[Exception] {
+    // no definitions for struct Person, should fail
+    // val wvlConverterEmpty = new WdlVarLinksConverter(verbose, Map.empty, Map.empty)
+    // testCases.foreach{ elem =>
+    // assertThrows[Exception] {
 //                check(elem, wvlConverterEmpty)
 //            }
 //        }
 
-        val typeAliases: Map[String, WomType] = Map("Person" -> personType)
-        val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
-        testCases.foreach{ elem =>
-            check(elem, wvlConverter)
-        }
+    val typeAliases: Map[String, WomType] = Map("Person" -> personType)
+    val wvlConverter                      = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
+    testCases.foreach { elem =>
+      check(elem, wvlConverter)
     }
+  }
 
-    it should "handle nested structs" taggedAs(EdgeTest) in {
-        // People
-        val personType = WomCompositeType(Map("name" -> WomStringType,
-                                              "age" -> WomIntegerType),
-                                          Some("Person"))
+  it should "handle nested structs" taggedAs (EdgeTest) in {
+    // People
+    val personType =
+      WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
 
-        val lucy = WomObject(Map("name" -> WomString("Lucy"),
-                                 "age" -> WomInteger(37)),
-                             personType)
-        val lear = WomObject(Map("name" -> WomString("King Lear"),
-                                 "age" -> WomInteger(41)),
-                             personType)
+    val lucy = WomObject(Map("name" -> WomString("Lucy"), "age"      -> WomInteger(37)), personType)
+    val lear = WomObject(Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)), personType)
 
-        // Houses
-        val houseType = WomCompositeType(Map("person" -> personType,
-                                             "zipcode" -> WomIntegerType,
-                                             "type" -> WomStringType),
-                                         Some("House"))
+    // Houses
+    val houseType = WomCompositeType(
+      Map("person" -> personType, "zipcode" -> WomIntegerType, "type" -> WomStringType),
+      Some("House")
+    )
 
-        val learCastle = WomObject(Map("person" -> lear,
-                                       "zipcode" -> WomInteger(1),
-                                       "type" -> WomString("Castle")),
-                                   houseType)
+    val learCastle = WomObject(
+      Map("person" -> lear, "zipcode" -> WomInteger(1), "type" -> WomString("Castle")),
+      houseType
+    )
 
-        val lucyHouse = WomObject(Map("person" -> lucy,
-                                      "zipcode" -> WomInteger(94043),
-                                      "type" -> WomString("town house")),
-                                  houseType)
+    val lucyHouse = WomObject(
+      Map("person" -> lucy, "zipcode" -> WomInteger(94043), "type" -> WomString("town house")),
+      houseType
+    )
 
-        val testCases = List(makeElement(learCastle) ,
-                             makeElement(lucyHouse))
+    val testCases = List(makeElement(learCastle), makeElement(lucyHouse))
 
-        val typeAliases: Map[String, WomType] = Map("Person" -> personType,
-                                                    "House" -> houseType)
-        val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
-        testCases.foreach{ elem =>
-            check(elem, wvlConverter)
-        }
+    val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
+    val wvlConverter                      = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
+    testCases.foreach { elem =>
+      check(elem, wvlConverter)
     }
+  }
 }

--- a/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
+++ b/src/test/scala/dxWDL/util/WdlVarLinksTest.scala
@@ -17,8 +17,8 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     Element("A", womValue.womType, womValue)
 
   def check(elem: Element, wvlConverter: WdlVarLinksConverter): Unit = {
-    val prefix                                = "XXX_"
-    val wvl: WdlVarLinks                      = wvlConverter.importFromWDL(elem.womType, elem.womValue)
+    val prefix = "XXX_"
+    val wvl: WdlVarLinks = wvlConverter.importFromWDL(elem.womType, elem.womValue)
     val allDxFields1: List[(String, JsValue)] = wvlConverter.genFields(wvl, prefix + elem.name)
     val allDxFields2 = allDxFields1.filter {
       case (key, v) => !key.endsWith(Utils.FLAT_FILES_SUFFIX)
@@ -91,8 +91,8 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     val personType =
       WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
 
-    val jeff   = WomObject(Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)), personType)
-    val janice = WomObject(Map("name" -> WomString("Janice"), "age"   -> WomInteger(25)), personType)
+    val jeff = WomObject(Map("name" -> WomString("Jeoffrey"), "age" -> WomInteger(16)), personType)
+    val janice = WomObject(Map("name" -> WomString("Janice"), "age" -> WomInteger(25)), personType)
 
     val testCases = List(makeElement(jeff), makeElement(janice))
 
@@ -105,7 +105,7 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
 //        }
 
     val typeAliases: Map[String, WomType] = Map("Person" -> personType)
-    val wvlConverter                      = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
+    val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
     testCases.foreach { elem =>
       check(elem, wvlConverter)
     }
@@ -116,7 +116,7 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     val personType =
       WomCompositeType(Map("name" -> WomStringType, "age" -> WomIntegerType), Some("Person"))
 
-    val lucy = WomObject(Map("name" -> WomString("Lucy"), "age"      -> WomInteger(37)), personType)
+    val lucy = WomObject(Map("name" -> WomString("Lucy"), "age" -> WomInteger(37)), personType)
     val lear = WomObject(Map("name" -> WomString("King Lear"), "age" -> WomInteger(41)), personType)
 
     // Houses
@@ -138,7 +138,7 @@ class WdlVarLinksTest extends FlatSpec with Matchers {
     val testCases = List(makeElement(learCastle), makeElement(lucyHouse))
 
     val typeAliases: Map[String, WomType] = Map("Person" -> personType, "House" -> houseType)
-    val wvlConverter                      = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
+    val wvlConverter = new WdlVarLinksConverter(verbose, Map.empty, typeAliases)
     testCases.foreach { elem =>
       check(elem, wvlConverter)
     }

--- a/src/test/scala/dxWDL/util/WomPrettyPrintApproxWdlTest.scala
+++ b/src/test/scala/dxWDL/util/WomPrettyPrintApproxWdlTest.scala
@@ -6,43 +6,43 @@ import wom.callable.{WorkflowDefinition}
 
 class WomPrettyPrintApproxWdlTest extends FlatSpec with Matchers {
 
-    private def tryToPrintFile(path : File) : Unit = {
-        val wfSourceCode = scala.io.Source.fromFile(path).mkString
-        try {
-            val (wf : WorkflowDefinition, _, typeAliases) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
-            val (_, _, blocks, outputs) = Block.split(wf.graph, wfSourceCode)
+  private def tryToPrintFile(path: File): Unit = {
+    val wfSourceCode = scala.io.Source.fromFile(path).mkString
+    try {
+      val (wf: WorkflowDefinition, _, typeAliases) =
+        ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+      val (_, _, blocks, outputs) = Block.split(wf.graph, wfSourceCode)
 
-            WomPrettyPrintApproxWdl.graphInputs(wf.inputs.toSeq)
-            WomPrettyPrintApproxWdl.graphOutputs(outputs)
-            blocks.foreach{ b =>
-                WomPrettyPrintApproxWdl.block(b)
-            }
-        } catch {
-            // Some of the source files are invalid, or contain tasks and not workflows
-            case e : Throwable => ()
-        }
+      WomPrettyPrintApproxWdl.graphInputs(wf.inputs.toSeq)
+      WomPrettyPrintApproxWdl.graphOutputs(outputs)
+      blocks.foreach { b =>
+        WomPrettyPrintApproxWdl.block(b)
+      }
+    } catch {
+      // Some of the source files are invalid, or contain tasks and not workflows
+      case e: Throwable => ()
     }
+  }
 
-    it should "print original WDL for draft2" in {
-        val testDir = new File("src/test/resources/draft2")
-        val testCases = testDir.listFiles.filter{ x =>
-            x.isFile && x.getName.endsWith(".wdl")
-        }.toVector
+  it should "print original WDL for draft2" in {
+    val testDir = new File("src/test/resources/draft2")
+    val testCases = testDir.listFiles.filter { x =>
+      x.isFile && x.getName.endsWith(".wdl")
+    }.toVector
 
-        for (path <- testCases) {
-            tryToPrintFile(path)
-        }
+    for (path <- testCases) {
+      tryToPrintFile(path)
     }
+  }
 
+  it should "print original WDL for version 1.0" in {
+    val testDir = new File("src/test/resources/compiler")
+    val testCases = testDir.listFiles.filter { x =>
+      x.isFile && x.getName.endsWith(".wdl")
+    }.toVector
 
-    it should "print original WDL for version 1.0" in {
-        val testDir = new File("src/test/resources/compiler")
-        val testCases = testDir.listFiles.filter{ x =>
-            x.isFile && x.getName.endsWith(".wdl")
-        }.toVector
-
-        for (path <- testCases) {
-            tryToPrintFile(path)
-        }
+    for (path <- testCases) {
+      tryToPrintFile(path)
     }
+  }
 }

--- a/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
+++ b/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
@@ -20,26 +20,26 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
 
   it should "evalConst" in {
     val allExpectedResults = Map(
-      "flag" -> Some(WomBoolean(true)),
-      "i" -> Some(WomInteger(8)),
-      "x" -> Some(WomFloat(2.718)),
-      "s" -> Some(WomString("hello world")),
-      "ar1" -> Some(
-        WomArray(
-          WomArrayType(WomStringType),
-          Vector(WomString("A"), WomString("B"), WomString("C"))
-        )
-      ),
-      "m1" -> Some(
-        WomMap(
-          WomMapType(WomStringType, WomIntegerType),
-          Map(WomString("X") -> WomInteger(1), WomString("Y") -> WomInteger(10))
-        )
-      ),
-      "p" -> Some(WomPair(WomInteger(1), WomInteger(12))),
-      "file2" -> None,
-      "k" -> None,
-      "readme" -> None
+        "flag" -> Some(WomBoolean(true)),
+        "i" -> Some(WomInteger(8)),
+        "x" -> Some(WomFloat(2.718)),
+        "s" -> Some(WomString("hello world")),
+        "ar1" -> Some(
+            WomArray(
+                WomArrayType(WomStringType),
+                Vector(WomString("A"), WomString("B"), WomString("C"))
+            )
+        ),
+        "m1" -> Some(
+            WomMap(
+                WomMapType(WomStringType, WomIntegerType),
+                Map(WomString("X") -> WomInteger(1), WomString("Y") -> WomInteger(10))
+            )
+        ),
+        "p" -> Some(WomPair(WomInteger(1), WomInteger(12))),
+        "file2" -> None,
+        "k" -> None,
+        "readme" -> None
     )
 
     // The workflow is a convenient packaging around WOM

--- a/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
+++ b/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
@@ -10,7 +10,8 @@ import wom.values._
 class WomValueAnalysisTest extends FlatSpec with Matchers {
 
   def parseExpressions(wdlCode: String): Vector[ExpressionNode] = {
-    val (wf: WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wdlCode)
+    val (wf: WorkflowDefinition, _, _) =
+      ParseWomSourceFile(false).parseWdlWorkflow(wdlCode)
     val eNodes: Vector[ExpressionNode] = wf.innerGraph.nodes.collect {
       case x: ExpressionNode => x
     }.toVector

--- a/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
+++ b/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
@@ -9,38 +9,44 @@ import wom.values._
 
 class WomValueAnalysisTest extends FlatSpec with Matchers {
 
-    def parseExpressions(wdlCode: String) : Vector[ExpressionNode] = {
-        val (wf : WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wdlCode)
-        val eNodes : Vector[ExpressionNode] = wf.innerGraph.nodes.collect{
-            case x : ExpressionNode => x
-        }.toVector
-        eNodes
-    }
+  def parseExpressions(wdlCode: String): Vector[ExpressionNode] = {
+    val (wf: WorkflowDefinition, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wdlCode)
+    val eNodes: Vector[ExpressionNode] = wf.innerGraph.nodes.collect {
+      case x: ExpressionNode => x
+    }.toVector
+    eNodes
+  }
 
-    it should "evalConst" in {
-        val allExpectedResults = Map(
-            "flag" -> Some(WomBoolean(true)),
-            "i" -> Some(WomInteger(8)),
-            "x" -> Some(WomFloat(2.718)),
-            "s" -> Some(WomString("hello world")),
-            "ar1" -> Some(WomArray(WomArrayType(WomStringType),
-                                   Vector(WomString("A"), WomString("B"), WomString("C")))),
-            "m1" -> Some(WomMap(WomMapType(WomStringType, WomIntegerType),
-                                Map(WomString("X") -> WomInteger(1),
-                                    WomString("Y") -> WomInteger(10)))),
-            "p" -> Some(WomPair(WomInteger(1), WomInteger(12))),
-            "file2" -> None,
-            "k" ->None,
-            "readme" -> None
+  it should "evalConst" in {
+    val allExpectedResults = Map(
+      "flag" -> Some(WomBoolean(true)),
+      "i"    -> Some(WomInteger(8)),
+      "x"    -> Some(WomFloat(2.718)),
+      "s"    -> Some(WomString("hello world")),
+      "ar1" -> Some(
+        WomArray(
+          WomArrayType(WomStringType),
+          Vector(WomString("A"), WomString("B"), WomString("C"))
         )
+      ),
+      "m1" -> Some(
+        WomMap(
+          WomMapType(WomStringType, WomIntegerType),
+          Map(WomString("X") -> WomInteger(1), WomString("Y") -> WomInteger(10))
+        )
+      ),
+      "p"      -> Some(WomPair(WomInteger(1), WomInteger(12))),
+      "file2"  -> None,
+      "k"      -> None,
+      "readme" -> None
+    )
 
-
-        // The workflow is a convenient packaging around WOM
-        // expressions. When we parse the workflow, the expressions lose
-        // their relative ordering, and become a graph. That's why we need
-        // to keep track of a map from identifier name to expected result.
-        val wdlCode =
-            """|version 1.0
+    // The workflow is a convenient packaging around WOM
+    // expressions. When we parse the workflow, the expressions lose
+    // their relative ordering, and become a graph. That's why we need
+    // to keep track of a map from identifier name to expected result.
+    val wdlCode =
+      """|version 1.0
                |
                |workflow foo {
                |
@@ -60,49 +66,49 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val expressions = parseExpressions(wdlCode)
-        for (node <- expressions) {
-            val id : String = node.identifier.localName.value
-            val expected : Option[WomValue] = allExpectedResults(id)
-            val expr : WomExpression = node.womExpression
-            val womType : WomType = node.womType
+    val expressions = parseExpressions(wdlCode)
+    for (node <- expressions) {
+      val id: String                 = node.identifier.localName.value
+      val expected: Option[WomValue] = allExpectedResults(id)
+      val expr: WomExpression        = node.womExpression
+      val womType: WomType           = node.womType
 
-            val retval = WomValueAnalysis.ifConstEval(womType, expr)
-            retval shouldBe(expected)
+      val retval = WomValueAnalysis.ifConstEval(womType, expr)
+      retval shouldBe (expected)
 
-            // Check that evalConst works
-            expected match {
-                case None =>
-                    assertThrows[Exception] {
-                        WomValueAnalysis.evalConst(womType, expr)
-                    }
-                    WomValueAnalysis.isExpressionConst(womType, expr) shouldBe(false)
-                case Some(x) =>
-                    WomValueAnalysis.evalConst(womType, expr) shouldBe(x)
-                    WomValueAnalysis.isExpressionConst(womType, expr) shouldBe(true)
-            }
-        }
+      // Check that evalConst works
+      expected match {
+        case None =>
+          assertThrows[Exception] {
+            WomValueAnalysis.evalConst(womType, expr)
+          }
+          WomValueAnalysis.isExpressionConst(womType, expr) shouldBe (false)
+        case Some(x) =>
+          WomValueAnalysis.evalConst(womType, expr) shouldBe (x)
+          WomValueAnalysis.isExpressionConst(womType, expr) shouldBe (true)
+      }
     }
+  }
 
-    it should "not be able to access unsupported file protocols" in {
-        val wdlCode =
-            """|version 1.0
+  it should "not be able to access unsupported file protocols" in {
+    val wdlCode =
+      """|version 1.0
                |
                |workflow foo {
                |    File readme = "gs://this_file_is_on_google_cloud"
                |}
                |""".stripMargin
 
-        val expressions = parseExpressions(wdlCode)
-        val node = expressions.head
-        assertThrows[Exception] {
-            WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
-        }
+    val expressions = parseExpressions(wdlCode)
+    val node        = expressions.head
+    assertThrows[Exception] {
+      WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
     }
+  }
 
-    it should "handle links to dx files" in {
-        val wdlCode =
-            """|version 1.0
+  it should "handle links to dx files" in {
+    val wdlCode =
+      """|version 1.0
                |
                |workflow foo {
                |    File fruit_list = "dx://dxWDL_playground:/test_data/fruit_list.txt"
@@ -112,9 +118,9 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
                |}
                |""".stripMargin
 
-        val expressions = parseExpressions(wdlCode)
-        val nodes = expressions.toList
-        for (node <- nodes)
-            WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
-    }
+    val expressions = parseExpressions(wdlCode)
+    val nodes       = expressions.toList
+    for (node <- nodes)
+      WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
+  }
 }

--- a/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
+++ b/src/test/scala/dxWDL/util/WomValueAnalysisTest.scala
@@ -20,9 +20,9 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
   it should "evalConst" in {
     val allExpectedResults = Map(
       "flag" -> Some(WomBoolean(true)),
-      "i"    -> Some(WomInteger(8)),
-      "x"    -> Some(WomFloat(2.718)),
-      "s"    -> Some(WomString("hello world")),
+      "i" -> Some(WomInteger(8)),
+      "x" -> Some(WomFloat(2.718)),
+      "s" -> Some(WomString("hello world")),
       "ar1" -> Some(
         WomArray(
           WomArrayType(WomStringType),
@@ -35,9 +35,9 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
           Map(WomString("X") -> WomInteger(1), WomString("Y") -> WomInteger(10))
         )
       ),
-      "p"      -> Some(WomPair(WomInteger(1), WomInteger(12))),
-      "file2"  -> None,
-      "k"      -> None,
+      "p" -> Some(WomPair(WomInteger(1), WomInteger(12))),
+      "file2" -> None,
+      "k" -> None,
       "readme" -> None
     )
 
@@ -68,10 +68,10 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
 
     val expressions = parseExpressions(wdlCode)
     for (node <- expressions) {
-      val id: String                 = node.identifier.localName.value
+      val id: String = node.identifier.localName.value
       val expected: Option[WomValue] = allExpectedResults(id)
-      val expr: WomExpression        = node.womExpression
-      val womType: WomType           = node.womType
+      val expr: WomExpression = node.womExpression
+      val womType: WomType = node.womType
 
       val retval = WomValueAnalysis.ifConstEval(womType, expr)
       retval shouldBe (expected)
@@ -100,7 +100,7 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
                |""".stripMargin
 
     val expressions = parseExpressions(wdlCode)
-    val node        = expressions.head
+    val node = expressions.head
     assertThrows[Exception] {
       WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
     }
@@ -119,7 +119,7 @@ class WomValueAnalysisTest extends FlatSpec with Matchers {
                |""".stripMargin
 
     val expressions = parseExpressions(wdlCode)
-    val nodes       = expressions.toList
+    val nodes = expressions.toList
     for (node <- nodes)
       WomValueAnalysis.ifConstEval(node.womType, node.womExpression)
   }


### PR DESCRIPTION
The scalafmt branch has been formatted by [scalafmt](https://scalameta.org/scalafmt/) with default options + allowing for line width 100. A .scalafmt.conf file has been added to the project root. The major difference between this scalafmt'd code and previous is that [scala specifies](https://docs.scala-lang.org/style/indentation.html) 2 spaces for indentation where we were using 4. I can go back to 4 if we would like to. The Internals doc specifying code style has been updated to mandate scalafmt as well.

All tests pass with the exception of one that was already failing on master.