### PR TITLE
Load app description and developer notes from readme files

### DIFF
--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -263,17 +263,17 @@ The following keys are recognized:
 * `tags`: An array of strings that will be added as tags on the generated applet.
 * `properties`: A hash of key-value pairs that will be added as properties on the generated applet. Both keys and values must be strings.
 * `details`: An object with an arbitrary set of details about the applet. The following keys are specifically recognized and used by the platform:
-  * advancedInputs
-  * citations
-  * contactEmail
-  * contactOrg
-  * contactUrl
-  * exampleProject
-  * repoUrl
-  * upstreamLicenses
-  * upstreamUrl
-  * upstreamVersion
-  * whatsNew: The task's change log. There are two different formats that are accepted:
+  * `advancedInputs`
+  * `citations`
+  * `contactEmail`
+  * `contactOrg`
+  * `contactUrl`
+  * `exampleProject`
+  * `repoUrl`
+  * `upstreamLicenses`
+  * `upstreamUrl`
+  * `upstreamVersion`
+  * `whatsNew`: The task's change log. There are two different formats that are accepted:
     * A (possibly Markdown-formatted) string
     * An array of versions, where each version is a hash with two keys: `version`, a version string, and `changes`, an array of change description strings. This object will be formatted into a Markdown string upon compilation.
 

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -102,6 +102,11 @@ object Utils {
     sb.toString
   }
 
+  // This one seems more idiomatic
+  def readFileContent2(path: Path): String = {
+    Files.readAllLines(path).asScala.mkString(System.lineSeparator())
+  }
+
   def exceptionToString(e: Throwable): String = {
     val sw = new java.io.StringWriter
     e.printStackTrace(new java.io.PrintWriter(sw))

--- a/src/main/scala/dxWDL/compiler/GenerateIR.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIR.scala
@@ -145,7 +145,8 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
       callables: Map[String, IR.Callable],
       language: Language.Value,
       locked: Boolean,
-      reorg: Either[Boolean, ReorgAttrs]
+      reorg: Either[Boolean, ReorgAttrs],
+      adjunctFiles: Map[String, Vector[Adjuncts.AdjunctFile]]
   ): (IR.Callable, Vector[IR.Callable]) = {
     def compileTask2(task: CallableTaskDefinition) = {
       val taskSourceCode = taskDir.get(task.name) match {
@@ -153,7 +154,7 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
         case Some(x) => x
       }
       GenerateIRTask(verbose, typeAliases, language, defaultRuntimeAttrs)
-        .apply(task, taskSourceCode)
+        .apply(task, taskSourceCode, adjunctFiles)
     }
     callable match {
       case exec: ExecutableTaskDefinition =>
@@ -180,7 +181,8 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
             allSources: Map[String, WorkflowSource],
             language: Language.Value,
             locked: Boolean,
-            reorg: Either[Boolean, ReorgAttrs]): IR.Bundle = {
+            reorg: Either[Boolean, ReorgAttrs],
+            adjunctFiles: Map[String, Vector[Adjuncts.AdjunctFile]]): IR.Bundle = {
     Utils.trace(verbose.on, s"IR pass")
     Utils.traceLevelInc()
 
@@ -236,7 +238,8 @@ case class GenerateIR(verbose: Verbose, defaultRuntimeAttrs: WdlRuntimeAttrs) {
                                                  allCallables,
                                                  language,
                                                  isLocked(callable),
-                                                 reorg)
+                                                 reorg,
+                                                 adjunctFiles)
       allCallables = allCallables ++ (auxCallables.map { apl =>
         apl.name -> apl
       }.toMap)

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -383,9 +383,10 @@ case class GenerateIRTask(verbose: Verbose,
     }
   }
 
