### PR TITLE
Add support for 'dx_type' and 'description' parameter_meta

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,9 +6,7 @@
   - label
   - choices
   - suggestions
-<!--
   - dx_type
--->
 
 ## 1.43 11-Feb-2020
 - Providing a tree structure representing a compiled workflow via `--execTree pretty`

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -251,13 +251,14 @@ The [WDL Spec](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#p
 
 - `stream`, indicates whether or not an input file should be streamed. See [here](#Streaming) for more details
 - Direct mappings to [inputSpec and outputSpec keywords in dxapp.json](https://documentation.dnanexus.com/developer/api/running-analyses/io-and-run-specifications):
-  - `group`
-  - `help`
-  - `label`
-  - `patterns`
-  - `choices`
-  - `suggestions`
-  - `dx_type` (maps to the `type` field in dxapp.json)
+  - `help` - `description` is also accepted as an alias for `help`; if the parameter definition is a string rather than a hash, the string is used as `help`.
+  - `group` - parameter grouping (used in the DNAnexus web UI).
+  - `label` - human-readable label for the parameter (used in the DNAnexus web UI).
+  - `patterns` - accepted filename patterns (applies to `File`-type parameters only).
+  - `choices` - allowed parameter values; currently, this is limited to primitive (`String`, `Int`, `Float`, `Boolean`) and `File` types parameters (and `Array`s of these types), i.e. it is not allowed for `Map` or `Struct` parameters.
+  - `suggestions` - suggested parameter values; currently has the same limitations as `choices`.
+  - `dx_type` - maps to the `type` field in dxapp.json; can be either a `String` value or a boolean "expression" (see example below). Applies to `File`-type parameters only.
+  - `default` - a default value for the parameter. This is ignored if the parameter's default value is defined in the `inputs` section.
 
 Although the WDL spec indicates that the `parameter_meta` section should apply to both input and output variables, WOM currently only maps the parameter_meta section to the input parameters.
 
@@ -268,23 +269,36 @@ task cgrep {
     input {
         String pattern
         File in_file
+        Int? multiplier
     }
+    Int actual_multiplier = select_first([multiplier, 1])
+
     parameter_meta {
         in_file: {
           help: "The input file to be searched",
+          group: "Basic",
           patterns: ["*.txt", "*.tsv"],
+          dx_type: { and: [ "fastq", { or: ["Read1", "Read2"] } ] },
           stream: true
         }
         pattern: {
-          help: "The pattern to use to search in_file"
+          help: "The pattern to use to search in_file",
+          group: "Advanced"
+        }
+        multiplier: {
+          help: "Number by which to multiply the count",
+          choices: [1, 2, 3],
+          default: 1
         }
     }
+
     command {
         grep '${pattern}' ${in_file} | wc -l
         cp ${in_file} out_file
     }
+
     output {
-        Int count = read_int(stdout())
+        Int count = read_int(stdout()) * actual_multiplier
         File out_file = "out_file"
     }
 }

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -257,9 +257,7 @@ The [WDL Spec](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#p
   - `patterns`
   - `choices`
   - `suggestions`
-<!--
   - `dx_type` (maps to the `type` field in dxapp.json)
--->
 
 Although the WDL spec indicates that the `parameter_meta` section should apply to both input and output variables, WOM currently only maps the parameter_meta section to the input parameters.
 

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -75,7 +75,7 @@ case class GenerateIRTask(verbose: Verbose,
       case _                           => None
     }.toVector
   }
-  
+
   // Convert a patterns WOM object value to IR
   private def metaPatternsObjToIR(obj: Map[String, MetaValueElement]): IR.IOAttrPatterns = {
     val name = obj.get("name") match {
@@ -98,46 +98,45 @@ case class GenerateIRTask(verbose: Verbose,
   }
 
   // A choices array may contain either raw values or (for data object types) annotated values,
-  // which are hashes with required 'value' key and optional 'name' key. Each value must be of the 
+  // which are hashes with required 'value' key and optional 'name' key. Each value must be of the
   // same type as the parameter, unless the parameter is an array, in which case choice values must
-  // be of the same type as the array's contained type. For now, we only allow choices for 
-  // primitive- and file-type parameters, because there could be ambiguity (e.g. if a choice has a 
+  // be of the same type as the array's contained type. For now, we only allow choices for
+  // primitive- and file-type parameters, because there could be ambiguity (e.g. if a choice has a
   // 'value' key, should we treat it as a raw map value or as an annotated value?).
-  // 
+  //
   // choices: [true, false]
   // OR
   // choices: [{name: 'file1', value: "dx://file-XXX"}, {name: 'file2', value: "dx://file-YYY"}]
-  private def metaChoicesArrayToIR(
-      array: Vector[MetaValueElement], womType: WomType): Option[IR.IOAttrChoices] = {
+  private def metaChoicesArrayToIR(array: Vector[MetaValueElement],
+                                   womType: WomType): Vector[IR.ChoiceRepr] = {
     if (array.isEmpty) {
-      Some(IR.IOAttrChoices(Vector()))
+      Vector()
     } else {
-      Some(IR.IOAttrChoices(array.map {
+      array.map {
         case MetaValueElementObject(fields) =>
           if (!fields.contains("value")) {
             throw new Exception("Annotated choice must have a 'value' key")
           } else {
             metaChoiceValueToIR(
-              womType = womType,
-              value = fields("value"),
-              name = fields.get("name"),
+                womType = womType,
+                value = fields("value"),
+                name = fields.get("name")
             )
           }
         case rawElement: MetaValueElement =>
           metaChoiceValueToIR(womType = womType, value = rawElement)
         case _ =>
           throw new Exception(
-            "Choices array must contain only raw values or annotated values (hash with "
-            + "optional 'name' and required 'value' keys)"
+              "Choices array must contain only raw values or annotated values (hash with "
+                + "optional 'name' and required 'value' keys)"
           )
-      }))
+      }
     }
   }
 
-  private def metaChoiceValueToIR(
-      womType: WomType,
-      value: MetaValueElement,
-      name: Option[MetaValueElement] = None): IR.ChoiceRepr = {
+  private def metaChoiceValueToIR(womType: WomType,
+                                  value: MetaValueElement,
+                                  name: Option[MetaValueElement] = None): IR.ChoiceRepr = {
     (womType, value) match {
       case (WomStringType, MetaValueElementString(str)) =>
         IR.ChoiceReprString(value = str)
@@ -150,58 +149,57 @@ case class GenerateIRTask(verbose: Verbose,
       case (WomSingleFileType, MetaValueElementString(str)) =>
         val nameStr: Option[String] = name match {
           case Some(MetaValueElementString(str)) => Some(str)
-          case _ => None
+          case _                                 => None
         }
         IR.ChoiceReprFile(value = str, name = nameStr)
       case _ =>
         throw new Exception(
-          "Choices keyword is only valid for primitive- and file-type parameters, and types must "
-          + "match between parameter and choices"
+            "Choices keyword is only valid for primitive- and file-type parameters, and types must "
+              + "match between parameter and choices"
         )
     }
   }
 
   // A suggestions array may contain either raw values or (for data object types) annotated values,
-  // which are hashes. Each value must be of the same type as the parameter, unless the parameter 
-  // is an array, in which case choice values must be of the same type as the array's contained 
-  // type. For now, we only allow choices for primitive- and file-type parameters, because there 
-  // could be ambiguity (e.g. if a choice has a 'value' key, should we treat it as a raw map value 
+  // which are hashes. Each value must be of the same type as the parameter, unless the parameter
+  // is an array, in which case choice values must be of the same type as the array's contained
+  // type. For now, we only allow choices for primitive- and file-type parameters, because there
+  // could be ambiguity (e.g. if a choice has a 'value' key, should we treat it as a raw map value
   // or as an annotated value?).
-  // 
+  //
   // suggestions: [true, false]
   // OR
   // suggestions: [
   //  {name: 'file1', value: "dx://file-XXX"}, {name: 'file2', value: "dx://file-YYY"}]
-  private def metaSuggestionsArrayToIR(
-      array: Vector[MetaValueElement], womType: WomType): Option[IR.IOAttrSuggestions] = {
+  private def metaSuggestionsArrayToIR(array: Vector[MetaValueElement],
+                                       womType: WomType): Vector[IR.SuggestionRepr] = {
     if (array.isEmpty) {
-      Some(IR.IOAttrSuggestions(Vector()))
+      Vector()
     } else {
-      Some(IR.IOAttrSuggestions(array.map {
+      array.map {
         case MetaValueElementObject(fields) =>
           metaSuggestionValueToIR(
-            womType = womType,
-            name = fields.get("name"),
-            value = fields.get("value"),
-            project = fields.get("project"),
-            path = fields.get("path"),
+              womType = womType,
+              name = fields.get("name"),
+              value = fields.get("value"),
+              project = fields.get("project"),
+              path = fields.get("path")
           )
         case rawElement: MetaValueElement =>
           metaSuggestionValueToIR(womType = womType, value = Some(rawElement))
         case _ =>
           throw new Exception(
-            "Suggestions array must contain only raw values or annotated (hash) values"
+              "Suggestions array must contain only raw values or annotated (hash) values"
           )
-      }))
+      }
     }
   }
-  
-  private def metaSuggestionValueToIR(
-      womType: WomType,
-      value: Option[MetaValueElement], 
-      name: Option[MetaValueElement] = None,
-      project: Option[MetaValueElement] = None,
-      path: Option[MetaValueElement] = None): IR.SuggestionRepr = {
+
+  private def metaSuggestionValueToIR(womType: WomType,
+                                      value: Option[MetaValueElement],
+                                      name: Option[MetaValueElement] = None,
+                                      project: Option[MetaValueElement] = None,
+                                      path: Option[MetaValueElement] = None): IR.SuggestionRepr = {
     (womType, value) match {
       case (WomStringType, Some(MetaValueElementString(str))) =>
         IR.SuggestionReprString(value = str)
@@ -217,51 +215,85 @@ case class GenerateIRTask(verbose: Verbose,
         val s = createSuggestionFileIR(None, name, project, path)
         if (s.project.isEmpty || s.path.isEmpty) {
           throw new Exception(
-            "If 'value' is not defined for a file-type suggestion, then both 'project' and 'path' "
-            + "must be defined"
+              "If 'value' is not defined for a file-type suggestion, then both 'project' and 'path' "
+                + "must be defined"
           )
         }
         s
       case _ =>
         throw new Exception(
-          "Suggestion keyword is only valid for primitive- and file-type parameters, and types "
-          + "must match between parameter and choices"
+            "Suggestion keyword is only valid for primitive- and file-type parameters, and types "
+              + "must match between parameter and choices"
         )
     }
   }
 
-  private def createSuggestionFileIR(
-      file: Option[String],   
-      name: Option[MetaValueElement],
-      project: Option[MetaValueElement],
-      path: Option[MetaValueElement]): IR.SuggestionReprFile = {
+  private def createSuggestionFileIR(file: Option[String],
+                                     name: Option[MetaValueElement],
+                                     project: Option[MetaValueElement],
+                                     path: Option[MetaValueElement]): IR.SuggestionReprFile = {
     val nameStr: Option[String] = name match {
       case Some(MetaValueElementString(str)) => Some(str)
-      case _ => None
+      case _                                 => None
     }
     val projectStr: Option[String] = project match {
       case Some(MetaValueElementString(str)) => Some(str)
-      case _ => None
+      case _                                 => None
     }
     val pathStr: Option[String] = path match {
       case Some(MetaValueElementString(str)) => Some(str)
-      case _ => None
+      case _                                 => None
     }
     IR.SuggestionReprFile(file, nameStr, projectStr, pathStr)
   }
 
+  private def metaConstraintToIR(constraint: MetaValueElement): IR.ConstraintRepr =
+    constraint match {
+      case MetaValueElementObject(obj: Map[String, MetaValueElement]) =>
+        if (obj.size != 1) {
+          throw new Exception("Constraint hash must have exactly one 'and' or 'or' key")
+        }
+        obj.head match {
+          case (IR.PARAM_META_CONSTRAINT_AND, MetaValueElementArray(array)) =>
+            IR.ConstraintReprOper(ConstraintOper.AND, array.map(metaConstraintToIR))
+          case (IR.PARAM_META_CONSTRAINT_OR, MetaValueElementArray(array)) =>
+            IR.ConstraintReprOper(ConstraintOper.OR, array.map(metaConstraintToIR))
+          case _ =>
+            throw new Exception(
+                "Constraint must have key 'and' or 'or' and an array value"
+            )
+        }
+      case MetaValueElementString(s) => IR.ConstraintReprString(s)
+      case _                         => throw new Exception("'dx_type' constraints must be either strings or hashes")
+    }
+
+  private def unwrapWomArrayType(womType: WomType): WomType = {
+    var wt = womType
+    while (wt.isInstanceOf[WomArrayType]) {
+      wt = wt.asInstanceOf[WomArrayType].memberType
+    }
+    wt
+  }
+
   // Extract the parameter_meta info from the WOM structure
-  // The parameter's WomType is passed in since some parameter metadata values are required to 
+  // The parameter's WomType is passed in since some parameter metadata values are required to
   // have the same type as the parameter.
-  private def unwrapParamMeta(
-      paramMeta: Option[MetaValueElement], womType: WomType): Option[Vector[IR.IOAttr]] = {
+  private def unwrapParamMeta(paramMeta: Option[MetaValueElement],
+                              womType: WomType): Option[Vector[IR.IOAttr]] = {
     paramMeta match {
       case None => None
+      // If the parameter metadata is a string, treat it as help
+      case Some(MetaValueElementString(text)) => Some(Vector(IR.IOAttrHelp(text)))
       case Some(MetaValueElementObject(obj)) => {
+        // Whether to use 'description' in place of help
+        val noHelp = !obj.contains(IR.PARAM_META_HELP)
         // Use flatmap to get the parameter metadata keys if they exist
         Some(obj.flatMap {
           case (IR.PARAM_META_GROUP, MetaValueElementString(text)) => Some(IR.IOAttrGroup(text))
-          case (IR.PARAM_META_HELP, MetaValueElementString(text)) => Some(IR.IOAttrHelp(text))
+          case (IR.PARAM_META_HELP, MetaValueElementString(text))  => Some(IR.IOAttrHelp(text))
+          // Use 'description' in place of 'help' if the former is present and the latter is not
+          case (IR.PARAM_META_DESCRIPTION, MetaValueElementString(text)) if noHelp =>
+            Some(IR.IOAttrHelp(text))
           case (IR.PARAM_META_LABEL, MetaValueElementString(text)) => Some(IR.IOAttrLabel(text))
           // Try to parse the patterns key
           // First see if it's an array
@@ -273,17 +305,17 @@ case class GenerateIRTask(verbose: Verbose,
             Some(metaPatternsObjToIR(obj))
           // Try to parse the choices key, which will be an array of either values or objects
           case (IR.PARAM_META_CHOICES, MetaValueElementArray(array)) =>
-            var wt = womType
-            while (wt.isInstanceOf[WomArrayType]) {
-              wt = wt.asInstanceOf[WomArrayType].memberType
-            }
-            metaChoicesArrayToIR(array, wt)
+            val wt = unwrapWomArrayType(womType)
+            Some(IR.IOAttrChoices(metaChoicesArrayToIR(array, wt)))
           case (IR.PARAM_META_SUGGESTIONS, MetaValueElementArray(array)) =>
-            var wt = womType
-            while (wt.isInstanceOf[WomArrayType]) {
-              wt = wt.asInstanceOf[WomArrayType].memberType
+            val wt = unwrapWomArrayType(womType)
+            Some(IR.IOAttrSuggestions(metaSuggestionsArrayToIR(array, wt)))
+          case (IR.PARAM_META_TYPE, dx_type: MetaValueElement) =>
+            val wt = unwrapWomArrayType(womType)
+            wt match {
+              case WomSingleFileType => Some(IR.IOAttrType(metaConstraintToIR(dx_type)))
+              case _                 => throw new Exception("'dx_type' can only be specified for File parameters")
             }
-            metaSuggestionsArrayToIR(array, wt)
           case _ => None
         }.toVector)
       }

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -54,7 +54,7 @@ object IR {
 
   // Keywords for string pattern matching in WDL parameter_meta
   val PARAM_META_CHOICES = "choices"
-  val PARAM_META_DEFAULT = "default" // TODO
+  val PARAM_META_DEFAULT = "default"
   val PARAM_META_DESCRIPTION = "description" // accepted as a synonym to 'help'
   val PARAM_META_GROUP = "group"
   val PARAM_META_HELP = "help"
@@ -149,6 +149,20 @@ object IR {
                                        constraints: Vector[ConstraintRepr])
       extends ConstraintRepr
 
+  /** Compile-time representation of the dxapp IO spec 'default' value.
+    * The default value can be specified when defining the parameter. If it is not (for example,
+    * if the parameter is optional and a separate variable is defined using select_first()), then
+    * the default value can be specified in paramter_meta and will be used when the dxapp.json
+    * is generated.
+  **/
+  sealed abstract class DefaultRepr
+  final case class DefaultReprString(value: String) extends DefaultRepr
+  final case class DefaultReprInteger(value: Int) extends DefaultRepr
+  final case class DefaultReprFloat(value: Double) extends DefaultRepr
+  final case class DefaultReprBoolean(value: Boolean) extends DefaultRepr
+  final case class DefaultReprFile(value: String) extends DefaultRepr
+  final case class DefaultReprArray(array: Vector[DefaultRepr]) extends DefaultRepr
+
   // Compile time representaiton of supported parameter_meta section
   // information for the dxapp IO spec.
   sealed abstract class IOAttr
@@ -159,6 +173,7 @@ object IR {
   final case class IOAttrChoices(choices: Vector[ChoiceRepr]) extends IOAttr
   final case class IOAttrSuggestions(suggestions: Vector[SuggestionRepr]) extends IOAttr
   final case class IOAttrType(constraint: ConstraintRepr) extends IOAttr
+  final case class IOAttrDefault(value: DefaultRepr) extends IOAttr
 
   // Compile time representation of a variable. Used also as
   // an applet argument.

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -31,10 +31,11 @@ object DxIOClass extends Enumeration {
   }
 }
 
-object DxInputSpec {
+object DxIOSpec {
   val NAME = "name"
   val CLASS = "class"
   val OPTIONAL = "optional"
+  val DEFAULT = "default"
   val CHOICES = "choices"
   val GROUP = "group"
   val HELP = "help"
@@ -132,7 +133,7 @@ object DxObject {
   }
 
   def parseIoParam(jsv: JsValue): IOParameter = {
-    val ioParam = jsv.asJsObject.getFields(DxInputSpec.NAME, DxInputSpec.CLASS) match {
+    val ioParam = jsv.asJsObject.getFields(DxIOSpec.NAME, DxIOSpec.CLASS) match {
       case Seq(JsString(name), JsString(klass)) =>
         val ioClass = DxIOClass.fromString(klass)
         IOParameter(name, ioClass, false)
@@ -140,27 +141,27 @@ object DxObject {
         throw new Exception(s"Malformed io spec ${other}")
     }
 
-    val optFlag = jsv.asJsObject.fields.get(DxInputSpec.OPTIONAL) match {
+    val optFlag = jsv.asJsObject.fields.get(DxIOSpec.OPTIONAL) match {
       case Some(JsBoolean(b)) => b
       case None               => false
     }
 
-    val group = jsv.asJsObject.fields.get(DxInputSpec.GROUP) match {
+    val group = jsv.asJsObject.fields.get(DxIOSpec.GROUP) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val help = jsv.asJsObject.fields.get(DxInputSpec.HELP) match {
+    val help = jsv.asJsObject.fields.get(DxIOSpec.HELP) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val label = jsv.asJsObject.fields.get(DxInputSpec.LABEL) match {
+    val label = jsv.asJsObject.fields.get(DxIOSpec.LABEL) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val patterns = jsv.asJsObject.fields.get(DxInputSpec.PATTERNS) match {
+    val patterns = jsv.asJsObject.fields.get(DxIOSpec.PATTERNS) match {
       case Some(JsArray(a)) =>
         Some(IOParamterPatternArray(a.flatMap {
           case JsString(s) => Some(s)
@@ -192,7 +193,7 @@ object DxObject {
       case _ => None
     }
 
-    val choices = jsv.asJsObject.fields.get(DxInputSpec.CHOICES) match {
+    val choices = jsv.asJsObject.fields.get(DxIOSpec.CHOICES) match {
       case Some(JsArray(a)) =>
         Some(a.map {
           case JsObject(fields) =>
@@ -210,7 +211,7 @@ object DxObject {
       case _ => None
     }
 
-    val suggestions = jsv.asJsObject.fields.get(DxInputSpec.SUGGESTIONS) match {
+    val suggestions = jsv.asJsObject.fields.get(DxIOSpec.SUGGESTIONS) match {
       case Some(JsArray(a)) =>
         Some(a.map {
           case JsObject(fields) =>
@@ -239,7 +240,7 @@ object DxObject {
       case _ => None
     }
 
-    val dx_type = jsv.asJsObject.fields.get(DxInputSpec.TYPE) match {
+    val dx_type = jsv.asJsObject.fields.get(DxIOSpec.TYPE) match {
       case Some(v: JsValue) => Some(ioParamTypeFromJs(v))
       case _                => None
     }

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -31,6 +31,19 @@ object DxIOClass extends Enumeration {
   }
 }
 
+object DxInputSpec {
+  val NAME = "name"
+  val CLASS = "class"
+  val OPTIONAL = "optional"
+  val CHOICES = "choices"
+  val GROUP = "group"
+  val HELP = "help"
+  val LABEL = "label"
+  val PATTERNS = "patterns"
+  val SUGGESTIONS = "suggestions"
+  val TYPE = "type"
+}
+
 // Types for the IO spec pattern section
 sealed abstract class IOParameterPattern
 case class IOParamterPatternArray(patterns: Vector[String]) extends IOParameterPattern
@@ -44,19 +57,33 @@ sealed abstract class IOParameterChoice
 final case class IOParameterChoiceString(value: String) extends IOParameterChoice
 final case class IOParameterChoiceNumber(value: BigDecimal) extends IOParameterChoice
 final case class IOParameterChoiceBoolean(value: Boolean) extends IOParameterChoice
-final case class IOParameterChoiceFile(
-  value: DxFile, name: Option[String]) extends IOParameterChoice
+final case class IOParameterChoiceFile(value: DxFile, name: Option[String])
+    extends IOParameterChoice
 
 // Types for the IO suggestions section
 sealed abstract class IOParameterSuggestion
 final case class IOParameterSuggestionString(value: String) extends IOParameterSuggestion
 final case class IOParameterSuggestionNumber(value: BigDecimal) extends IOParameterSuggestion
 final case class IOParameterSuggestionBoolean(value: Boolean) extends IOParameterSuggestion
-final case class IOParameterSuggestionFile(
-  name: Option[String],
-  value: Option[DxFile],
-  project: Option[DxProject],
-  path: Option[String]) extends IOParameterSuggestion
+final case class IOParameterSuggestionFile(name: Option[String],
+                                           value: Option[DxFile],
+                                           project: Option[DxProject],
+                                           path: Option[String])
+    extends IOParameterSuggestion
+
+final object DxConstraint {
+  val AND = "$and"
+  val OR = "$or"
+}
+final object ConstraintOper extends Enumeration {
+  val AND, OR = Value
+}
+sealed abstract class IOParameterTypeConstraint
+sealed case class IOParameterTypeConstraintString(constraint: String)
+    extends IOParameterTypeConstraint
+sealed case class IOParameterTypeConstraintOper(oper: ConstraintOper.Value,
+                                                constraints: Vector[IOParameterTypeConstraint])
+    extends IOParameterTypeConstraint
 
 // Representation of the IO spec
 case class IOParameter(
@@ -68,7 +95,8 @@ case class IOParameter(
     label: Option[String] = None,
     patterns: Option[IOParameterPattern] = None,
     choices: Option[Vector[IOParameterChoice]] = None,
-    suggestions: Option[Vector[IOParameterSuggestion]] = None
+    suggestions: Option[Vector[IOParameterSuggestion]] = None,
+    dx_type: Option[IOParameterTypeConstraint] = None
 )
 
 // Extra fields for describe
@@ -104,7 +132,7 @@ object DxObject {
   }
 
   def parseIoParam(jsv: JsValue): IOParameter = {
-    val ioParam = jsv.asJsObject.getFields("name", "class") match {
+    val ioParam = jsv.asJsObject.getFields(DxInputSpec.NAME, DxInputSpec.CLASS) match {
       case Seq(JsString(name), JsString(klass)) =>
         val ioClass = DxIOClass.fromString(klass)
         IOParameter(name, ioClass, false)
@@ -112,27 +140,27 @@ object DxObject {
         throw new Exception(s"Malformed io spec ${other}")
     }
 
-    val optFlag = jsv.asJsObject.fields.get("optional") match {
+    val optFlag = jsv.asJsObject.fields.get(DxInputSpec.OPTIONAL) match {
       case Some(JsBoolean(b)) => b
       case None               => false
     }
 
-    val group = jsv.asJsObject.fields.get("group") match {
+    val group = jsv.asJsObject.fields.get(DxInputSpec.GROUP) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val help = jsv.asJsObject.fields.get("help") match {
+    val help = jsv.asJsObject.fields.get(DxInputSpec.HELP) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val label = jsv.asJsObject.fields.get("label") match {
+    val label = jsv.asJsObject.fields.get(DxInputSpec.LABEL) match {
       case Some(JsString(s)) => Some(s)
       case _                 => None
     }
 
-    val patterns = jsv.asJsObject.fields.get("patterns") match {
+    val patterns = jsv.asJsObject.fields.get(DxInputSpec.PATTERNS) match {
       case Some(JsArray(a)) =>
         Some(IOParamterPatternArray(a.flatMap {
           case JsString(s) => Some(s)
@@ -164,60 +192,89 @@ object DxObject {
       case _ => None
     }
 
-    val choices = jsv.asJsObject.fields.get("choices") match {
-      case Some(JsArray(a)) => Some(a.map {
-        case JsObject(fields) => 
-          val nameStr: Option[String] = fields.get("name") match {
-            case Some(JsString(s)) => Some(s)
-            case _ => None
-          }
-          IOParameterChoiceFile(
-            name = nameStr, value = DxUtils.dxFileFromJsValue(fields("value")))
-        case JsString(s) => IOParameterChoiceString(s)
-        case JsNumber(n) => IOParameterChoiceNumber(n)
-        case JsBoolean(b) => IOParameterChoiceBoolean(b)
-        case _ => throw new Exception("Unsupported choice value")
-      })
+    val choices = jsv.asJsObject.fields.get(DxInputSpec.CHOICES) match {
+      case Some(JsArray(a)) =>
+        Some(a.map {
+          case JsObject(fields) =>
+            val nameStr: Option[String] = fields.get("name") match {
+              case Some(JsString(s)) => Some(s)
+              case _                 => None
+            }
+            IOParameterChoiceFile(name = nameStr,
+                                  value = DxUtils.dxFileFromJsValue(fields("value")))
+          case JsString(s)  => IOParameterChoiceString(s)
+          case JsNumber(n)  => IOParameterChoiceNumber(n)
+          case JsBoolean(b) => IOParameterChoiceBoolean(b)
+          case _            => throw new Exception("Unsupported choice value")
+        })
       case _ => None
     }
 
-    val suggestions = jsv.asJsObject.fields.get("suggestions") match {
-      case Some(JsArray(a)) => Some(a.map {
-        case JsObject(fields) => 
-          val name: Option[String] = fields.get("name") match {
-            case Some(JsString(s)) => Some(s)
-            case _ => None
-          }
-          val value: Option[DxFile] = fields.get("value") match {
-            case Some(v: JsValue) => Some(DxUtils.dxFileFromJsValue(v))
-            case _ => None
-          }
-          val project: Option[DxProject] = fields.get("project") match {
-            case Some(JsString(p)) => Some(DxProject(p))
-            case _ => None
-          }
-          val path: Option[String] = fields.get("path") match {
-            case Some(JsString(s)) => Some(s)
-            case _ => None
-          }
-          IOParameterSuggestionFile(name, value, project, path)
-        case JsString(s) => IOParameterSuggestionString(s)
-        case JsNumber(n) => IOParameterSuggestionNumber(n)
-        case JsBoolean(b) => IOParameterSuggestionBoolean(b)
-        case _ => throw new Exception("Unsupported suggestion value")
-      })
+    val suggestions = jsv.asJsObject.fields.get(DxInputSpec.SUGGESTIONS) match {
+      case Some(JsArray(a)) =>
+        Some(a.map {
+          case JsObject(fields) =>
+            val name: Option[String] = fields.get("name") match {
+              case Some(JsString(s)) => Some(s)
+              case _                 => None
+            }
+            val value: Option[DxFile] = fields.get("value") match {
+              case Some(v: JsValue) => Some(DxUtils.dxFileFromJsValue(v))
+              case _                => None
+            }
+            val project: Option[DxProject] = fields.get("project") match {
+              case Some(JsString(p)) => Some(DxProject(p))
+              case _                 => None
+            }
+            val path: Option[String] = fields.get("path") match {
+              case Some(JsString(s)) => Some(s)
+              case _                 => None
+            }
+            IOParameterSuggestionFile(name, value, project, path)
+          case JsString(s)  => IOParameterSuggestionString(s)
+          case JsNumber(n)  => IOParameterSuggestionNumber(n)
+          case JsBoolean(b) => IOParameterSuggestionBoolean(b)
+          case _            => throw new Exception("Unsupported suggestion value")
+        })
       case _ => None
+    }
+
+    val dx_type = jsv.asJsObject.fields.get(DxInputSpec.TYPE) match {
+      case Some(v: JsValue) => Some(ioParamTypeFromJs(v))
+      case _                => None
     }
 
     ioParam.copy(
-      optional = optFlag,
-      group = group,
-      help = help,
-      label = label,
-      patterns = patterns,
-      choices = choices,
-      suggestions = suggestions,
+        optional = optFlag,
+        group = group,
+        help = help,
+        label = label,
+        patterns = patterns,
+        choices = choices,
+        suggestions = suggestions,
+        dx_type = dx_type
     )
+  }
+
+  def ioParamTypeFromJs(value: JsValue): IOParameterTypeConstraint = {
+    value match {
+      case JsString(s) => IOParameterTypeConstraintString(s)
+      case JsObject(fields) =>
+        if (fields.size != 1) {
+          throw new Exception("Constraint hash must have exactly one '$and' or '$or' key")
+        }
+        fields.head match {
+          case (DxConstraint.AND, JsArray(array)) =>
+            IOParameterTypeConstraintOper(ConstraintOper.AND, array.map(ioParamTypeFromJs))
+          case (DxConstraint.OR, JsArray(array)) =>
+            IOParameterTypeConstraintOper(ConstraintOper.OR, array.map(ioParamTypeFromJs))
+          case _ =>
+            throw new Exception(
+                "Constraint must have key '$and' or '$or' and an array value"
+            )
+        }
+      case _ => throw new Exception(s"Invalid paramter type value ${value}")
+    }
   }
 
   def parseIOSpec(specs: Vector[JsValue]): Vector[IOParameter] = {

--- a/src/test/resources/compiler/add_default.wdl
+++ b/src/test/resources/compiler/add_default.wdl
@@ -1,0 +1,28 @@
+version 1.0
+
+task add_default {
+    input {
+        Int a = 1
+        Int? b
+    }
+
+    Int b_actual = select_first([b, 2])
+
+    command {
+        echo $((${a} + ${b_actual}))
+    }
+
+    meta {
+        summary: "Adds two int together"
+    }
+
+    parameter_meta {
+        b: {
+            default: 2
+        }
+    }
+
+    output {
+        Int result = read_int(stdout())
+    }
+}

--- a/src/test/resources/compiler/add_dx_type.wdl
+++ b/src/test/resources/compiler/add_dx_type.wdl
@@ -1,0 +1,32 @@
+version 1.0
+
+task add_dx_type {
+    input {
+        File a
+        File b
+    }
+
+    command {
+    cat ~{a} ~{b}
+    }
+
+    parameter_meta {
+        a: {
+            dx_type: "fastq"
+        }
+        b: {
+            dx_type: {
+                and: [
+                    "fastq", 
+                    {
+                        or: ["Read1", "Read2"]
+                    }
+                ]
+            }
+        }
+    }
+
+    output {
+        String result = stdout()
+    }
+}

--- a/src/test/resources/compiler/add_help.wdl
+++ b/src/test/resources/compiler/add_help.wdl
@@ -4,6 +4,9 @@ task add_help {
     input {
         Int a
         Int b
+        String c
+        String d
+        String e
     }
     command {
         echo $((${a} + ${b}))
@@ -19,6 +22,14 @@ task add_help {
 			b: {
 				help: "righthand side"
 			}
+            c: {
+                description: "Use this"
+            }
+            d: {
+                help: "Use this",
+                description: "Don't use this"
+            }
+            e: "Use this"
 		}
 
     output {

--- a/src/test/resources/compiler/default_type_mismatch.wdl
+++ b/src/test/resources/compiler/default_type_mismatch.wdl
@@ -1,0 +1,31 @@
+version 1.0
+
+# This should fail to compile due to a type mismatch between 'b' and its default value
+# in parameter_meta
+
+task add_default {
+    input {
+        Int a = 1
+        Int? b
+    }
+
+    Int b_actual = select_first([b, 2])
+
+    command {
+        echo $((${a} + ${b_actual}))
+    }
+
+    meta {
+        summary: "Adds two int together"
+    }
+
+    parameter_meta {
+        b: {
+            default: "two"
+        }
+    }
+
+    output {
+        Int result = read_int(stdout())
+    }
+}

--- a/src/test/resources/compiler/dx_type_nonfile.wdl
+++ b/src/test/resources/compiler/dx_type_nonfile.wdl
@@ -1,0 +1,23 @@
+version 1.0
+
+# Should fail because dx_type is not allowed for non-file parameters
+
+task add_dx_type {
+    input {
+        String a
+    }
+    
+    command {
+    echo ~{a}
+    }
+
+    parameter_meta {
+        a: {
+            dx_type: "fastq"
+        }
+    }
+
+    output {
+        String result = stdout()
+    }
+}

--- a/src/test/resources/compiler/help_input_params.wdl
+++ b/src/test/resources/compiler/help_input_params.wdl
@@ -10,6 +10,7 @@ task help_input_params_cgrep {
     input {
         String pattern
         File in_file
+        String s
     }
     parameter_meta {
       in_file : {
@@ -18,10 +19,11 @@ task help_input_params_cgrep {
         label: "Input file"
       }
       pattern: {
-        help: "The pattern to use to search in_file",
+        description: "The pattern to use to search in_file",
         group: "Common",
         label: "Search pattern"
       }
+      s: "This is help for s"
     }
     command {
         grep '${pattern}' ${in_file} | wc -l

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -563,7 +563,6 @@ class GenerateIRTest extends FlatSpec with Matchers {
     ))
   }
 
-
   // Check parameter_meta `choices` keyword
   it should "recognize choices in parameters_meta via CVar for input CVars" in {
     val path = pathFromBasename("compiler", "choice_values.wdl")
@@ -584,14 +583,18 @@ class GenerateIRTest extends FlatSpec with Matchers {
             None,
             Some(
                 Vector(
-                    IR.IOAttrChoices(Vector(
-                      IR.ChoiceReprFile(
-                        name = None, value = "dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"
-                      ),
-                      IR.ChoiceReprFile(
-                        name = None, value = "dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"
-                      ),
-                    ))
+                    IR.IOAttrChoices(
+                        Vector(
+                            IR.ChoiceReprFile(
+                                name = None,
+                                value = "dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"
+                            ),
+                            IR.ChoiceReprFile(
+                                name = None,
+                                value = "dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"
+                            )
+                        )
+                    )
                 )
             )
         ),
@@ -599,12 +602,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
             "pattern",
             WomStringType,
             None,
-            Some(Vector(
-                IR.IOAttrChoices(Vector(
-                  IR.ChoiceReprString(value = "A"),
-                  IR.ChoiceReprString(value = "B"),
-                ))
-            ))
+            Some(
+                Vector(
+                    IR.IOAttrChoices(
+                        Vector(
+                            IR.ChoiceReprString(value = "A"),
+                            IR.ChoiceReprString(value = "B")
+                        )
+                    )
+                )
+            )
         )
     )
   }
@@ -629,14 +636,18 @@ class GenerateIRTest extends FlatSpec with Matchers {
             None,
             Some(
                 Vector(
-                    IR.IOAttrChoices(Vector(
-                      IR.ChoiceReprFile(
-                        name = Some("file1"), value = "dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"
-                      ),
-                      IR.ChoiceReprFile(
-                        name = Some("file2"), value = "dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"
-                      ),
-                    ))
+                    IR.IOAttrChoices(
+                        Vector(
+                            IR.ChoiceReprFile(
+                                name = Some("file1"),
+                                value = "dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"
+                            ),
+                            IR.ChoiceReprFile(
+                                name = Some("file2"),
+                                value = "dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"
+                            )
+                        )
+                    )
                 )
             )
         ),
@@ -644,12 +655,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
             "pattern",
             WomStringType,
             None,
-            Some(Vector(
-                IR.IOAttrChoices(Vector(
-                  IR.ChoiceReprString(value = "A"),
-                  IR.ChoiceReprString(value = "B"),
-                ))
-            ))
+            Some(
+                Vector(
+                    IR.IOAttrChoices(
+                        Vector(
+                            IR.ChoiceReprString(value = "A"),
+                            IR.ChoiceReprString(value = "B")
+                        )
+                    )
+                )
+            )
         )
     )
   }
@@ -684,20 +699,22 @@ class GenerateIRTest extends FlatSpec with Matchers {
             None,
             Some(
                 Vector(
-                    IR.IOAttrSuggestions(Vector(
-                      IR.SuggestionReprFile(
-                        name = None,
-                        value = Some("dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"),
-                        project = None,
-                        path = None,
-                      ),
-                      IR.SuggestionReprFile(
-                        name = None,
-                        value = Some("dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"),
-                        project = None,
-                        path = None,
-                      ),
-                    ))
+                    IR.IOAttrSuggestions(
+                        Vector(
+                            IR.SuggestionReprFile(
+                                name = None,
+                                value = Some("dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"),
+                                project = None,
+                                path = None
+                            ),
+                            IR.SuggestionReprFile(
+                                name = None,
+                                value = Some("dx://file-Fg5PgBj0ffPP0Jjv3zfv0yxq"),
+                                project = None,
+                                path = None
+                            )
+                        )
+                    )
                 )
             )
         ),
@@ -705,12 +722,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
             "pattern",
             WomStringType,
             None,
-            Some(Vector(
-                IR.IOAttrSuggestions(Vector(
-                  IR.SuggestionReprString(value = "A"),
-                  IR.SuggestionReprString(value = "B"),
-                ))
-            ))
+            Some(
+                Vector(
+                    IR.IOAttrSuggestions(
+                        Vector(
+                            IR.SuggestionReprString(value = "A"),
+                            IR.SuggestionReprString(value = "B")
+                        )
+                    )
+                )
+            )
         )
     )
   }
@@ -735,20 +756,22 @@ class GenerateIRTest extends FlatSpec with Matchers {
             None,
             Some(
                 Vector(
-                    IR.IOAttrSuggestions(Vector(
-                      IR.SuggestionReprFile(
-                        name = Some("file1"),
-                        value = Some("dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"),
-                        project = None,
-                        path = None,
-                      ),
-                      IR.SuggestionReprFile(
-                        name = Some("file2"),
-                        value = None,
-                        project = Some("project-FGpfqjQ0ffPF1Q106JYP2j3v"),
-                        path = Some("/test_data/f2.txt.gz"),
-                      ),
-                    ))
+                    IR.IOAttrSuggestions(
+                        Vector(
+                            IR.SuggestionReprFile(
+                                name = Some("file1"),
+                                value = Some("dx://file-Fg5PgBQ0ffP7B8bg3xqB115G"),
+                                project = None,
+                                path = None
+                            ),
+                            IR.SuggestionReprFile(
+                                name = Some("file2"),
+                                value = None,
+                                project = Some("project-FGpfqjQ0ffPF1Q106JYP2j3v"),
+                                path = Some("/test_data/f2.txt.gz")
+                            )
+                        )
+                    )
                 )
             )
         ),
@@ -756,12 +779,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
             "pattern",
             WomStringType,
             None,
-            Some(Vector(
-                IR.IOAttrSuggestions(Vector(
-                  IR.SuggestionReprString(value = "A"),
-                  IR.SuggestionReprString(value = "B"),
-                ))
-            ))
+            Some(
+                Vector(
+                    IR.IOAttrSuggestions(
+                        Vector(
+                            IR.SuggestionReprString(value = "A"),
+                            IR.SuggestionReprString(value = "B")
+                        )
+                    )
+                )
+            )
         )
     )
   }
@@ -779,6 +806,67 @@ class GenerateIRTest extends FlatSpec with Matchers {
   // Check parameter_meta `suggestions` keyword fails when there is a missing keyword
   it should "throw exception when file suggestion is missing a keyword" in {
     val path = pathFromBasename("compiler", "suggestions_missing_arg.wdl")
+    val retval = Main.compile(
+        path.toString :: cFlags
+    )
+    retval shouldBe a[Main.UnsuccessfulTermination]
+    // TODO: make assertion about exception message
+  }
+
+  // Check parameter_meta `dx_type` keyword
+  it should "recognize dx_type in parameters_meta via CVar for input CVars" in {
+    val path = pathFromBasename("compiler", "add_dx_type.wdl")
+    val retval = Main.compile(
+        path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
+    }
+
+    val cgrepApplet = getAppletByName("add_dx_type", bundle)
+    cgrepApplet.inputs shouldBe Vector(
+        IR.CVar(
+            "a",
+            WomSingleFileType,
+            None,
+            Some(
+                Vector(
+                    IR.IOAttrType(IR.ConstraintReprString("fastq"))
+                )
+            )
+        ),
+        IR.CVar(
+            "b",
+            WomSingleFileType,
+            None,
+            Some(
+                Vector(
+                    IR.IOAttrType(
+                        IR.ConstraintReprOper(
+                            ConstraintOper.AND,
+                            Vector(
+                                IR.ConstraintReprString("fastq"),
+                                IR.ConstraintReprOper(
+                                    ConstraintOper.OR,
+                                    Vector(
+                                        IR.ConstraintReprString("Read1"),
+                                        IR.ConstraintReprString("Read2")
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+  }
+
+  // Check parameter_meta `dx_type` keyword fails when specified for a non-file parameter
+  it should "throw exception when dx_type is used on non-file parameter" in {
+    val path = pathFromBasename("compiler", "dx_type_nonfile.wdl")
     val retval = Main.compile(
         path.toString :: cFlags
     )
@@ -810,12 +898,13 @@ class GenerateIRTest extends FlatSpec with Matchers {
             ),
             "pattern" -> MetaValueElement.MetaValueElementObject(
                 Map(
-                    "help" -> MetaValueElement
+                    "description" -> MetaValueElement
                       .MetaValueElementString("The pattern to use to search in_file"),
                     "group" -> MetaValueElement.MetaValueElementString("Common"),
                     "label" -> MetaValueElement.MetaValueElementString("Search pattern")
                 )
-            )
+            ),
+            "s" -> MetaValueElement.MetaValueElementString("This is help for s")
         )
     )
     val iDef = cgrepTask.inputs.find(_.name == "in_file").get
@@ -864,6 +953,16 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val cgrepApplet = getAppletByName("help_input_params_cgrep", bundle)
     cgrepApplet.inputs shouldBe Vector(
+        IR.CVar(
+            "s",
+            WomStringType,
+            None,
+            Some(
+                Vector(
+                    IR.IOAttrHelp("This is help for s")
+                )
+            )
+        ),
         IR.CVar(
             "in_file",
             WomSingleFileType,

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -384,18 +384,24 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case Some(x) => (x(0), x(1))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
-    pattern.choices shouldBe Some(Vector(
-      IOParameterChoiceString(value = "A"),
-      IOParameterChoiceString(value = "B"),
-    ))
-    in_file.choices shouldBe Some(Vector(
-      IOParameterChoiceFile(
-        name = None, value = DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")
-      ),
-      IOParameterChoiceFile(
-        name = None, value = DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")
-      ),
-    ))
+    pattern.choices shouldBe Some(
+        Vector(
+            IOParameterChoiceString(value = "A"),
+            IOParameterChoiceString(value = "B")
+        )
+    )
+    in_file.choices shouldBe Some(
+        Vector(
+            IOParameterChoiceFile(
+                name = None,
+                value = DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")
+            ),
+            IOParameterChoiceFile(
+                name = None,
+                value = DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")
+            )
+        )
+    )
   }
 
   it should "be able to include annotated choices information in inputSpec" in {
@@ -405,7 +411,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         path.toString :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
-      case other => throw new Exception(s"Unexpected result ${other}")
+      case other                    => throw new Exception(s"Unexpected result ${other}")
     }
 
     val dxApplet = DxApplet.getInstance(appId)
@@ -414,18 +420,24 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case Some(x) => (x(0), x(1))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
-    pattern.choices shouldBe Some(Vector(
-      IOParameterChoiceString(value = "A"),
-      IOParameterChoiceString(value = "B"),
-    ))
-    in_file.choices shouldBe Some(Vector(
-      IOParameterChoiceFile(
-        name = Some("file1"), value = DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")
-      ),
-      IOParameterChoiceFile(
-        name = Some("file2"), value = DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")
-      ),
-    ))
+    pattern.choices shouldBe Some(
+        Vector(
+            IOParameterChoiceString(value = "A"),
+            IOParameterChoiceString(value = "B")
+        )
+    )
+    in_file.choices shouldBe Some(
+        Vector(
+            IOParameterChoiceFile(
+                name = Some("file1"),
+                value = DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")
+            ),
+            IOParameterChoiceFile(
+                name = Some("file2"),
+                value = DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")
+            )
+        )
+    )
   }
 
   it should "be able to include suggestion information in inputSpec" in {
@@ -445,24 +457,28 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case Some(x) => (x(0), x(1))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
-    pattern.suggestions shouldBe Some(Vector(
-      IOParameterSuggestionString(value = "A"),
-      IOParameterSuggestionString(value = "B"),
-    ))
-    in_file.suggestions shouldBe Some(Vector(
-      IOParameterSuggestionFile(
-        name = None,
-        value = Some(DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")),
-        project = None,
-        path = None,
-      ),
-      IOParameterSuggestionFile(
-        name = None, 
-        value = Some(DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")),
-        project = None,
-        path = None,
-      ),
-    ))
+    pattern.suggestions shouldBe Some(
+        Vector(
+            IOParameterSuggestionString(value = "A"),
+            IOParameterSuggestionString(value = "B")
+        )
+    )
+    in_file.suggestions shouldBe Some(
+        Vector(
+            IOParameterSuggestionFile(
+                name = None,
+                value = Some(DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")),
+                project = None,
+                path = None
+            ),
+            IOParameterSuggestionFile(
+                name = None,
+                value = Some(DxFile.getInstance("file-Fg5PgBj0ffPP0Jjv3zfv0yxq")),
+                project = None,
+                path = None
+            )
+        )
+    )
   }
 
   it should "be able to include annotated suggestion information in inputSpec" in {
@@ -472,7 +488,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         path.toString :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
-      case other => throw new Exception(s"Unexpected result ${other}")
+      case other                    => throw new Exception(s"Unexpected result ${other}")
     }
 
     val dxApplet = DxApplet.getInstance(appId)
@@ -481,24 +497,62 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case Some(x) => (x(0), x(1))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
-    pattern.suggestions shouldBe Some(Vector(
-      IOParameterSuggestionString(value = "A"),
-      IOParameterSuggestionString(value = "B"),
-    ))
-    in_file.suggestions shouldBe Some(Vector(
-      IOParameterSuggestionFile(
-        name = Some("file1"),
-        value = Some(DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")),
-        project = None,
-        path = None,
-      ),
-      IOParameterSuggestionFile(
-        name = Some("file2"),
-        value = None,
-        project = Some(DxProject("project-FGpfqjQ0ffPF1Q106JYP2j3v")),
-        path = Some("/test_data/f2.txt.gz")
-      ),
-    ))
+    pattern.suggestions shouldBe Some(
+        Vector(
+            IOParameterSuggestionString(value = "A"),
+            IOParameterSuggestionString(value = "B")
+        )
+    )
+    in_file.suggestions shouldBe Some(
+        Vector(
+            IOParameterSuggestionFile(
+                name = Some("file1"),
+                value = Some(DxFile.getInstance("file-Fg5PgBQ0ffP7B8bg3xqB115G")),
+                project = None,
+                path = None
+            ),
+            IOParameterSuggestionFile(
+                name = Some("file2"),
+                value = None,
+                project = Some(DxProject("project-FGpfqjQ0ffPF1Q106JYP2j3v")),
+                path = Some("/test_data/f2.txt.gz")
+            )
+        )
+    )
+  }
+
+  it should "be able to include dx_type information in inputSpec" in {
+    val path = pathFromBasename("compiler", "add_dx_type.wdl")
+
+    val appId = Main.compile(
+        path.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case other                    => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    val dxApplet = DxApplet.getInstance(appId)
+    val inputSpec = dxApplet.describe(Set(Field.InputSpec))
+    val (file_a, file_b) = inputSpec.inputSpec match {
+      case Some(x) => (x(0), x(1))
+      case other   => throw new Exception(s"Unexpected result ${other}")
+    }
+    file_a.dx_type shouldBe Some(IOParameterTypeConstraintString("fastq"))
+    file_b.dx_type shouldBe Some(
+        IOParameterTypeConstraintOper(
+            ConstraintOper.AND,
+            Vector(
+                IOParameterTypeConstraintString("fastq"),
+                IOParameterTypeConstraintOper(
+                    ConstraintOper.OR,
+                    Vector(
+                        IOParameterTypeConstraintString("Read1"),
+                        IOParameterTypeConstraintString("Read2")
+                    )
+                )
+            )
+        )
+    )
   }
 
   it should "be able to include help information in inputSpec" in {
@@ -514,12 +568,15 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val dxApplet = DxApplet.getInstance(appId)
     val inputSpec = dxApplet.describe(Set(Field.InputSpec))
-    val (a, b) = inputSpec.inputSpec match {
-      case Some(x) => (x(0), x(1))
+    val (a, b, c, d, e) = inputSpec.inputSpec match {
+      case Some(x) => (x(0), x(1), x(2), x(3), x(4))
       case other   => throw new Exception(s"Unexpected result ${other}")
     }
     a.help shouldBe Some("lefthand side")
     b.help shouldBe Some("righthand side")
+    c.help shouldBe Some("Use this")
+    d.help shouldBe Some("Use this")
+    e.help shouldBe Some("Use this")
   }
 
   it should "be able to include group information in inputSpec" in {

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -325,7 +325,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     pattern.help shouldBe Some("The pattern to use to search in_file")
     pattern.group shouldBe Some("Common")
     pattern.label shouldBe Some("Search pattern")
-    in_file.patterns shouldBe Some(IOParamterPatternArray(Vector("*.txt", "*.tsv")))
+    in_file.patterns shouldBe Some(IOParameterPatternArray(Vector("*.txt", "*.tsv")))
     in_file.help shouldBe Some("The input file to be searched")
     in_file.group shouldBe Some("Common")
     in_file.label shouldBe Some("Input file")
@@ -355,9 +355,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     pattern.group shouldBe Some("Common")
     pattern.label shouldBe Some("Search pattern")
     in_file.patterns shouldBe Some(
-        IOParamterPatternObject(Some(Vector("*.txt", "*.tsv")),
-                                Some("file"),
-                                Some(Vector("foo", "bar")))
+        IOParameterPatternObject(Some(Vector("*.txt", "*.tsv")),
+                                 Some("file"),
+                                 Some(Vector("foo", "bar")))
     )
     in_file.help shouldBe Some("The input file to be searched")
     in_file.group shouldBe Some("Common")
@@ -553,6 +553,26 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
             )
         )
     )
+  }
+
+  it should "be able to include default information in inputSpec" in {
+    val path = pathFromBasename("compiler", "add_default.wdl")
+
+    val appId = Main.compile(
+        path.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case other                    => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    val dxApplet = DxApplet.getInstance(appId)
+    val inputSpec = dxApplet.describe(Set(Field.InputSpec))
+    val (int_a, int_b) = inputSpec.inputSpec match {
+      case Some(x) => (x(0), x(1))
+      case other   => throw new Exception(s"Unexpected result ${other}")
+    }
+    int_a.default shouldBe Some(IOParameterDefaultNumber(1))
+    int_b.default shouldBe Some(IOParameterDefaultNumber(2))
   }
 
   it should "be able to include help information in inputSpec" in {


### PR DESCRIPTION
This PR is the last set of enhancements for DEVEX-1473. It is now possible to specify all of the keywords in the dxapp inputSpec directly in WDL parameter_meta (with a few limitations that are described in the docs).

* dx_type maps to 'type' in dxapp inputSpec
* description can be used as an alias for help (but 'help' takes precedence)
* default can be used to specify the default value for an optional parameter
* parameter_meta is now parsed for optional parameters

I also reformatted some files with scalafmt.