### PR TITLE
Silencer added to DXHTTRequest

### DIFF
--- a/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -109,6 +109,9 @@ public class DXHTTPRequest {
 
     private static final String USER_AGENT = DXUserAgent.getUserAgent();
 
+    // consider moving this to DXEnvironment.java
+    private static final String debugLevel = System.getenv("_DX_DEBUG") == null ? "0": System.getenv("_DX_DEBUG");
+
     private static String errorMessage(String method, String resource, String errorString,
             int retryWait, int nextRetryNum, int maxRetries) {
         String baseError = method + " " + resource + ": " + errorString + ".";
@@ -128,9 +131,6 @@ public class DXHTTPRequest {
     private static void logError(String msg) {
 
         // check that if debug level is not set (null), set it as "0"
-        String debugLevel = System.getenv("_DX_DEBUG");
-        debugLevel = debugLevel == null ? "0": debugLevel;
-
         if (!debugLevel.equals("0")) {
             System.err.println("[" + System.currentTimeMillis() + "] " + msg);
         }

--- a/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -423,15 +423,17 @@ public class DXHTTPRequest {
                         // Just fall back to reproducing the entire response
                         // body.
                     }
-                    logError(errorType + ": " + errorMessage + ". Code: " + Integer.toString(statusCode)
-                        + " Request ID: " + requestId);
+                    // Temporarily remove logging error to allow better control on handling exception
+                    // logError(errorType + ": " + errorMessage + ". Code: " + Integer.toString(statusCode)
+                    //    + " Request ID: " + requestId);
                     throw DXAPIException.getInstance(errorType, errorMessage, statusCode);
                 } else {
                     // Propagate 500 error to caller
                     if (this.disableRetry && statusCode != 503) {
-                        logError("POST " + resource + ": " + statusCode + " Internal Server Error, try "
-                                + String.valueOf(attempts + 1) + "/" + NUM_RETRIES
-                                + " Request ID: " +  requestId);
+                        // Temporarily remove logging error to allow better control on handling exception
+                        // logError("POST " + resource + ": " + statusCode + " Internal Server Error, try "
+                        //      + String.valueOf(attempts + 1) + "/" + NUM_RETRIES
+                        //      + " Request ID: " +  requestId);
                         throw new InternalErrorException("Internal Server Error", statusCode);
                     }
                     // If retries enabled, 500 InternalError should get retried unconditionally
@@ -455,23 +457,28 @@ public class DXHTTPRequest {
                 int secondsToWait = retryAfterSeconds;
 
                 if (this.disableRetry) {
-                    logError("POST " + resource + ": 503 Service Unavailable, suggested wait "
-                            + secondsToWait + " seconds" + ". Request ID: " +  requestId);
+                    // Temporarily remove logging error to allow better control on handling exception
+                    // logError("POST " + resource + ": 503 Service Unavailable, suggested wait "
+                    //        + secondsToWait + " seconds" + ". Request ID: " +  requestId);
                     throw e;
                 }
 
                 // Retries due to 503 Service Unavailable and Retry-After do NOT count against the
                 // allowed number of retries.
-                logError("POST " + resource + ": 503 Service Unavailable, waiting for "
-                        + Integer.toString(secondsToWait) + " seconds" + " Request ID: " +  requestId);
+
+                // Temporarily remove logging error to allow better control on handling exception
+                // logError("POST " + resource + ": 503 Service Unavailable, waiting for "
+                //        + Integer.toString(secondsToWait) + " seconds" + " Request ID: " +  requestId);
                 sleep(secondsToWait);
                 continue;
             } catch (IOException e) {
                 // Note, this catches both exceptions directly thrown from httpclient.execute (e.g.
                 // no connectivity to server) and exceptions thrown by our code above after parsing
                 // the response.
-                logError(errorMessage("POST", resource, e.toString(), timeoutSeconds,
-                        attempts + 1, NUM_RETRIES));
+
+                // Temporarily remove logging error to allow better control on handling exception
+                // logError(errorMessage("POST", resource, e.toString(), timeoutSeconds,
+                //        attempts + 1, NUM_RETRIES));
                 if (attempts == NUM_RETRIES || !retryRequest) {
                     if (statusCode == null) {
                         throw new DXHTTPException();

--- a/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -423,17 +423,15 @@ public class DXHTTPRequest {
                         // Just fall back to reproducing the entire response
                         // body.
                     }
-                    // Temporarily remove logging error to allow better control on handling exception
-                    // logError(errorType + ": " + errorMessage + ". Code: " + Integer.toString(statusCode)
-                    //    + " Request ID: " + requestId);
+                    logError(errorType + ": " + errorMessage + ". Code: " + Integer.toString(statusCode)
+                        + " Request ID: " + requestId);
                     throw DXAPIException.getInstance(errorType, errorMessage, statusCode);
                 } else {
                     // Propagate 500 error to caller
                     if (this.disableRetry && statusCode != 503) {
-                        // Temporarily remove logging error to allow better control on handling exception
-                        // logError("POST " + resource + ": " + statusCode + " Internal Server Error, try "
-                        //      + String.valueOf(attempts + 1) + "/" + NUM_RETRIES
-                        //      + " Request ID: " +  requestId);
+                        logError("POST " + resource + ": " + statusCode + " Internal Server Error, try "
+                                + String.valueOf(attempts + 1) + "/" + NUM_RETRIES
+                                + " Request ID: " +  requestId);
                         throw new InternalErrorException("Internal Server Error", statusCode);
                     }
                     // If retries enabled, 500 InternalError should get retried unconditionally
@@ -457,28 +455,23 @@ public class DXHTTPRequest {
                 int secondsToWait = retryAfterSeconds;
 
                 if (this.disableRetry) {
-                    // Temporarily remove logging error to allow better control on handling exception
-                    // logError("POST " + resource + ": 503 Service Unavailable, suggested wait "
-                    //        + secondsToWait + " seconds" + ". Request ID: " +  requestId);
+                    logError("POST " + resource + ": 503 Service Unavailable, suggested wait "
+                            + secondsToWait + " seconds" + ". Request ID: " +  requestId);
                     throw e;
                 }
 
                 // Retries due to 503 Service Unavailable and Retry-After do NOT count against the
                 // allowed number of retries.
-
-                // Temporarily remove logging error to allow better control on handling exception
-                // logError("POST " + resource + ": 503 Service Unavailable, waiting for "
-                //        + Integer.toString(secondsToWait) + " seconds" + " Request ID: " +  requestId);
+                logError("POST " + resource + ": 503 Service Unavailable, waiting for "
+                        + Integer.toString(secondsToWait) + " seconds" + " Request ID: " +  requestId);
                 sleep(secondsToWait);
                 continue;
             } catch (IOException e) {
                 // Note, this catches both exceptions directly thrown from httpclient.execute (e.g.
                 // no connectivity to server) and exceptions thrown by our code above after parsing
                 // the response.
-
-                // Temporarily remove logging error to allow better control on handling exception
-                // logError(errorMessage("POST", resource, e.toString(), timeoutSeconds,
-                //        attempts + 1, NUM_RETRIES));
+                logError(errorMessage("POST", resource, e.toString(), timeoutSeconds,
+                        attempts + 1, NUM_RETRIES));
                 if (attempts == NUM_RETRIES || !retryRequest) {
                     if (statusCode == null) {
                         throw new DXHTTPException();

--- a/src/main/java/com/dnanexus/DXHTTPRequest.java
+++ b/src/main/java/com/dnanexus/DXHTTPRequest.java
@@ -120,13 +120,20 @@ public class DXHTTPRequest {
     }
 
     /**
-     * Prints an error message to stderr
+     * Prints an error message to stderr when _DX_DEBUG env is set as > 0.
      *
      * @param msg the error message to be printed
      *
      */
     private static void logError(String msg) {
-        System.err.println("[" + System.currentTimeMillis() + "] " + msg);
+
+        // check that if debug level is not set (null), set it as "0"
+        String debugLevel = System.getenv("_DX_DEBUG");
+        debugLevel = debugLevel == null ? "0": debugLevel;
+
+        if (!debugLevel.equals("0")) {
+            System.err.println("[" + System.currentTimeMillis() + "] " + msg);
+        }
     }
 
     /**


### PR DESCRIPTION
Hi, @orodeh  as discussed, I have commented out all logError in src/main/java/com/dnanexus/DXHTTPRequest.java

I have also checked that the message is no longer in the stdout.

I think another way is to modify the logError method to check the environment variable `_DX_DEBUG` do you think that will work? Although that will introduce another variable that we have to be aware of

ie something like

```
 private static void logError(String msg) {
        System.err.println("[" + System.currentTimeMillis() + "] " + msg);
    }
```
to 
```
 private static void logError(String msg) {
        if (System.getenv("_DX_DEBUG") != null) {
            System.err.println("[" + System.currentTimeMillis() + "] " + msg);
        }
    }

```