-  private def unwrapTaskMeta(meta: Map[String, MetaValueElement],
-                             adjunctFiles: Option[Vector[Adjuncts.AdjunctFile]]): 
-                             Vector[IR.TaskAttr] = {
+  private def unwrapTaskMeta(
+      meta: Map[String, MetaValueElement],
+      adjunctFiles: Option[Vector[Adjuncts.AdjunctFile]]
+  ): Vector[IR.TaskAttr] = {
     val appAttrs = meta.flatMap {
       case (IR.META_TITLE, MetaValueElementString(text))       => Some(IR.TaskAttrTitle(text))
       case (IR.META_DESCRIPTION, MetaValueElementString(text)) => Some(IR.TaskAttrDescription(text))

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -440,7 +440,7 @@ case class GenerateIRTask(verbose: Verbose,
   // native applet.
   def apply(task: CallableTaskDefinition,
             taskSourceCode: String,
-            adjunctFiles: Map[String, Vector[Adjuncts.AdjunctFile]]): IR.Applet = {
+            adjunctFiles: Option[Vector[Adjuncts.AdjunctFile]]): IR.Applet = {
     Utils.trace(verbose.on, s"Compiling task ${task.name}")
 
     // create dx:applet input definitions. Note, some "inputs" are
@@ -508,7 +508,7 @@ case class GenerateIRTask(verbose: Verbose,
       }
 
     // Parse any task metadata (other than 'type' and 'id', which are handled above)
-    val taskAttr = unwrapTaskMeta(task.meta, adjunctFiles.get(task.name))
+    val taskAttr = unwrapTaskMeta(task.meta, adjunctFiles)
 
     // Figure out if we need to use docker
     val docker = triageDockerImage(task.runtimeAttributes.attributes.get("docker"))

--- a/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRWorkflow.scala
@@ -21,7 +21,8 @@ case class GenerateIRWorkflow(wf: WorkflowDefinition,
                               language: Language.Value,
                               verbose: Verbose,
                               locked: Boolean,
-                              reorg: Either[Boolean, ReorgAttrs]) {
+                              reorg: Either[Boolean, ReorgAttrs],
+                              adjunctFiles: Option[Vector[Adjuncts.AdjunctFile]]) {
   val verbose2: Boolean = verbose.containsKey("GenerateIR")
 
   private case class LinkedVar(cVar: CVar, sArg: SArg)

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -22,8 +22,21 @@ object IR {
   val REORG = "reorg"
   val CUSTOM_REORG_CONFIG = "reorg_config"
 
+  // The following keywords/types correspond to app(let) attributes from dxapp.json (except for
+  // inputSpec/outputSpec attributes, which are defined separately). These attributes can be used
+  // in the meta section of task WDL, and will be parsed out and used when generating the native
+  // app.
+  val META_DESCRIPTION = "description"
+  val META_DEVELOPER_NOTES = "developer_notes"
+  val META_TYPE = "type"
+  val META_ID = "id"
+
+  sealed abstract class AppAttr
+  final case class AppAttrDescription(text: String) extends AppAttr
+  final case class AppAttrDeveloperNotes(text: String) extends AppAttr
+
   // The following keywords/types correspond to attributes of inputSpec/outputSpec from
-  // dxapp.json. These attributes can be used in the parameter_meta section of WDL, and
+  // dxapp.json. These attributes can be used in the parameter_meta section of task WDL, and
   // will be parsed out and used when generating the native app.
   //  Example:
   //
@@ -277,6 +290,7 @@ object IR {
     * @param kind          Kind of applet: task, scatter, ...
     * @param task          Task definition
     * @param womSourceCode WDL/CWL source code for task.
+    * @param meta          Additional app(let) metadata
     */
   case class Applet(name: String,
                     inputs: Vector[CVar],
@@ -284,7 +298,8 @@ object IR {
                     instanceType: InstanceType,
                     docker: DockerImage,
                     kind: AppletKind,
-                    womSourceCode: String)
+                    womSourceCode: String,
+                    meta: Option[Vector[AppAttr]] = None)
       extends Callable {
     def inputVars = inputs
     def outputVars = outputs

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -220,7 +220,7 @@ case class Top(cOpt: CompilerOptions) {
   }
 
   private def womToIR(source: Path): IR.Bundle = {
-    val (language, womBundle, allSources, subBundles) =
+    val (language, womBundle, allSources, adjunctFiles, subBundles) =
       ParseWomSourceFile(verbose.on).apply(source, cOpt.importDirs)
 
     // Check that each workflow/task appears just one
@@ -252,7 +252,7 @@ case class Top(cOpt: CompilerOptions) {
     }
 
     new GenerateIR(cOpt.verbose, defaultRuntimeAttrs)
-      .apply(everythingBundle, allSources, language, cOpt.locked, reorgApp)
+      .apply(everythingBundle, allSources, language, cOpt.locked, reorgApp, adjunctFiles)
   }
 
   // Compile IR only

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -333,7 +333,7 @@ task Add {
             accu
           } else {
             val sourceCode = callable match {
-              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode) =>
+              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode, _) =>
                 // This is a task, include its source code, instead of a header.
                 val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
                 assert(taskDir.size == 1)

--- a/src/main/scala/dxWDL/util/Adjunct.scala
+++ b/src/main/scala/dxWDL/util/Adjunct.scala
@@ -20,8 +20,8 @@ object Adjuncts {
       wdlName = wdlName.dropRight(4)
     }
 
-    val readmeRegexp = s"(?i)readme.${wdlName}.(.*)(?:.md)".r
-    val developerNotesRegexp = s"(?i)readme.developer.${wdlName}.(.*)(?:.md)".r
+    val readmeRegexp = s"(?i)readme\.${wdlName}\.(.+)\.md".r
+    val developerNotesRegexp = s"(?i)readme\.developer\.${wdlName}\.(.+)\.md".r
 
     parentDir.listFiles
       .flatMap { file =>

--- a/src/main/scala/dxWDL/util/Adjunct.scala
+++ b/src/main/scala/dxWDL/util/Adjunct.scala
@@ -1,0 +1,41 @@
+/** dxWDL supports reading some metadata from "adjunct" files - i.e. files in the same directory
+  * as the WDL file.
+**/
+package dxWDL.util
+
+import java.nio.file.Path
+import dxWDL.base.Utils
+
+object Adjuncts {
+  sealed abstract class AdjunctFile
+  final case class Readme(text: String) extends AdjunctFile
+  final case class DeveloperNotes(text: String) extends AdjunctFile
+
+  def findAdjunctFiles(path: Path): Map[String, Vector[AdjunctFile]] = {
+    val file = path.toFile
+    val parentDir = file.getParentFile
+    var wdlName = file.getName
+
+    if (wdlName.endsWith(".wdl")) {
+      wdlName = wdlName.dropRight(4)
+    }
+
+    val readmeRegexp = s"(?i)readme.${wdlName}.(.*)(?:.md)".r
+    val developerNotesRegexp = s"(?i)readme.developer.${wdlName}.(.*)(?:.md)".r
+
+    parentDir.listFiles
+      .flatMap { file =>
+        {
+          file.getName match {
+            case readmeRegexp(target) =>
+              Some(target -> Readme(Utils.readFileContent2(file.toPath)))
+            case developerNotesRegexp(target) =>
+              Some(target -> DeveloperNotes(Utils.readFileContent2(file.toPath)))
+            case _ => None
+          }
+        }
+      }
+      .groupBy(_._1)
+      .mapValues(_.map(_._2).toVector) // handle list that might have duplicates
+  }
+}

--- a/src/main/scala/dxWDL/util/Adjunct.scala
+++ b/src/main/scala/dxWDL/util/Adjunct.scala
@@ -11,7 +11,19 @@ object Adjuncts {
   final case class Readme(text: String) extends AdjunctFile
   final case class DeveloperNotes(text: String) extends AdjunctFile
 
+  // Given the path to a primary (WDL file), search in the same directory (the path's parent)
+  // for adjunct files. The currently recognizd adjuncts are:
+  // * readme.<wdlname>.<task|workflow>.md
+  // * readme.developer.<wdlname>.<task|workflow>.md
+  //
+  // Note: we rely on the restriction, imposed by Top.mergeIntoOneBundle, that all task/workflow
+  // names are unique; otherwise, we would need for the key in the returned map to be
+  // (file_name, callable_name) to ensure uniqueness.
   def findAdjunctFiles(path: Path): Map[String, Vector[AdjunctFile]] = {
+    if (!path.isAbsolute) {
+      throw new Exception(s"path is not absolute: ${path}")
+    }
+
     val file = path.toFile
     val parentDir = file.getParentFile
     var wdlName = file.getName

--- a/src/main/scala/dxWDL/util/Adjunct.scala
+++ b/src/main/scala/dxWDL/util/Adjunct.scala
@@ -20,8 +20,8 @@ object Adjuncts {
       wdlName = wdlName.dropRight(4)
     }
 
-    val readmeRegexp = s"(?i)readme\.${wdlName}\.(.+)\.md".r
-    val developerNotesRegexp = s"(?i)readme\.developer\.${wdlName}\.(.+)\.md".r
+    val readmeRegexp = s"(?i)readme\\.${wdlName}\\.(.+)\\.md".r
+    val developerNotesRegexp = s"(?i)readme\\.developer\\.${wdlName}\\.(.+)\\.md".r
 
     parentDir.listFiles
       .flatMap { file =>

--- a/src/test/resources/compiler/Readme.wf_readme.add.md
+++ b/src/test/resources/compiler/Readme.wf_readme.add.md
@@ -1,0 +1,1 @@
+This is the readme for the wf_linear add task.

--- a/src/test/resources/compiler/Readme.wf_readme.wf_linear.md
+++ b/src/test/resources/compiler/Readme.wf_readme.wf_linear.md
@@ -1,0 +1,1 @@
+This is the readme for the wf_linear workflow.

--- a/src/test/resources/compiler/wf_readme.wdl
+++ b/src/test/resources/compiler/wf_readme.wdl
@@ -1,0 +1,75 @@
+version 1.0
+
+# A WDL workflow with expressions, but without branches and loops.
+
+workflow wf_readme {
+    input {
+        Int x = 3
+        Int y = 5
+    }
+
+    call add {
+        input: a=x, b=y
+    }
+
+    Int z = add.result + 1
+
+    call mul { input: a=z, b=5 }
+
+    call inc { input: i= z + mul.result + 8}
+
+    output {
+        Int result = inc.result
+    }
+}
+
+
+task add {
+    input {
+        Int a
+        Int b
+    }
+
+    meta {
+        developer_notes: "Developer notes defined in WDL"
+    }
+
+    command {
+        echo $((${a} + ${b}))
+    }
+    
+    output {
+        Int result = read_int(stdout())
+    }
+}
+
+task mul {
+    input {
+        Int a
+        Int b
+    }
+    
+    meta {
+        description: "Description defined in WDL"
+    }
+
+    command {
+        echo $((a * b))
+    }
+    output {
+        Int result = a * b
+    }
+}
+
+task inc {
+    input {
+        Int i
+    }
+
+    command <<<
+        python -c "print(${i} + 1)"
+    >>>
+    output {
+        Int result = read_int(stdout())
+    }
+}

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1419,8 +1419,8 @@ class GenerateIRTest extends FlatSpec with Matchers {
     val incApp = getAppletByName("inc", bundle)
     incApp.meta match {
       case Some(v: Vector[IR.TaskAttr]) => v.size shouldBe 0
-      case None                        => None
-      case other                       => throw new Exception("meta is not None or empty for inc task")
+      case None                         => None
+      case other                        => throw new Exception("meta is not None or empty for inc task")
     }
   }
 }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1392,33 +1392,33 @@ class GenerateIRTest extends FlatSpec with Matchers {
 
     val addApp = getAppletByName("add", bundle)
     addApp.meta match {
-      case Some(v: Vector[IR.AppAttr]) =>
+      case Some(v: Vector[IR.TaskAttr]) =>
         v.size shouldBe 2
         v.foreach {
-          case IR.AppAttrDescription(text) =>
+          case IR.TaskAttrDescription(text) =>
             text shouldBe "This is the readme for the wf_linear add task."
-          case IR.AppAttrDeveloperNotes(text) =>
+          case IR.TaskAttrDeveloperNotes(text) =>
             text shouldBe "Developer notes defined in WDL"
-          case other => throw new Exception(s"Invalid AppAttr for add task ${other}")
+          case other => throw new Exception(s"Invalid TaskAttr for add task ${other}")
         }
-      case _ => throw new Exception("meta is None or is not a Vector of AppAttr for add task")
+      case _ => throw new Exception("meta is None or is not a Vector of TaskAttr for add task")
     }
 
     val mulApp = getAppletByName("mul", bundle)
     mulApp.meta match {
-      case Some(v: Vector[IR.AppAttr]) =>
+      case Some(v: Vector[IR.TaskAttr]) =>
         v.size shouldBe 1
         v.foreach {
-          case IR.AppAttrDescription(text) =>
+          case IR.TaskAttrDescription(text) =>
             text shouldBe "Description defined in WDL"
-          case other => throw new Exception(s"Invalid AppAttr for mul task ${other}")
+          case other => throw new Exception(s"Invalid TaskAttr for mul task ${other}")
         }
-      case _ => throw new Exception("meta is None or is not a Vector of AppAttr for mul task")
+      case _ => throw new Exception("meta is None or is not a Vector of TaskAttr for mul task")
     }
 
     val incApp = getAppletByName("inc", bundle)
     incApp.meta match {
-      case Some(v: Vector[IR.AppAttr]) => v.size shouldBe 0
+      case Some(v: Vector[IR.TaskAttr]) => v.size shouldBe 0
       case None                        => None
       case other                       => throw new Exception("meta is not None or empty for inc task")
     }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1326,4 +1326,53 @@ class GenerateIRTest extends FlatSpec with Matchers {
     retval shouldBe a[Main.SuccessfulTerminationIR]
   }
 
+  it should "handle adjunct files in workflows and tasks" in {
+    val path = pathFromBasename("compiler", "wf_readme.wdl")
+    val retval = Main.compile(path.toString :: cFlags)
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
+    }
+
+    // val workflow = bundle.primaryCallable match {
+    //   case Some(wf: IR.Workflow) => wf
+    //   case _ => throw new Exception("primaryCallable is not a workflow")
+    // }
+    // TODO: test workflow readme
+
+    val addApp = getAppletByName("add", bundle)
+    addApp.meta match {
+      case Some(v: Vector[IR.AppAttr]) =>
+        v.size shouldBe 2
+        v.foreach {
+          case IR.AppAttrDescription(text) =>
+            text shouldBe "This is the readme for the wf_linear add task."
+          case IR.AppAttrDeveloperNotes(text) =>
+            text shouldBe "Developer notes defined in WDL"
+          case other => throw new Exception(s"Invalid AppAttr for add task ${other}")
+        }
+      case _ => throw new Exception("meta is None or is not a Vector of AppAttr for add task")
+    }
+
+    val mulApp = getAppletByName("mul", bundle)
+    mulApp.meta match {
+      case Some(v: Vector[IR.AppAttr]) =>
+        v.size shouldBe 1
+        v.foreach {
+          case IR.AppAttrDescription(text) =>
+            text shouldBe "Description defined in WDL"
+          case other => throw new Exception(s"Invalid AppAttr for mul task ${other}")
+        }
+      case _ => throw new Exception("meta is None or is not a Vector of AppAttr for mul task")
+    }
+
+    val incApp = getAppletByName("inc", bundle)
+    incApp.meta match {
+      case Some(v: Vector[IR.AppAttr]) => v.size shouldBe 0
+      case None                        => None
+      case other                       => throw new Exception("meta is not None or empty for inc task")
+    }
+  }
 }

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -130,7 +130,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
     val dxPathConfig = DxPathConfig.apply(jobHomeDir, false, verbose)
     dxPathConfig.createCleanDirs()
 
-    val (language, womBundle: WomBundle, allSources, _) =
+    val (language, womBundle: WomBundle, allSources, _, _) =
       ParseWomSourceFile(false).apply(wdlCode, List.empty)
     val task: CallableTaskDefinition = ParseWomSourceFile(false).getMainTask(womBundle)
     assert(allSources.size == 1)

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -90,7 +90,7 @@ class WfFragRunnerTest extends FlatSpec with Matchers {
     val source: Path = pathFromBasename("frag_runner", "wf_linear.wdl")
     val (dxPathConfig, dxIoFunctions) = setup()
 
-    val (language, womBundle: WomBundle, allSources, subBundles) =
+    val (language, womBundle: WomBundle, allSources, subBundles, _) =
       ParseWomSourceFile(false).apply(source, List.empty)
     subBundles.size should be(0)
     val wfSource = allSources.values.head

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -153,7 +153,7 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "categorize correctly calls to subworkflows" taggedAs (EdgeTest) in {
     val path = pathFromBasename("subworkflows", "trains.wdl")
-    val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, womBundle, sources, _, _) = parseWomSourceFile.apply(path, List.empty)
     val (_, wfSourceCode) = sources.find {
       case (key, wdlCode) =>
         key.endsWith("trains.wdl")
@@ -172,7 +172,7 @@ class BlockTest extends FlatSpec with Matchers {
   it should "get subblocks" in {
     val path = pathFromBasename("nested", "two_levels.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (_, womBundle, sources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, womBundle, sources, _, _) = parseWomSourceFile.apply(path, List.empty)
     val (wf: WorkflowDefinition, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
 
     // sort from low to high according to the source lines.
@@ -201,7 +201,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "handle calls to imported modules II" in {
     val path = pathFromBasename("draft2", "block_category.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("block_category.wdl")
@@ -219,7 +220,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "handle calls to imported modules" in {
     val path = pathFromBasename("draft2", "conditionals1.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals1.wdl")
@@ -245,7 +247,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "compile a workflow calling a subworkflow as a direct call" in {
     val path = pathFromBasename("draft2", "movies.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _, _) =
+      parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("movies.wdl")
@@ -292,7 +295,7 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "find the correct number of scatters" in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")
-    val (_, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, womBundle: WomBundle, allSources, _, _) = parseWomSourceFile.apply(path, List.empty)
 
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals_base.wdl")
@@ -311,7 +314,8 @@ class BlockTest extends FlatSpec with Matchers {
 
   it should "sort a subblock properly" in {
     val path = pathFromBasename("draft2", "conditionals4.wdl")
-    val (language, womBundle: WomBundle, allSources, _) = parseWomSourceFile.apply(path, List.empty)
+    val (language, womBundle: WomBundle, allSources, _, _) =
+      parseWomSourceFile.apply(path, List.empty)
     val (_, wfSource) = allSources.find {
       case (name, _) => name.endsWith("conditionals4.wdl")
     }.get


### PR DESCRIPTION
This PR introduces the concept of "adjunct" files, which are files in the same directory as the WDL that provide additional information.

Currently, there are two types of adjunct files:

* Readme: must have name `Readme.<wdlname>.<taskname>.md`, where wdlname is the name of the WDL file without the ".wdl" extension, and taskname is the name of the task. Filenames are matched case-insensitively.
* Developer Notes: must have name `Readme.developer.<wdlname>.<taskname>.md`

During parsing, adjunct files are discovered by name. During conversion to IR, if the task metadata does not have "description" and there was a Readme adjunct discovered, the description is set to the contents of that file. Similarly, if developer_notes is not defined in the applet meadata and Developer Notes adjunct was discovered, the developer_notes are set to the contents of that file.

Please review this file and comment on the approach I've taken. If there is a better way to do this, or a more appropriate way to organize the code, I want to know. I also realize that this currently only works for the main WDL file - adjuncts are not being discovered for imports. There is also not a great method of discovering remote adjuncts other than to try to fetch the file with the expected name and see if it exists.