### PR TITLE
Add support for 'description' and 'dx_type' in parameter_meta

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,9 +6,7 @@
   - label
   - choices
   - suggestions
-<!--
   - dx_type
--->
 
 ## 1.43 11-Feb-2020
 - Providing a tree structure representing a compiled workflow via `--execTree pretty`

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -257,9 +257,7 @@ The [WDL Spec](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#p
   - `patterns`
   - `choices`
   - `suggestions`
-<!--
   - `dx_type` (maps to the `type` field in dxapp.json)
--->
 
 Although the WDL spec indicates that the `parameter_meta` section should apply to both input and output variables, WOM currently only maps the parameter_meta section to the input parameters.
 

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -282,13 +282,18 @@ case class GenerateIRTask(verbose: Verbose,
       paramMeta: Option[MetaValueElement], womType: WomType
   ): Option[Vector[IR.IOAttr]] = paramMeta match {
     case None => None
+    // If the parameter metadata is a string, treat it as help
+    case Some(MetaValueElementString(text)) => Some(Vector(IR.IOAttrHelp(text)))
     case Some(MetaValueElementObject(obj)) => {
+      // Whether to use 'description' in place of help
+      val noHelp = !obj.contains(IR.PARAM_META_HELP)
       // Use flatmap to get the parameter metadata keys if they exist
       Some(obj.flatMap {
         case (IR.PARAM_META_GROUP, MetaValueElementString(text)) => Some(IR.IOAttrGroup(text))
         case (IR.PARAM_META_HELP, MetaValueElementString(text)) => Some(IR.IOAttrHelp(text))
-        case (IR.PARAM_META_DESCRIPTION, MetaValueElementString(text)) => 
-          Some(IR.IOAttrDescription(text))
+        // Use 'description' in place of 'help' if the former is present and the latter is not
+        case (IR.PARAM_META_DESCRIPTION, MetaValueElementString(text)) if noHelp => 
+          Some(IR.IOAttrHelp(text))
         case (IR.PARAM_META_LABEL, MetaValueElementString(text)) => Some(IR.IOAttrLabel(text))
         // Try to parse the patterns key
         // First see if it's an array

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -287,6 +287,8 @@ case class GenerateIRTask(verbose: Verbose,
       Some(obj.flatMap {
         case (IR.PARAM_META_GROUP, MetaValueElementString(text)) => Some(IR.IOAttrGroup(text))
         case (IR.PARAM_META_HELP, MetaValueElementString(text)) => Some(IR.IOAttrHelp(text))
+        case (IR.PARAM_META_DESCRIPTION, MetaValueElementString(text)) => 
+          Some(IR.IOAttrDescription(text))
         case (IR.PARAM_META_LABEL, MetaValueElementString(text)) => Some(IR.IOAttrLabel(text))
         // Try to parse the patterns key
         // First see if it's an array

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -252,15 +252,15 @@ case class GenerateIRTask(verbose: Verbose,
       constraint: MetaValueElement): IR.ConstraintRepr = constraint match {
     case MetaValueElementObject(obj: Map[String, MetaValueElement]) =>
       if (obj.size != 1) {
-        throw new Exception("Constraint hash must have exaclty one 'and_' or 'or_' key")
+        throw new Exception("Constraint hash must have exactly one 'and' or 'or' key")
       }
       obj.head match {
-        case ("and_", MetaValueElementArray(array)) => 
-          IR.ConstraintReprOper("and", array.map(metaConstraintToIR))
-        case ("or_", MetaValueElementArray(array)) =>
-          IR.ConstraintReprOper("or", array.map(metaConstraintToIR))
+        case (IR.PARAM_META_CONSTRAINT_AND, MetaValueElementArray(array)) => 
+          IR.ConstraintReprOper(ConstraintOper.AND, array.map(metaConstraintToIR))
+        case (IR.PARAM_META_CONSTRAINT_OR, MetaValueElementArray(array)) =>
+          IR.ConstraintReprOper(ConstraintOper.OR, array.map(metaConstraintToIR))
         case _ => throw new Exception(
-          "Constraint must have key 'and_' or 'or_' and an array value"
+          "Constraint must have key 'and' or 'or' and an array value"
         )
       }
     case MetaValueElementString(s) => IR.ConstraintReprString(s)
@@ -305,10 +305,9 @@ case class GenerateIRTask(verbose: Verbose,
           Some(IR.IOAttrSuggestions(metaSuggestionsArrayToIR(array, wt)))
         case (IR.PARAM_META_TYPE, dx_type: MetaValueElement) => 
           val wt = unwrapWomArrayType(womType)
-          if (wt.isInstanceOf[WomSingleFileType]) {
-            Some(IR.IOAttrType(metaConstraintToIR(dx_type)))
-          } else {
-            throw new Exception("'dx_type' can only be specified for File parameters")
+          wt match {
+            case WomSingleFileType => Some(IR.IOAttrType(metaConstraintToIR(dx_type)))
+            case _ => throw new Exception("'dx_type' can only be specified for File parameters")
           }
         case _ => None
       }.toVector)

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -25,6 +25,8 @@ object IR {
   // Keywords for string pattern matching used in in WDL parameter_meta
   
   val PARAM_META_CHOICES = "choices"
+  val PARAM_META_DEFAULT = "default"
+  val PARAM_META_DESCRIPTION = "description"  // accepted as a synonym to 'help'
   val PARAM_META_GROUP = "group"
   val PARAM_META_HELP = "help"
   val PARAM_META_LABEL = "label"
@@ -101,6 +103,7 @@ object IR {
   sealed abstract class IOAttr
   final case class IOAttrGroup(text: String) extends IOAttr
   final case class IOAttrHelp(text: String) extends IOAttr
+  final case class IOAttrDescription(text: String) extends IOAttr
   final case class IOAttrLabel(text: String) extends IOAttr
   final case class IOAttrPatterns(patternRepr: PatternsRepr) extends IOAttr
   final case class IOAttrChoices(choices: Vector[ChoiceRepr]) extends IOAttr

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -103,7 +103,6 @@ object IR {
   sealed abstract class IOAttr
   final case class IOAttrGroup(text: String) extends IOAttr
   final case class IOAttrHelp(text: String) extends IOAttr
-  final case class IOAttrDescription(text: String) extends IOAttr
   final case class IOAttrLabel(text: String) extends IOAttr
   final case class IOAttrPatterns(patternRepr: PatternsRepr) extends IOAttr
   final case class IOAttrChoices(choices: Vector[ChoiceRepr]) extends IOAttr

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -30,7 +30,7 @@ object IR {
   val PARAM_META_LABEL = "label"
   val PARAM_META_PATTERNS = "patterns"
   val PARAM_META_SUGGESTIONS = "suggestions"
-  val PARAM_META_TYPE = "dx_type" // TODO
+  val PARAM_META_TYPE = "dx_type"
 
   /** Compile time representation of the dxapp IO spec patterns
     *  Example:
@@ -88,6 +88,11 @@ object IR {
     path: Option[String],
   ) extends SuggestionRepr
 
+  sealed abstract class ConstraintRepr
+  sealed case class ConstraintReprString(constraint: String) extends ConstraintRepr
+  sealed case class ConstraintReprOper(oper: String, constraints: Vector[ConstraintRepr]) 
+      extends ConstraintRepr
+
   // Compile time representaiton of supported parameter_meta section
   // information for the dxapp IO spec.
   sealed abstract class IOAttr
@@ -97,7 +102,8 @@ object IR {
   final case class IOAttrPatterns(patternRepr: PatternsRepr) extends IOAttr
   final case class IOAttrChoices(choices: Vector[ChoiceRepr]) extends IOAttr
   final case class IOAttrSuggestions(suggestions: Vector[SuggestionRepr]) extends IOAttr
-
+  final case class IOAttrType(constraint: ConstraintRepr) extends IOAttr
+  
   // Compile time representation of a variable. Used also as
   // an applet argument.
   //

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -13,7 +13,7 @@ import wom.types.WomType
 import wom.values.WomValue
 
 import dxWDL.base.Utils
-import dxWDL.dx.{DxFile, DxWorkflowStage}
+import dxWDL.dx.{ConstraintOper, DxFile, DxWorkflowStage}
 
 object IR {
   // stages that the compiler uses in generated DNAx workflows
@@ -22,7 +22,7 @@ object IR {
   val REORG = "reorg"
   val CUSTOM_REORG_CONFIG = "reorg_config"
 
-  // Keywords for string pattern matching
+  // Keywords for string pattern matching used in in WDL parameter_meta
   
   val PARAM_META_CHOICES = "choices"
   val PARAM_META_GROUP = "group"
@@ -31,6 +31,9 @@ object IR {
   val PARAM_META_PATTERNS = "patterns"
   val PARAM_META_SUGGESTIONS = "suggestions"
   val PARAM_META_TYPE = "dx_type"
+  
+  val PARAM_META_CONSTRAINT_AND = "and"
+  val PARAM_META_CONSTRAINT_OR = "or"
 
   /** Compile time representation of the dxapp IO spec patterns
     *  Example:
@@ -90,8 +93,8 @@ object IR {
 
   sealed abstract class ConstraintRepr
   sealed case class ConstraintReprString(constraint: String) extends ConstraintRepr
-  sealed case class ConstraintReprOper(oper: String, constraints: Vector[ConstraintRepr]) 
-      extends ConstraintRepr
+  sealed case class ConstraintReprOper(
+    oper: ConstraintOper.Value, constraints: Vector[ConstraintRepr]) extends ConstraintRepr
 
   // Compile time representaiton of supported parameter_meta section
   // information for the dxapp IO spec.

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -183,6 +183,8 @@ case class Native(dxWDLrtId: Option[String],
                 }
               }
             })))
+          case IR.IOAttrType(constraint) =>
+            Some(IR.PARAM_META_TYPE =>
           case _ => None
         }.toMap
       }

--- a/src/test/resources/compiler/add_dx_type.wdl
+++ b/src/test/resources/compiler/add_dx_type.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task add_group {
+task add_dx_type {
     input {
         File a
         File b
@@ -16,10 +16,10 @@ task add_group {
         }
         b: {
             dx_type: {
-                and_: [
+                and: [
                     "fastq", 
                     {
-                        or_: ["Read1", "Read2"]
+                        or: ["Read1", "Read2"]
                     }
                 ]
             }

--- a/src/test/resources/compiler/add_dx_type.wdl
+++ b/src/test/resources/compiler/add_dx_type.wdl
@@ -1,0 +1,32 @@
+version 1.0
+
+task add_group {
+    input {
+        File a
+        File b
+    }
+    
+    command {
+    cat ~{a} ~{b}
+    }
+
+    parameter_meta {
+        a: {
+            dx_type: "fastq"
+        }
+        b: {
+            dx_type: {
+                and_: [
+                    "fastq", 
+                    {
+                        or_: ["Read1", "Read2"]
+                    }
+                ]
+            }
+        }
+    }
+
+    output {
+        String result = stdout()
+    }
+}

--- a/src/test/resources/compiler/add_help.wdl
+++ b/src/test/resources/compiler/add_help.wdl
@@ -4,6 +4,9 @@ task add_help {
     input {
         Int a
         Int b
+        String c
+        String d
+        String e
     }
     command {
         echo $((${a} + ${b}))
@@ -12,14 +15,22 @@ task add_help {
         summary: "Adds two int together"
     }
 
-		parameter_meta {
-			a: {
-				help: "lefthand side"
-			}
-			b: {
-				help: "righthand side"
-			}
-		}
+    parameter_meta {
+        a: {
+            help: "lefthand side"
+        }
+        b: {
+            help: "righthand side"
+        }
+        c: {
+            description: "Use this"
+        }
+        d: {
+            help: "Use this",
+            description: "Don't use this"
+        }
+        e: "Use this"
+    }
 
     output {
         Int result = read_int(stdout())

--- a/src/test/resources/compiler/help_input_params.wdl
+++ b/src/test/resources/compiler/help_input_params.wdl
@@ -10,6 +10,7 @@ task help_input_params_cgrep {
     input {
         String pattern
         File in_file
+        String s
     }
     parameter_meta {
       in_file : {
@@ -18,10 +19,11 @@ task help_input_params_cgrep {
         label: "Input file"
       }
       pattern: {
-        help: "The pattern to use to search in_file",
+        description: "The pattern to use to search in_file",
         group: "Common",
         label: "Search pattern"
       }
+      s: "This is help for s"
     }
     command {
         grep '${pattern}' ${in_file} | wc -l

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -863,12 +863,13 @@ class GenerateIRTest extends FlatSpec with Matchers {
             ),
             "pattern" -> MetaValueElement.MetaValueElementObject(
                 Map(
-                    "help" -> MetaValueElement
+                    "description" -> MetaValueElement
                       .MetaValueElementString("The pattern to use to search in_file"),
                     "group" -> MetaValueElement.MetaValueElementString("Common"),
                     "label" -> MetaValueElement.MetaValueElementString("Search pattern")
                 )
-            )
+            ),
+            "s" -> MetaValueElement.MetaValueElementString("This is help for s")
         )
     )
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
@@ -917,6 +918,14 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val cgrepApplet = getAppletByName("help_input_params_cgrep", bundle)
     cgrepApplet.inputs shouldBe Vector(
+        IR.CVar(
+          "s",
+          WomStringType,
+          None,
+          Some(Vector(
+            IR.IOAttrHelp("This is help for s")
+          ))
+        ),
         IR.CVar(
             "in_file",
             WomSingleFileType,

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -548,12 +548,15 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val dxApplet = DxApplet.getInstance(appId)
     val inputSpec = dxApplet.describe(Set(Field.InputSpec))
-    val (a, b) = inputSpec.inputSpec match {
-      case Some(x) => (x(0), x(1))
+    val (a, b, c, d, e) = inputSpec.inputSpec match {
+      case Some(x) => (x(0), x(1), x(2), x(3), x(4))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
     a.help shouldBe Some("lefthand side")
     b.help shouldBe Some("righthand side")
+    c.help shouldBe Some("Use this")
+    d.help shouldBe Some("Use this")
+    e.help shouldBe Some("Use this")
   }
 
   it should "be able to include group information in inputSpec" in {


### PR DESCRIPTION
* dx_type is used to specify the DNAnexus type, which can be a string or a boolean "expression"
* description is used if it is specified and 'help' is not. Also, if the parameter is defined as a String in parameter_meta, that string is used for 'help'.