### PR TITLE
Patterns object

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 1.43
 - Providing a tree structure representing a compiled workflow via `--execTree pretty`
 - For the json structure use `--execTree json`
+- Added support for the parameter_meta: patterns to take an object: [docs/ExpertOptions](doc/ExpertOptions.md#parameter_meta-section) 
 
 ## 1.42 23-Jan-2020
 - Providing a JSON structure representing a compiled workflow. This can be done with the command line flag `--execTree`. For example:
@@ -14,7 +15,7 @@ java -jar dxWDL-v1.42.jar compile CODE.wdl --project project-xxxx --execTree
 - Bug fix for case where the number of executions is large and requires multiple queries.
 
 ## 1.41 21-Jan-2020
-- Added support for `patterns` and `help` in the `parameters_meta` section of a WDL task. For more information, see [docs/ExpertOptions](doc/ExpertOptions.md#parameter_meta-section)
+- Added support for `patterns` and `help` in the `parameter_meta` section of a WDL task. For more information, see [docs/ExpertOptions](doc/ExpertOptions.md#parameter_meta-section)
 - Upgrade to Cromwell v48
 - Upgrade to dxfuse v0.17
 - Added support for a `path` command line argument to `dxni`.

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -250,7 +250,7 @@ for limited support.
 The [WDL Spec](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#parameter-metadata-section) defines a `parameter_meta` section that may contain key value pairs to assoicate metadata with input and output variables. Currently, three keywords are supported:
 
 - `help`, which maps directly to the dxapp.json inputSpec.help field
-- `patterns`, which maps directly to the dxapp.json inputSpec.patterns field
+- `patterns`, which maps directly to the dxapp.json inputSpec.patterns field, both array and object form
 - `stream`, indicates whether or not an input file should be streamed. See [here](#Streaming) for more details
 
 More about `help` and `patterns` can be read [here](https://documentation.dnanexus.com/developer/api/running-analyses/io-and-run-specifications). Although the WDL spec indicates that the `parameter_meta` section should apply to both input and output variables, WOM currently only maps the parameter_meta section to the input vars.

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -77,11 +77,34 @@ case class GenerateIRTask(verbose: Verbose,
       Some(obj.flatMap {
         case (IR.PARAM_META_HELP, MetaValueElementString(text)) => Some(IR.IOAttrHelp(text))
         case (IR.PARAM_META_PATTERNS, MetaValueElementArray(array)) =>
-          Some(IR.IOAttrPatterns(array.flatMap {
+          Some(IR.IOAttrPatterns(IR.PatternsReprArray(array.flatMap {
             case MetaValueElementString(pattern) => Some(pattern)
             case _                               => None
-
-          }.toVector))
+          }.toVector)))
+        case (IR.PARAM_META_PATTERNS, MetaValueElementObject(obj)) =>
+          val name = obj.get("name") match {
+            case Some(MetaValueElementArray(array)) =>
+              Some(array.flatMap {
+                case MetaValueElementString(value) => Some(value)
+                case _                             => None
+              }.toVector)
+            case _ => None
+          }
+          val klass = obj.get("class") match {
+            case Some(MetaValueElementString(value)) => Some(value)
+            case _                                   => None
+          }
+          val tag = obj.get("tag") match {
+            case Some(MetaValueElementArray(array)) =>
+              Some(array.flatMap {
+                case MetaValueElementString(value) => Some(value)
+                case _                             => None
+              }.toVector)
+            case _ => None
+          }
+          Some(
+              IR.IOAttrPatterns(IR.PatternsReprObj(name, klass, tag))
+          )
         case _ => None
 
       }.toVector)

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -89,7 +89,7 @@ case class GenerateIRTask(verbose: Verbose,
         // First see if it's an array
         case (IR.PARAM_META_PATTERNS, MetaValueElementArray(array)) =>
           Some(IR.IOAttrPatterns(IR.PatternsReprArray(metaStringArrayToVec(array))))
-        // See if it's an object, and if it is, parse out the optionsl key, class, and tag keys
+        // See if it's an object, and if it is, parse out the optional key, class, and tag keys
         // Note all three are optional
         case (IR.PARAM_META_PATTERNS, MetaValueElementObject(obj)) =>
           val name = obj.get("name") match {

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -26,7 +26,17 @@ object IR {
   val PARAM_META_HELP = "help"
   val PARAM_META_PATTERNS = "patterns"
 
-  // Compile time representation of the dxapp IO spec patterns
+  /** Compile time representation of the dxapp IO spec patterns
+    *  Example:
+    *  'patterns': { // PatternsReprObj
+    *    'name': ['*.sam', '*.bam'],
+    *    'class': 'file',
+    *    'tag': ['foo', 'bar']
+    *  }
+    *   OR
+    * 'patterns': ['*.sam', '*.bam'] // PatternsReprArray
+    *
+   **/
   sealed abstract class PatternsRepr
   final case class PatternsReprArray(patterns: Vector[String]) extends PatternsRepr
   final case class PatternsReprObj(name: Option[Vector[String]],

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -26,11 +26,19 @@ object IR {
   val PARAM_META_HELP = "help"
   val PARAM_META_PATTERNS = "patterns"
 
+  // Compile time representation of the dxapp IO spec patterns
+  sealed abstract class PatternsRepr
+  final case class PatternsReprArray(patterns: Vector[String]) extends PatternsRepr
+  final case class PatternsReprObj(name: Option[Vector[String]],
+                                   klass: Option[String],
+                                   tag: Option[Vector[String]])
+      extends PatternsRepr
+
   // Compile time representaiton of supported parameter_meta section
-  // information.
+  // information for the dxapp IO spec
   sealed abstract class IOAttr
   final case class IOAttrHelp(text: String) extends IOAttr
-  final case class IOAttrPatterns(patterns: Vector[String]) extends IOAttr
+  final case class IOAttrPatterns(patternRepr: PatternsRepr) extends IOAttr
 
   // Compile time representation of a variable. Used also as
   // an applet argument.

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -130,6 +130,7 @@ case class Native(dxWDLrtId: Option[String],
                       else None,
                       if (klass.isDefined) Some("class" -> JsString(klass.get)) else None
                   ).flatten.toMap
+                  // If all three keys for the object version of patterns are None, return None
                   if (attrs.isEmpty) None else Some(IR.PARAM_META_PATTERNS -> JsObject(attrs))
               }
             case _ => None

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -17,7 +17,6 @@ import dxWDL.base._
 import dxWDL.util._
 import dxWDL.dx._
 import IR.{CVar, SArg}
-import dxWDL.compiler.IR.PatternsReprArray
 
 // The end result of the compiler
 object Native {
@@ -107,6 +106,7 @@ case class Native(dxWDLrtId: Option[String],
         wdlVarLinksConverter.genFields(wvl, name).toMap
     }
 
+    // Create the IO Attributes, currently `patterns` and `help`
     def jsMapFromAttrs(
         help: Option[Vector[IR.IOAttr]]
     ): Map[String, JsValue] = {
@@ -126,7 +126,7 @@ case class Native(dxWDLrtId: Option[String],
                   val attrs: Map[String, JsValue] = List(
                       if (name.isDefined) Some("name" -> JsArray(name.get.map(JsString(_))))
                       else None,
-                      if (tags.isDefined) Some("tags" -> JsArray(tags.get.map(JsString(_))))
+                      if (tags.isDefined) Some("tag" -> JsArray(tags.get.map(JsString(_))))
                       else None,
                       if (klass.isDefined) Some("class" -> JsString(klass.get)) else None
                   ).flatten.toMap

--- a/src/test/resources/compiler/pattern_obj_params.wdl
+++ b/src/test/resources/compiler/pattern_obj_params.wdl
@@ -1,0 +1,36 @@
+version 1.0
+
+# adding a pattern attr to the parameter_meta section for an input variable
+# should propogate that var to the interface
+
+# Correct
+task pattern_params_obj_cgrep {
+    input {
+        String pattern
+        File in_file
+    }
+    parameter_meta {
+        in_file: {
+          help: "The input file to be searched",
+          patterns: {
+              name: ["*.txt", "*.tsv"],
+              class: "file",
+              tag: ["foo", "bar"]
+          }
+        }
+        pattern: {
+          help: "The pattern to use to search in_file"
+        }
+        out_file: {
+          patterns: ["*.txt", "*.tsv"]
+        }
+    }
+    command {
+        grep '${pattern}' ${in_file} | wc -l
+        cp ${in_file} out_file
+    }
+    output {
+        Int count = read_int(stdout())
+        File out_file = "out_file"
+    }
+}

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -310,7 +310,56 @@ class GenerateIRTest extends FlatSpec with Matchers {
             Some(
                 Vector(
                     IR.IOAttrHelp("The input file to be searched"),
-                    IR.IOAttrPatterns(Vector("*.txt", "*.tsv"))
+                    IR.IOAttrPatterns(IR.PatternsReprArray(Vector("*.txt", "*.tsv")))
+                )
+            )
+        ),
+        IR.CVar(
+            "pattern",
+            WomStringType,
+            None,
+            Some(Vector(IR.IOAttrHelp("The pattern to use to search in_file")))
+        )
+    )
+    cgrepApplet.outputs shouldBe Vector(
+        IR.CVar("count", WomIntegerType, None, None),
+        IR.CVar(
+            "out_file",
+            WomSingleFileType,
+            None,
+            None
+        )
+    )
+  }
+
+  // Check parameter_meta `pattern` keyword
+  it should "recognize pattern object in parameters_obj_meta via CVar for input CVars" in {
+    val path = pathFromBasename("compiler", "pattern_obj_params.wdl")
+    val retval = Main.compile(
+        path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
+    }
+
+    val cgrepApplet = getAppletByName("pattern_params_obj_cgrep", bundle)
+    cgrepApplet.inputs shouldBe Vector(
+        IR.CVar(
+            "in_file",
+            WomSingleFileType,
+            None,
+            Some(
+                Vector(
+                    IR.IOAttrHelp("The input file to be searched"),
+                    IR.IOAttrPatterns(
+                        IR.PatternsReprObj(
+                            Some(Vector("*.txt", "*.tsv")),
+                            Some("file"),
+                            Some(Vector("foo", "bar"))
+                        )
+                    )
                 )
             )
         ),

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -381,7 +381,7 @@ class GenerateIRTest extends FlatSpec with Matchers {
     )
   }
 
-  // Check parameter_meta `help` keyword
+  // Check parameter_meta pattern: ["array"]
   it should "recognize pattern in parameters_meta via WOM" in {
     val path = pathFromBasename("compiler", "pattern_params.wdl")
     val retval = Main.compile(
@@ -436,6 +436,82 @@ class GenerateIRTest extends FlatSpec with Matchers {
                     Vector(
                         MetaValueElement.MetaValueElementString("*.txt"),
                         MetaValueElement.MetaValueElementString("*.tsv")
+                    )
+                )
+            )
+        )
+    ))
+  }
+
+  // Check parameter_meta pattern: {"object"}
+  it should "recognize pattern object in parameters_meta via WOM" in {
+    val path = pathFromBasename("compiler", "pattern_obj_params.wdl")
+    val retval = Main.compile(
+        path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
+    }
+
+    val cgrepTask = getTaskByName("pattern_params_obj_cgrep", bundle)
+    cgrepTask.parameterMeta shouldBe (
+        Map(
+            "in_file" -> MetaValueElement.MetaValueElementObject(
+                Map(
+                    "help" -> MetaValueElement
+                      .MetaValueElementString("The input file to be searched"),
+                    "patterns" -> MetaValueElement.MetaValueElementObject(
+                        Map(
+                            "class" -> MetaValueElement.MetaValueElementString("file"),
+                            "tag" -> MetaValueElement.MetaValueElementArray(
+                                Vector(MetaValueElement.MetaValueElementString("foo"),
+                                       MetaValueElement.MetaValueElementString("bar"))
+                            ),
+                            "name" -> MetaValueElement.MetaValueElementArray(
+                                Vector(MetaValueElement.MetaValueElementString("*.txt"),
+                                       MetaValueElement.MetaValueElementString("*.tsv"))
+                            )
+                        )
+                    )
+                )
+            ),
+            "pattern" -> MetaValueElement.MetaValueElementObject(
+                Map(
+                    "help" -> MetaValueElement
+                      .MetaValueElementString("The pattern to use to search in_file")
+                )
+            ),
+            "out_file" -> MetaValueElement.MetaValueElementObject(
+                Map(
+                    "patterns" -> MetaValueElement.MetaValueElementArray(
+                        Vector(
+                            MetaValueElement.MetaValueElementString("*.txt"),
+                            MetaValueElement.MetaValueElementString("*.tsv")
+                        )
+                    )
+                )
+            )
+        )
+    )
+    val iDef = cgrepTask.inputs.find(_.name == "in_file").get
+    iDef.parameterMeta shouldBe (Some(
+        MetaValueElement.MetaValueElementObject(
+            Map(
+                "help" -> MetaValueElement
+                  .MetaValueElementString("The input file to be searched"),
+                "patterns" -> MetaValueElement.MetaValueElementObject(
+                    Map(
+                        "class" -> MetaValueElement.MetaValueElementString("file"),
+                        "tag" -> MetaValueElement.MetaValueElementArray(
+                            Vector(MetaValueElement.MetaValueElementString("foo"),
+                                   MetaValueElement.MetaValueElementString("bar"))
+                        ),
+                        "name" -> MetaValueElement.MetaValueElementArray(
+                            Vector(MetaValueElement.MetaValueElementString("*.txt"),
+                                   MetaValueElement.MetaValueElementString("*.tsv"))
+                        )
                     )
                 )
             )


### PR DESCRIPTION
This is a PR to add the object value to the parameter_meta.patterns field. So it now is feature complete with what is described in this document: https://documentation.dnanexus.com/developer/api/running-analyses/io-and-run-specifications.

Example

```
version 1.0

# adding a pattern attr to the parameter_meta section for an input variable
# should propogate that var to the interface

# Correct
task pattern_params_obj_cgrep {
    input {
        String pattern
        File in_file
    }
    parameter_meta {
        in_file: {
          help: "The input file to be searched",
          patterns: {
              name: ["*.txt", "*.tsv"],
              class: "file",
              tag: ["foo", "bar"]
          }
        }
        pattern: {
          help: "The pattern to use to search in_file"
        }
        out_file: {
          patterns: ["*.txt", "*.tsv"]
        }
    }
    command {
        grep '${pattern}' ${in_file} | wc -l
        cp ${in_file} out_file
    }
    output {
        Int count = read_int(stdout())
        File out_file = "out_file"
    }
}
```