### PR TITLE
Treeform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.43
+- Providing a tree structure representing a compiled workflow via `--execTree pretty`
+- For the json structure use `--execTree json`
+
 ## 1.42 23-Jan-2020
 - Providing a JSON structure representing a compiled workflow. This can be done with the command line flag `--execTree`. For example:
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "v1.42"
+    version = "v1.43"
 }
 
 #

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -319,11 +319,15 @@ object Main extends App {
     rtDebugLvl
   }
 
-  private def parseExecTree(execTreeTypeAsString: String): TreePrinter = execTreeTypeAsString.toLowerCase match {
-    case "json" => JsonTreePrinter
-    case "pretty" => PrettyTreePrinter
-    case _ => throw new Exception(s"--execTree must be either json or pretty, found $execTreeTypeAsString")
-  }
+  private def parseExecTree(execTreeTypeAsString: String): TreePrinter =
+    execTreeTypeAsString.toLowerCase match {
+      case "json"   => JsonTreePrinter
+      case "pretty" => PrettyTreePrinter
+      case _ =>
+        throw new Exception(
+            s"--execTree must be either json or pretty, found $execTreeTypeAsString"
+        )
+    }
 
   private def parseStreamAllFiles(s: String): Boolean = {
     s.toLowerCase match {
@@ -378,7 +382,8 @@ object Main extends App {
 
     val treePrinter: Option[TreePrinter] = options.get("execTree") match {
       case None => None
-      case Some(treeType) => Some(parseExecTree(treeType(0))) // take first element and drop the rest? 
+      case Some(treeType) =>
+        Some(parseExecTree(treeType(0))) // take first element and drop the rest?
     }
     val runtimeDebugLevel: Option[Int] =
       options.get("runtimeDebugLevel") match {

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -284,25 +284,6 @@ object Utils {
   }
 
   def genNSpaces(n: Int) = s"${" " * n}"
-  def genTree(level: Int, indent: Int, last: Boolean = false): String = {
-    level match {
-      case 0 => ""
-      case 1 => {
-        last match {
-          case true  => s"└${"─" * (level * (indent - 1))} "
-          case false => s"├${"─" * (level * (indent - 1))} "
-        }
-      }
-      case _ => {
-        last match {
-          case true =>
-            s"│${" " * ((level - 1) * indent)}${" " * (level - 2)}└${"─" * (indent - 1)} "
-          case false =>
-            s"│${" " * ((level - 1) * indent)}${" " * (level - 2)}├${"─" * (indent - 1)} "
-        }
-      }
-    }
-  }
 
   def traceLevelSet(i: Int): Unit = {
     traceLevel = i

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -284,6 +284,25 @@ object Utils {
   }
 
   def genNSpaces(n: Int) = s"${" " * n}"
+  def genTree(level: Int, indent: Int, last: Boolean = false): String = {
+    level match {
+      case 0 => ""
+      case 1 => {
+        last match {
+          case true  => s"└${"─" * (level * (indent - 1))} "
+          case false => s"├${"─" * (level * (indent - 1))} "
+        }
+      }
+      case _ => {
+        last match {
+          case true =>
+            s"│${" " * ((level - 1) * indent)}${" " * (level - 2)}└${"─" * (indent - 1)} "
+          case false =>
+            s"│${" " * ((level - 1) * indent)}${" " * (level - 2)}├${"─" * (indent - 1)} "
+        }
+      }
+    }
+  }
 
   def traceLevelSet(i: Int): Unit = {
     traceLevel = i

--- a/src/main/scala/dxWDL/base/package.scala
+++ b/src/main/scala/dxWDL/base/package.scala
@@ -33,6 +33,11 @@ case class Verbose(on: Boolean, quiet: Boolean, keywords: Set[String]) {
   }
 }
 
+// Tree printer types for the execTree option
+sealed trait TreePrinter
+case object JsonTreePrinter extends TreePrinter
+case object PrettyTreePrinter extends TreePrinter
+
 // Packing of all compiler flags in an easy to digest
 // format
 case class CompilerOptions(archive: Boolean,
@@ -48,7 +53,7 @@ case class CompilerOptions(archive: Boolean,
                            projectWideReuse: Boolean,
                            reorg: Boolean,
                            streamAllFiles: Boolean,
-                           execTree: Boolean,
+                           execTree: Option[TreePrinter],
                            runtimeDebugLevel: Option[Int],
                            verbose: Verbose)
 

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -328,8 +328,8 @@ case class Top(cOpt: CompilerOptions) {
             val tree = new Tree(cResults.execDict)
             val js = tree.apply(primary)
             // Pretty printing requires more work
-            //val pretty = tree.prettyPrint(primary)
-            (wf.dxExec.getId, Some((js, "")))
+            val pretty = tree.prettyPrint(primary)
+            (wf.dxExec.getId, Some((js, pretty)))
         }
       case Some(wf) =>
         (wf.dxExec.getId, None)

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -300,7 +300,7 @@ case class Top(cOpt: CompilerOptions) {
             folder: String,
             dxProject: DxProject,
             runtimePathConfig: DxPathConfig,
-            execTree: Boolean): (String, Option[(JsValue, String)]) = {
+            execTree: Option[TreePrinter]): (String, Option[Either[String, JsValue]]) = {
     val bundle: IR.Bundle = womToIR(source)
 
     // lookup platform files in bulk
@@ -320,16 +320,17 @@ case class Top(cOpt: CompilerOptions) {
       case None =>
         val ids = cResults.execDict.map { case (_, r) => r.dxExec.getId }.mkString(",")
         (ids, None)
-      case Some(wf) if execTree =>
+      case Some(wf) if execTree.isDefined =>
         cResults.primaryCallable match {
           case None =>
-            (wf.dxExec.getId, Some((JsNull, "")))
+            (wf.dxExec.getId, None)
           case Some(primary) =>
             val tree = new Tree(cResults.execDict)
-            val js = tree.apply(primary)
-            // Pretty printing requires more work
-            val pretty = tree.prettyPrint(primary)
-            (wf.dxExec.getId, Some((js, pretty)))
+            val treeRepr = execTree.get match { // Safe get because we check isDefined above
+              case PrettyTreePrinter => Left(tree.prettyPrint(primary))
+              case JsonTreePrinter => Right(tree.apply(primary)) // Convert to string
+            }
+            (wf.dxExec.getId, Some(treeRepr))
         }
       case Some(wf) =>
         (wf.dxExec.getId, None)

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -328,7 +328,7 @@ case class Top(cOpt: CompilerOptions) {
             val tree = new Tree(cResults.execDict)
             val treeRepr = execTree.get match { // Safe get because we check isDefined above
               case PrettyTreePrinter => Left(tree.prettyPrint(primary))
-              case JsonTreePrinter => Right(tree.apply(primary)) // Convert to string
+              case JsonTreePrinter   => Right(tree.apply(primary)) // Convert to string
             }
             (wf.dxExec.getId, Some(treeRepr))
         }

--- a/src/main/scala/dxWDL/compiler/Tree.scala
+++ b/src/main/scala/dxWDL/compiler/Tree.scala
@@ -81,8 +81,11 @@ case class Tree(execDict: Map[String, ExecRecord]) {
           }
         }.toVector
 
-        val stages = stageLines.mkString("\n")
-        prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET + "\n" + stages
+        if (stageLines.size > 0) {
+          prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET + "\n" + stageLines.mkString("\n")
+        } else {
+          prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET
+        }
       }
       case apl: IR.Applet => {
         apl.kind match {
@@ -94,7 +97,7 @@ case class Tree(execDict: Map[String, ExecRecord]) {
                 val isLast = index == (calls.size - 1)
                 val postPrefix = if (isLast) lastElem else midElem
                 val wholePrefix = if (isLast) {
-                  prefix.replace("├", "│").replace("└", "│").replace("─", " ") + postPrefix
+                  prefix.replace("├", "│").replace("└", " ").replace("─", " ") + postPrefix
                 } else {
                   prefix.replace("├", " ").replace("└", " ").replace("─", " ") + postPrefix
                 }
@@ -107,8 +110,12 @@ case class Tree(execDict: Map[String, ExecRecord]) {
               case None       => s"${apl.name}"
             }
 
-            prefix + Console.CYAN + s"App ${kindToString(apl.kind)}: " + Console.WHITE + name + Console.RESET + "\n" + links
-              .mkString("\n")
+            if (links.size > 0) {
+              prefix + Console.CYAN + s"App ${kindToString(apl.kind)}: " + Console.WHITE + name + Console.RESET + "\n" + links
+                .mkString("\n")
+            } else {
+              prefix + Console.CYAN + s"App ${kindToString(apl.kind)}: " + Console.WHITE + name + Console.RESET
+            }
           }
           case _ =>
             val name = stageDesc match {

--- a/src/main/scala/dxWDL/compiler/Tree.scala
+++ b/src/main/scala/dxWDL/compiler/Tree.scala
@@ -68,7 +68,7 @@ case class Tree(execDict: Map[String, ExecRecord]) {
           }
         }.toVector
 
-        Displayable(primary, wf.name + " WF", stageLines)
+        Displayable(primary, wf.name + " (Workflow)", stageLines)
 
       }
       case apl: IR.Applet => {
@@ -82,10 +82,10 @@ case class Tree(execDict: Map[String, ExecRecord]) {
                 prettyPrintRec(calleeRecord)
               }
             }.toVector
-            Displayable(primary, apl.name + " " + kindToString(apl.kind), links)
+            Displayable(primary, s"${apl.name} (${kindToString(apl.kind)})", links)
           }
           case _ =>
-            Displayable(primary, apl.name + " " + kindToString(apl.kind), Vector())
+            Displayable(primary, s"${apl.name} (${kindToString(apl.kind)})", Vector())
         }
       }
     }

--- a/src/main/scala/dxWDL/compiler/Tree.scala
+++ b/src/main/scala/dxWDL/compiler/Tree.scala
@@ -56,8 +56,32 @@ case class Tree(execDict: Map[String, ExecRecord]) {
     }
   }
 
-  // Traverse the exec tree and generate an appropriate name + color based on the node type
-  // pass back the prefix for the next node build on.
+  /** Recursivly traverse the exec tree and generate an appropriate name + color based on the node type.
+    * The prefix is built up as recursive calls happen. This allows for mainaining the locations of branches
+    * in the tree. When a prefix made for a current node, it undergoes a transformation to strip out any
+    * extra characters from previous calls. This maintains the indenation level and tree branches.
+    *
+    * Color scheme:
+    *   'types' are in CYAN, types being Workflow, App, Task etc
+    *   'names' are in WHITE for all app types, and YELLOW for workflow types
+    *
+    * Step by step:
+    *
+    *       TREE                                            LEVEL               prettyPrint calls (approx)                                                         NOTES
+    * Workflow: four_levels                                 0. Workflow         0a. prettyPrint(IR.Workflow, None)
+    * ├───App Inputs: common                                1. App              1a. prettyPrint(IR.App, Some("common"), 3, "├───")
+    * ├───App Fragment: if ((username == "a"))              1. App              1b. prettyPrint(IR.AppFrag, Some("if ((username == "a"))", 3, "├───")              The starting prefix for 6 would be ├───└───, that combo gets fixed to be what you actually see by the replace rules
+    * │   └───Workflow: four_levels_block_0                 2. Workflow         2a. prettyPrint(IR.Workflow, None, 3, "│   └───")
+    * │       ├───App Task: c1                              3. App              3a. prettyPrint(IR.App, None, 3, "│       ├───")                                   The prefix in the step before this would have looked like "│   └───├───"
+    * │       └───App Task: c2                              3. App              3b. pretyyPrint(IR.App, None, 3, "│       └───")
+    * ├───App Fragment: scatter (i in [1, 4, 9])            1. App              1c. prettyPrint(IR.AppFrag, Some("scatter (i in [1, 4, 9])", 3, "├───")
+    * │   └───App Fragment: four_levels_frag_4              2. App              2b. prettyPrint(IR.AppFrag, Some("four_levels_frag_4"), 3, "├───├───")
+    * │       └───Workflow: four_levels_block_1_0           3. Worflow          3c. prettyPrint(IR.Workflow, None, 3, "│       └───")
+    * │           ├───App Fragment: if ((j == "john"))      4. App              4a. prettyPrint(IR.AppFrag, Some("if ((j == "john"))"), 3, "│           ├───")
+    * │           │   └───App Task: concat                  5. App              5a. prettyPrint(IR.App, None, 3, "│           │   └───")                           The prefix that would be 'fixed', into this was "│           ├───└───"
+    * │           └───App Fragment: if ((j == "clease"))    4. App              4b. prettyPrint(IR.AppFrag, Some("if ((j == "clease"))"), 3, "│           └───")
+    * └───App Outputs: outputs                              1. App              1d. prettyPrint(IR.AppFrag, Some("outputs"), 3, "└───")
+    * */
   def prettyPrint(primary: Native.ExecRecord,
                   stageDesc: Option[String] = None,
                   indent: Int = 3,
@@ -66,23 +90,33 @@ case class Tree(execDict: Map[String, ExecRecord]) {
     val lastElem = s"└${"─" * indent}"
     val midElem = s"├${"─" * indent}"
 
+    // Determine the type of the current node
     primary.callable match {
       case wf: IR.Workflow => {
+        // If it's a workflow, we know it could have stages, follow each stage node as well
         val stageLines = wf.stages.zipWithIndex.map {
           case (stage, index) => {
             val isLast = index == wf.stages.size - 1
             val postPrefix = if (isLast) lastElem else midElem
             val wholePrefix = if (isLast) {
+              // This is the last node at this level, remove any ─ or └ characters fromt he
+              // prefix thus far, then append a prefix with a └.
               prefix.replace("├", "│").replace("└", " ").replace("─", " ") + postPrefix
             } else {
+              // Not last, strop out previous characters from the prefix and add a ├.
               prefix.replace("├", " ").replace("└", " ").replace("─", " ") + postPrefix
             }
+            // For Stages, the stage description field is more useful than the stage name, but it is only
+            // available on the workflow node, so pass it to the prettyPrint call that will generate the
+            // name for the stage
             prettyPrint(execDict(stage.calleeName), Some(stage.description), indent, wholePrefix)
           }
         }.toVector
 
+        // Append the stages to the workflow node that they originated from, if there are any
         if (stageLines.size > 0) {
-          prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET + "\n" + stageLines.mkString("\n")
+          prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET + "\n" + stageLines
+            .mkString("\n")
         } else {
           prefix + Console.CYAN + "Workflow: " + Console.YELLOW + wf.name + Console.RESET
         }
@@ -105,6 +139,7 @@ case class Tree(execDict: Map[String, ExecRecord]) {
               }
             }.toVector
 
+            // If our applet came from a stage as described by the workflow, use the passed back name
             val name = stageDesc match {
               case Some(name) => name
               case None       => s"${apl.name}"
@@ -118,6 +153,7 @@ case class Tree(execDict: Map[String, ExecRecord]) {
             }
           }
           case _ =>
+            // If our applet came from a stage as described by the workflow, use the passed back name
             val name = stageDesc match {
               case Some(name) => name
               case None       => s"${apl.name}"

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -115,41 +115,47 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "Native compile a single WDL task" taggedAs (NativeTestXX, EdgeTest) in {
     val path = pathFromBasename("compiler", "add.wdl")
     val retval = Main.compile(
-        path.toString :: "--execTree" :: cFlags
+        path.toString :: "--execTree" :: "json" :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationTree]
     inside(retval) {
-      case Main.SuccessfulTerminationTree(treeJs, treePretty) =>
-        treeJs.asJsObject.getFields("name", "kind") match {
-          case Seq(JsString(name), JsString(kind)) =>
-            name shouldBe ("add")
-            kind shouldBe ("Task")
-          //System.out.println(treePretty)
-          case other =>
-            throw new Exception(s"tree representation is wrong ${treeJs}")
-        }
-        println(treePretty)
+      case Main.SuccessfulTerminationTree(pretty) =>
+        pretty match {
+          case Left(str) => false // should not be the pretty string version
+          case Right(treeJs) => {
+            treeJs.asJsObject.getFields("name", "kind") match {
+              case Seq(JsString(name), JsString(kind)) =>
+                name shouldBe ("add")
+                kind shouldBe ("Task")
+              case other =>
+                throw new Exception(s"tree representation is wrong ${treeJs}")
+            }
+          }
+      }
     }
   }
 
   // linear workflow
   it should "Native compile a linear WDL workflow without expressions" taggedAs (NativeTestXX, EdgeTest) in {
     val path = pathFromBasename("compiler", "wf_linear_no_expr.wdl")
-    val retval = Main.compile(path.toString :: "--execTree" :: cFlags)
+    val retval = Main.compile(path.toString :: "--execTree" :: "json" :: cFlags)
     retval shouldBe a[Main.SuccessfulTerminationTree]
 
     inside(retval) {
-      case Main.SuccessfulTerminationTree(treeJs, treePretty) =>
-        treeJs.asJsObject.getFields("name", "kind", "stages") match {
-          case Seq(JsString(name), JsString(kind), JsArray(stages)) =>
-            name shouldBe ("wf_linear_no_expr")
-            kind shouldBe ("workflow")
-            stages.size shouldBe (3)
-          //System.out.println(treePretty)
-          case other =>
-            throw new Exception(s"tree representation is wrong ${treeJs}")
+      case Main.SuccessfulTerminationTree(pretty) =>
+        pretty match {
+          case Left(str) => false // should not be the pretty string version
+          case Right(treeJs) => {
+            treeJs.asJsObject.getFields("name", "kind", "stages") match {
+              case Seq(JsString(name), JsString(kind), JsArray(stages)) =>
+                name shouldBe ("wf_linear_no_expr")
+                kind shouldBe ("workflow")
+                stages.size shouldBe (3)
+              case other =>
+                throw new Exception(s"tree representation is wrong ${treeJs}")
+            }
+          }
         }
-        println(treePretty)
     }
   }
 
@@ -179,24 +185,57 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "Native compile a workflow with one level nesting" taggedAs (NativeTestXX, EdgeTest) in {
     val path = pathFromBasename("nested", "two_levels.wdl")
     val retval = Main.compile(
-        path.toString :: "--force" :: "--execTree" :: cFlags
+        path.toString :: "--force" :: "--execTree" :: "json" :: cFlags
     )
     retval shouldBe a[Main.SuccessfulTerminationTree]
 
     inside(retval) {
-      case Main.SuccessfulTerminationTree(treeJs, treePretty) =>
-        treeJs.asJsObject.getFields("name", "kind", "stages") match {
-          case Seq(JsString(name), JsString(kind), JsArray(stages)) =>
-            name shouldBe ("two_levels")
-            kind shouldBe ("workflow")
-            stages.size shouldBe (3)
-          //System.out.println(treePretty)
-          case other =>
-            throw new Exception(s"tree representation is wrong ${treeJs}")
+      case Main.SuccessfulTerminationTree(pretty) =>
+        pretty match {
+          case Left(str) => false // should not produce a pretty string
+          case Right(treeJs) => {
+            treeJs.asJsObject.getFields("name", "kind", "stages") match {
+              case Seq(JsString(name), JsString(kind), JsArray(stages)) =>
+                name shouldBe ("two_levels")
+                kind shouldBe ("workflow")
+                stages.size shouldBe (3)
+              case other =>
+                throw new Exception(s"tree representation is wrong ${treeJs}")
+            }
+          }
         }
-        println(treePretty)
     }
   }
+  
+  // it should "Display pretty print of tree with deep nesting" taggedAs (NativeTestXX, EdgeTest) in {
+  //   val path = pathFromBasename("nested", "four_levels.wdl")
+  //   val controlCode : (Char) => Boolean = (c:Char) => (c <= 32 || c == 127)
+  //   val retval = Main.compile(
+  //       path.toString :: "--force" :: "--execTree" :: "pretty" :: cFlags
+  //   )
+  //   retval shouldBe a[Main.SuccessfulTerminationTree]
+
+  //   inside(retval) {
+  //     case Main.SuccessfulTerminationTree(pretty) =>
+  //       pretty match {
+  //         case Left(str) => 
+  //           str.filterNot(controlCode) shouldBe """Workflow: four_levels
+  //                          |├───App Inputs: common
+  //                          |├───App Fragment: if ((username == "a"))
+  //                          |│   └───Workflow: four_levels_block_0
+  //                          |│       ├───App Task: c1
+  //                          |│       └───App Task: c2
+  //                          |├───App Fragment: scatter (i in [1, 4, 9])
+  //                          |│   └───App Fragment: four_levels_frag_4
+  //                          |│       └───Workflow: four_levels_block_1_0
+  //                          |│           ├───App Fragment: if ((j == "john"))
+  //                          |│           │   └───App Task: concat
+  //                          |│           └───App Fragment: if ((j == "clease"))
+  //                          |└───App Outputs: outputs""".stripMargin
+  //         case Right(treeJs) => false // should not go down this road
+  //       }
+  //   }
+  // }
 
   it should "handle various conditionals" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -128,6 +128,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
           case other =>
             throw new Exception(s"tree representation is wrong ${treeJs}")
         }
+        println(treePretty)
     }
   }
 
@@ -148,6 +149,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
           case other =>
             throw new Exception(s"tree representation is wrong ${treeJs}")
         }
+        println(treePretty)
     }
   }
 
@@ -192,6 +194,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
           case other =>
             throw new Exception(s"tree representation is wrong ${treeJs}")
         }
+        println(treePretty)
     }
   }
 

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -131,7 +131,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
                 throw new Exception(s"tree representation is wrong ${treeJs}")
             }
           }
