### PR TITLE
Error: bad object DxApplet during workflow compilation with -projectWideReuse option

### DIFF
--- a/scripts/proxy_test.py
+++ b/scripts/proxy_test.py
@@ -101,12 +101,6 @@ def compile(project, folder, version_id, proxy = None):
     return oid.decode("ascii")
 
 
-def build_dirs(project, version_id):
-    base_folder = "/builds/{}".format(version_id)
-    folder = base_folder + "/proxy"
-    project.new_folder(folder, parents=True)
-    return folder
-
 # test 1:
 # The squid configuration has a deny-all. The compiler should fail.
 def test_deny(project, folder, version_id):
@@ -266,7 +260,7 @@ def main():
     project = util.get_project(args.project)
     if project is None:
         raise RuntimeError("Could not find project {}".format(args.project))
-    folder = build_dirs(project, version_id)
+    folder = util.build_dirs(project, version_id)
     print("project: {} ({})".format(project.name, project.get_id()))
     print("folder: {}".format(folder))
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -160,6 +160,7 @@ test_unlocked=["array_structs",
                "path_not_taken",
                "optionals",
                "shapes"]
+test_project_wide_reuse=['add2', "add_many"]
 
 test_import_dirs=["A"]
 TestMetaData = namedtuple('TestMetaData', ['name','kind'])
@@ -498,6 +499,8 @@ def compiler_per_test_flags(tname):
         flags.append("-locked")
     if tname in test_reorg:
         flags.append("-reorg")
+    if tname in test_project_wide_reuse:
+        flags.append("-projectWideReuse")
     if tname in test_defaults:
         flags.append("-defaults")
         flags.append(desc.wdl_input)
@@ -674,6 +677,8 @@ def main():
                            action="store_true", default=False)
     argparser.add_argument("--project", help="DNAnexus project ID",
                            default="dxWDL_playground")
+    argparser.add_argument("--project-wide-reuse", help="look for existing applets in the entire project",
+                           action="store_true", default=False)
     argparser.add_argument("--stream-all-files", help="Stream all input files with dxfs2",
                            action="store_true", default=False)
     argparser.add_argument("--runtime-debug-level",
@@ -746,6 +751,8 @@ def main():
             compiler_flags += ["-verboseKey", key]
     if args.runtime_debug_level:
         compiler_flags += ["-runtimeDebugLevel", args.runtime_debug_level]
+    if args.project_wide_reuse:
+        compiler_flags.append("-projectWideReuse")
 
     #  is "native" included in one of the test names?
     if ("call_native" in test_names or

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -501,7 +501,7 @@ case class Native(dxWDLrtId: Option[String],
     dxObjDir.lookupOtherVersions(name, digest) match {
       case None => ()
       case Some((dxObj, desc)) =>
-        dxObj match {
+        desc match {
           case a: DxAppDescribe =>
             Utils.trace(verbose.on, s"Found existing version of app ${name}")
           case apl: DxAppletDescribe =>


### PR DESCRIPTION
There was a wrong comparison when looking for other versions of the same applet. It is weird that scala type safety did not flag this, because two different types were compared. They could never match.