-      }
+        }
     }
   }
 
@@ -206,36 +206,36 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         }
     }
   }
-  
-  // it should "Display pretty print of tree with deep nesting" taggedAs (NativeTestXX, EdgeTest) in {
-  //   val path = pathFromBasename("nested", "four_levels.wdl")
-  //   val controlCode : (Char) => Boolean = (c:Char) => (c <= 32 || c == 127)
-  //   val retval = Main.compile(
-  //       path.toString :: "--force" :: "--execTree" :: "pretty" :: cFlags
-  //   )
-  //   retval shouldBe a[Main.SuccessfulTerminationTree]
 
-  //   inside(retval) {
-  //     case Main.SuccessfulTerminationTree(pretty) =>
-  //       pretty match {
-  //         case Left(str) => 
-  //           str.filterNot(controlCode) shouldBe """Workflow: four_levels
-  //                          |├───App Inputs: common
-  //                          |├───App Fragment: if ((username == "a"))
-  //                          |│   └───Workflow: four_levels_block_0
-  //                          |│       ├───App Task: c1
-  //                          |│       └───App Task: c2
-  //                          |├───App Fragment: scatter (i in [1, 4, 9])
-  //                          |│   └───App Fragment: four_levels_frag_4
-  //                          |│       └───Workflow: four_levels_block_1_0
-  //                          |│           ├───App Fragment: if ((j == "john"))
-  //                          |│           │   └───App Task: concat
-  //                          |│           └───App Fragment: if ((j == "clease"))
-  //                          |└───App Outputs: outputs""".stripMargin
-  //         case Right(treeJs) => false // should not go down this road
-  //       }
-  //   }
-  // }
+  ignore should "Display pretty print of tree with deep nesting" taggedAs (NativeTestXX, EdgeTest) in {
+    val path = pathFromBasename("nested", "four_levels.wdl")
+    val controlCode: (Char) => Boolean = (c: Char) => (c <= 32 || c == 127)
+    val retval = Main.compile(
+        path.toString :: "--force" :: "--execTree" :: "pretty" :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationTree]
+
+    inside(retval) {
+      case Main.SuccessfulTerminationTree(pretty) =>
+        pretty match {
+          case Left(str) =>
+            str.filterNot(controlCode) shouldBe """Workflow: four_levels
+                                                  |├───App Inputs: common
+                                                  |├───App Fragment: if ((username == "a"))
+                                                  |│   └───Workflow: four_levels_block_0
+                                                  |│       ├───App Task: c1
+                                                  |│       └───App Task: c2
+                                                  |├───App Fragment: scatter (i in [1, 4, 9])
+                                                  |│   └───App Fragment: four_levels_frag_4
+                                                  |│       └───Workflow: four_levels_block_1_0
+                                                  |│           ├───App Fragment: if ((j == "john"))
+                                                  |│           │   └───App Task: concat
+                                                  |│           └───App Fragment: if ((j == "clease"))
+                                                  |└───App Outputs: outputs""".stripMargin
+          case Right(treeJs) => false // should not go down this road
+        }
+    }
+  }
 
   it should "handle various conditionals" taggedAs (NativeTestXX) in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")


### PR DESCRIPTION
Adding a `tree`-like pretty print option via the --execTree pretty option. It works, I just haven't found a good way to make a test for it. The escape codes for the colors really mess with direct text comparison.

EX of it in action:
![image](https://user-images.githubusercontent.com/6712477/73503105-20008000-4380-11ea-9924-3419b5a2f188.png)
