### PR TITLE
Feat/devex 1463 app metadata

### DIFF
--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -394,7 +394,17 @@ case class GenerateIRTask(verbose: Verbose,
       case (IR.META_DETAILS, MetaValueElementObject(fields)) =>
         Some(IR.TaskAttrDetails(fields.mapValues(unwrapAny)))
       case (IR.META_OPEN_SOURCE, MetaValueElementBoolean(b)) => Some(IR.TaskAttrOpenSource(b))
-      case _                                                 => None
+      case (IR.META_CATEGORIES, MetaValueElementArray(array)) =>
+        Some(IR.TaskAttrCategories(array.map {
+          case MetaValueElementString(text) => text
+          case other                        => throw new Exception(s"Invalid category: ${other}")
+        }))
+      case (IR.META_TYPES, MetaValueElementArray(array)) =>
+        Some(IR.TaskAttrTypes(array.map {
+          case MetaValueElementString(text) => text
+          case other                        => throw new Exception(s"Invalid type: ${other}")
+        }))
+      case _ => None
     }.toVector
   }
 
@@ -470,7 +480,7 @@ case class GenerateIRTask(verbose: Verbose,
       }
 
     // Parse any task metadata (other than 'type' and 'id', which are handled above)
-    val TaskAttr = unwrapTaskMeta(task.meta)
+    val taskAttr = unwrapTaskMeta(task.meta)
 
     // Figure out if we need to use docker
     val docker = triageDockerImage(task.runtimeAttributes.attributes.get("docker"))
@@ -506,6 +516,6 @@ case class GenerateIRTask(verbose: Verbose,
               dockerFinal,
               kind,
               selfContainedSourceCode,
-              Some(TaskAttr))
+              Some(taskAttr))
   }
 }

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -395,12 +395,12 @@ case class GenerateIRTask(verbose: Verbose,
       case (IR.META_VERSION, MetaValueElementString(text)) => Some(IR.AppAttrVersion(text))
       case (IR.META_DETAILS, MetaValueElementObject(fields)) =>
         val change_log: Option[IR.ChangesRepr] = fields.get("change_log") match {
-          case None                         => None
-          case MetaValueElementString(text) => Some(IR.ChangesReprString(text))
-          case MetaValueElementArray(eltArray) =>
+          case None                               => None
+          case Some(MetaValueElementString(text)) => Some(IR.ChangesReprString(text))
+          case Some(MetaValueElementArray(eltArray)) =>
             Some(IR.ChangesReprList(eltArray.map {
               case MetaValueElementObject(fields) =>
-                IR.VersionChanges(fields("version"),
+                IR.VersionChanges(unwrapMetaValueElementString(fields("version")),
                                   unwrapMetaValueElementStringArray(fields("changes")))
               case other =>
                 throw new Exception(s"Unexpected value for 'change_log' element: ${other}")
@@ -417,7 +417,7 @@ case class GenerateIRTask(verbose: Verbose,
                 change_log
             )
         )
-      case (IR.META_OPEN_SOURCE, MetaValueElementBoolean(b)) => Some(IR.AppAttrBoolean(b))
+      case (IR.META_OPEN_SOURCE, MetaValueElementBoolean(b)) => Some(IR.AppAttrOpenSource(b))
       case _                                                 => None
     }.toVector
   }

--- a/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dxWDL/compiler/GenerateIRTask.scala
@@ -404,6 +404,16 @@ case class GenerateIRTask(verbose: Verbose,
           case MetaValueElementString(text) => text
           case other                        => throw new Exception(s"Invalid type: ${other}")
         }))
+      case (IR.META_TAGS, MetaValueElementArray(array)) =>
+        Some(IR.TaskAttrTags(array.map {
+          case MetaValueElementString(text) => text
+          case other                        => throw new Exception(s"Invalid type: ${other}")
+        }))
+      case (IR.META_PROPERTIES, MetaValueElementObject(fields)) =>
+        Some(IR.TaskAttrProperties(fields.mapValues {
+          case MetaValueElementString(text) => text
+          case other                        => throw new Exception(s"Invalid property value: ${other}")
+        }))
       case _ => None
     }.toVector
   }

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -36,33 +36,14 @@ object IR {
   val META_TYPE = "type"
   val META_ID = "id"
 
-  // Two different way to specify change log. If given the second form, dxWDL turns it into a
-  // nicely markdown-formatted change list when generating the dxapp.
-  //  change_log: "## Changelog\n* Optionally markdown formated"
-  //
-  //  change_log: [
-  //    { version: "1.1", changes: ["Added paramter --foo", "Added cowsay easter-egg"] },
-  //    { version: "1.0", changes: ["Intial version"] }
-  //  ]
-  sealed abstract class ChangesRepr
-  final case class ChangesReprString(text: String) extends ChangesRepr
-  final case class VersionChanges(version: String, changes: Vector[String])
-  final case class ChangesReprList(changes: Vector[VersionChanges]) extends ChangesRepr
-
-  sealed abstract class AppAttr
-  final case class AppAttrTitle(text: String) extends AppAttr
-  final case class AppAttrDescription(text: String) extends AppAttr
-  final case class AppAttrSummary(text: String) extends AppAttr
-  final case class AppAttrDeveloperNotes(text: String) extends AppAttr
-  final case class AppAttrVersion(text: String) extends AppAttr
-  final case class AppAttrDetails(contact_email: Option[String] = None,
-                                  upstream_version: Option[String] = None,
-                                  upstream_author: Option[String] = None,
-                                  upstream_url: Option[String] = None,
-                                  upstream_licenses: Option[Vector[String]] = None,
-                                  change_log: Option[ChangesRepr] = None)
-      extends AppAttr
-  final case class AppAttrOpenSource(isOpenSource: Boolean) extends AppAttr
+  sealed abstract class TaskAttr
+  final case class TaskAttrTitle(text: String) extends TaskAttr
+  final case class TaskAttrDescription(text: String) extends TaskAttr
+  final case class TaskAttrSummary(text: String) extends TaskAttr
+  final case class TaskAttrDeveloperNotes(text: String) extends TaskAttr
+  final case class TaskAttrVersion(text: String) extends TaskAttr
+  final case class TaskAttrDetails(details: Map[String, Any]) extends TaskAttr
+  final case class TaskAttrOpenSource(isOpenSource: Boolean) extends TaskAttr
 
   // The following keywords/types correspond to attributes of inputSpec/outputSpec from
   // dxapp.json. These attributes can be used in the parameter_meta section of task WDL, and
@@ -328,7 +309,7 @@ object IR {
                     docker: DockerImage,
                     kind: AppletKind,
                     womSourceCode: String,
-                    meta: Option[Vector[AppAttr]] = None)
+                    meta: Option[Vector[TaskAttr]] = None)
       extends Callable {
     def inputVars = inputs
     def outputVars = outputs

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -50,6 +50,8 @@ object IR {
   final case class TaskAttrOpenSource(isOpenSource: Boolean) extends TaskAttr
   final case class TaskAttrCategories(categories: Vector[String]) extends TaskAttr
   final case class TaskAttrTypes(types: Vector[String]) extends TaskAttr
+  final case class TaskAttrTags(tags: Vector[String]) extends TaskAttr
+  final case class TaskAttrProperties(properties: Map[String, String]) extends TaskAttr
 
   // The following keywords/types correspond to attributes of inputSpec/outputSpec from
   // dxapp.json. These attributes can be used in the parameter_meta section of task WDL, and

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -26,15 +26,19 @@ object IR {
   // inputSpec/outputSpec attributes, which are defined separately). These attributes can be used
   // in the meta section of task WDL, and will be parsed out and used when generating the native
   // app.
-  val META_TITLE = "title"
-  val META_DESCRIPTION = "description"
-  val META_SUMMARY = "summary"
-  val META_DEVELOPER_NOTES = "developer_notes"
-  val META_VERSION = "version"
-  val META_DETAILS = "details"
-  val META_OPEN_SOURCE = "open_source"
   val META_TYPE = "type"
   val META_ID = "id"
+  val META_CATEGORIES = "categories"
+  val META_DESCRIPTION = "description"
+  val META_DETAILS = "details"
+  val META_DEVELOPER_NOTES = "developer_notes"
+  val META_OPEN_SOURCE = "open_source"
+  val META_PROPERTIES = "properties"
+  val META_SUMMARY = "summary"
+  val META_TAGS = "tags"
+  val META_TITLE = "title"
+  val META_TYPES = "types"
+  val META_VERSION = "version"
 
   sealed abstract class TaskAttr
   final case class TaskAttrTitle(text: String) extends TaskAttr
@@ -44,6 +48,8 @@ object IR {
   final case class TaskAttrVersion(text: String) extends TaskAttr
   final case class TaskAttrDetails(details: Map[String, Any]) extends TaskAttr
   final case class TaskAttrOpenSource(isOpenSource: Boolean) extends TaskAttr
+  final case class TaskAttrCategories(categories: Vector[String]) extends TaskAttr
+  final case class TaskAttrTypes(types: Vector[String]) extends TaskAttr
 
   // The following keywords/types correspond to attributes of inputSpec/outputSpec from
   // dxapp.json. These attributes can be used in the parameter_meta section of task WDL, and

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -333,7 +333,7 @@ task Add {
             accu
           } else {
             val sourceCode = callable match {
-              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode) =>
+              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode, _) =>
                 // This is a task, include its source code, instead of a header.
                 val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
                 assert(taskDir.size == 1)

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -18,7 +18,8 @@ case class DxAppletDescribe(project: String,
                             description: Option[String] = None,
                             developerNotes: Option[String] = None,
                             summary: Option[String] = None,
-                            title: Option[String] = None)
+                            title: Option[String] = None,
+                            types: Option[Vector[String]] = None)
     extends DxObjectDescribe
 
 case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable {
@@ -75,18 +76,27 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
     val developerNotes = descJs.asJsObject.fields.get("developerNotes").flatMap(unwrapString)
     val summary = descJs.asJsObject.fields.get("summary").flatMap(unwrapString)
     val title = descJs.asJsObject.fields.get("title").flatMap(unwrapString)
+    val types = descJs.asJsObject.fields.get("types").flatMap(unwrapStringArray)
     desc.copy(details = details,
               properties = props,
               description = description,
               developerNotes = developerNotes,
               summary = summary,
-              title = title)
+              title = title,
+              types = types)
   }
 
   def unwrapString(jsValue: JsValue): Option[String] = {
     jsValue match {
       case JsString(value) => Some(value)
       case _               => None
+    }
+  }
+
+  def unwrapStringArray(jsValue: JsValue): Option[Vector[String]] = {
+    jsValue match {
+      case JsArray(array) => Some(array.flatMap(unwrapString))
+      case _              => None
     }
   }
 

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -14,7 +14,11 @@ case class DxAppletDescribe(project: String,
                             properties: Option[Map[String, String]],
                             details: Option[JsValue],
                             inputSpec: Option[Vector[IOParameter]],
-                            outputSpec: Option[Vector[IOParameter]])
+                            outputSpec: Option[Vector[IOParameter]],
+                            description: Option[String] = None,
+                            developerNotes: Option[String] = None,
+                            summary: Option[String] = None,
+                            title: Option[String] = None)
     extends DxObjectDescribe
 
 case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable {
@@ -67,7 +71,23 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
 
     val details = descJs.asJsObject.fields.get("details")
     val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-    desc.copy(details = details, properties = props)
+    val description = descJs.asJsObject.fields.get("description").flatMap(unwrapString)
+    val developerNotes = descJs.asJsObject.fields.get("developerNotes").flatMap(unwrapString)
+    val summary = descJs.asJsObject.fields.get("summary").flatMap(unwrapString)
+    val title = descJs.asJsObject.fields.get("title").flatMap(unwrapString)
+    desc.copy(details = details,
+              properties = props,
+              description = description,
+              developerNotes = developerNotes,
+              summary = summary,
+              title = title)
+  }
+
+  def unwrapString(jsValue: JsValue): Option[String] = {
+    jsValue match {
+      case JsString(value) => Some(value)
+      case _               => None
+    }
   }
 
   def newRun(name: String,

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -19,7 +19,8 @@ case class DxAppletDescribe(project: String,
                             developerNotes: Option[String] = None,
                             summary: Option[String] = None,
                             title: Option[String] = None,
-                            types: Option[Vector[String]] = None)
+                            types: Option[Vector[String]] = None,
+                            tags: Option[Vector[String]] = None)
     extends DxObjectDescribe
 
 case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable {
@@ -70,20 +71,23 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
         throw new Exception(s"Malformed JSON ${descJs}")
     }
 
-    val details = descJs.asJsObject.fields.get("details")
-    val props = descJs.asJsObject.fields.get("properties").map(DxObject.parseJsonProperties)
-    val description = descJs.asJsObject.fields.get("description").flatMap(unwrapString)
-    val developerNotes = descJs.asJsObject.fields.get("developerNotes").flatMap(unwrapString)
-    val summary = descJs.asJsObject.fields.get("summary").flatMap(unwrapString)
-    val title = descJs.asJsObject.fields.get("title").flatMap(unwrapString)
-    val types = descJs.asJsObject.fields.get("types").flatMap(unwrapStringArray)
+    val descFields: Map[String, JsValue] = descJs.asJsObject.fields
+    val details = descFields.get("details")
+    val props = descFields.get("properties").map(DxObject.parseJsonProperties)
+    val description = descFields.get("description").flatMap(unwrapString)
+    val developerNotes = descFields.get("developerNotes").flatMap(unwrapString)
+    val summary = descFields.get("summary").flatMap(unwrapString)
+    val title = descFields.get("title").flatMap(unwrapString)
+    val types = descFields.get("types").flatMap(unwrapStringArray)
+    val tags = descFields.get("tags").flatMap(unwrapStringArray)
     desc.copy(details = details,
               properties = props,
               description = description,
               developerNotes = developerNotes,
               summary = summary,
               title = title,
-              types = types)
+              types = types,
+              tags = tags)
   }
 
   def unwrapString(jsValue: JsValue): Option[String] = {

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -113,8 +113,9 @@ case class IOParameter(
 
 // Extra fields for describe
 object Field extends Enumeration {
-  val Analysis, Applet, ArchivalState, Created, Details, Folder, Id, InputSpec, Modified, Name,
-      OutputSpec, ParentJob, Parts, Project, Properties, Size, Stages = Value
+  val Analysis, Applet, ArchivalState, Created, Description, Details, DeveloperNotes, Folder, Id,
+      InputSpec, Modified, Name, OutputSpec, ParentJob, Parts, Project, Properties, Size, Stages,
+      Summary, Tags, Title = Value
 }
 
 trait DxObjectDescribe {
@@ -329,23 +330,27 @@ object DxObject {
 
   def requestFields(fields: Set[Field.Value]): JsValue = {
     val fieldStrings = fields.map {
-      case Field.Analysis      => "analysis"
-      case Field.Applet        => "applet"
-      case Field.ArchivalState => "archivalState"
-      case Field.Created       => "created"
-      case Field.Details       => "details"
-      case Field.Folder        => "folder"
-      case Field.Id            => "id"
-      case Field.InputSpec     => "inputSpec"
-      case Field.Modified      => "modified"
-      case Field.Name          => "name"
-      case Field.OutputSpec    => "outputSpec"
-      case Field.ParentJob     => "parentJob"
-      case Field.Parts         => "parts"
-      case Field.Project       => "project"
-      case Field.Properties    => "properties"
-      case Field.Size          => "size"
-      case Field.Stages        => "stages"
+      case Field.Analysis       => "analysis"
+      case Field.Applet         => "applet"
+      case Field.ArchivalState  => "archivalState"
+      case Field.Created        => "created"
+      case Field.Description    => "description"
+      case Field.DeveloperNotes => "developerNotes"
+      case Field.Details        => "details"
+      case Field.Folder         => "folder"
+      case Field.Id             => "id"
+      case Field.InputSpec      => "inputSpec"
+      case Field.Modified       => "modified"
+      case Field.Name           => "name"
+      case Field.OutputSpec     => "outputSpec"
+      case Field.ParentJob      => "parentJob"
+      case Field.Parts          => "parts"
+      case Field.Project        => "project"
+      case Field.Properties     => "properties"
+      case Field.Size           => "size"
+      case Field.Stages         => "stages"
+      case Field.Summary        => "summary"
+      case Field.Title          => "title"
     }.toVector
     val m: Map[String, JsValue] = fieldStrings.map { x =>
       x -> JsTrue

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -113,9 +113,9 @@ case class IOParameter(
 
 // Extra fields for describe
 object Field extends Enumeration {
-  val Analysis, Applet, ArchivalState, Created, Description, Details, DeveloperNotes, Folder, Id,
-      InputSpec, Modified, Name, OutputSpec, ParentJob, Parts, Project, Properties, Size, Stages,
-      Summary, Tags, Title = Value
+  val Analysis, Applet, ArchivalState, DxCategories, Created, Description, Details, DeveloperNotes,
+      Folder, Id, InputSpec, Modified, Name, OutputSpec, ParentJob, Parts, Project, Properties,
+      Size, Stages, Summary, Tags, Title, Types = Value
 }
 
 trait DxObjectDescribe {
@@ -333,6 +333,7 @@ object DxObject {
       case Field.Analysis       => "analysis"
       case Field.Applet         => "applet"
       case Field.ArchivalState  => "archivalState"
+      case Field.DxCategories   => "categories"
       case Field.Created        => "created"
       case Field.Description    => "description"
       case Field.DeveloperNotes => "developerNotes"
@@ -351,6 +352,7 @@ object DxObject {
       case Field.Stages         => "stages"
       case Field.Summary        => "summary"
       case Field.Title          => "title"
+      case Field.Types          => "types"
     }.toVector
     val m: Map[String, JsValue] = fieldStrings.map { x =>
       x -> JsTrue

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -113,7 +113,7 @@ case class IOParameter(
 
 // Extra fields for describe
 object Field extends Enumeration {
-  val Analysis, Applet, ArchivalState, DxCategories, Created, Description, Details, DeveloperNotes,
+  val Analysis, Applet, ArchivalState, Categories, Created, Description, Details, DeveloperNotes,
       Folder, Id, InputSpec, Modified, Name, OutputSpec, ParentJob, Parts, Project, Properties,
       Size, Stages, Summary, Tags, Title, Types = Value
 }
@@ -333,7 +333,7 @@ object DxObject {
       case Field.Analysis       => "analysis"
       case Field.Applet         => "applet"
       case Field.ArchivalState  => "archivalState"
-      case Field.DxCategories   => "categories"
+      case Field.Categories     => "categories"
       case Field.Created        => "created"
       case Field.Description    => "description"
       case Field.DeveloperNotes => "developerNotes"
@@ -351,6 +351,7 @@ object DxObject {
       case Field.Size           => "size"
       case Field.Stages         => "stages"
       case Field.Summary        => "summary"
+      case Field.Tags           => "tags"
       case Field.Title          => "title"
       case Field.Types          => "types"
     }.toVector

--- a/src/test/resources/compiler/add_app_meta.wdl
+++ b/src/test/resources/compiler/add_app_meta.wdl
@@ -33,7 +33,7 @@ task add {
         }
         tags: ["add", "ints"]
         properties: {
-            
+            foo: "bar"
         }
     }
     

--- a/src/test/resources/compiler/add_app_meta.wdl
+++ b/src/test/resources/compiler/add_app_meta.wdl
@@ -1,0 +1,42 @@
+version 1.0
+
+task add_app_meta {
+    input {
+        Int a
+        Int b
+    }
+
+    meta {
+        title: "Add Ints"
+        summary: "Adds two int together"
+        description: "This app adds together two integers and returns the sum"
+        developer_notes: "Check out my sick bash expression! Three dolla signs!!!"
+        version: "1.0"
+        open_source: true
+        details: {
+            contact_email: "joe@dev.com",
+            upstream_version: "1.0",
+            upstream_author: "Joe Developer",
+            upstream_url: "https://dev.com/joe",
+            upstream_licenses: ["MIT"],
+            change_log: [
+                { 
+                    version: "1.1", 
+                    changes: ["Added paramter --foo", "Added cowsay easter-egg"] 
+                },
+                {
+                    version: "1.0", 
+                    changes: ["Intial version"]
+                }
+            ]
+        }
+    }
+    
+    command {
+        echo $((${a} + ${b}))
+    }
+
+    output {
+        Int result = read_int(stdout())
+    }
+}

--- a/src/test/resources/compiler/add_app_meta.wdl
+++ b/src/test/resources/compiler/add_app_meta.wdl
@@ -8,11 +8,12 @@ task add {
 
     meta {
         title: "Add Ints"
-        summary: "Adds two int together"
-        description: "This app adds together two integers and returns the sum"
+        description: "Adds two int together. This app adds together two integers and returns the sum"
         developer_notes: "Check out my sick bash expression! Three dolla signs!!!"
+        categories: ["Assembly"]
         version: "1.0"
         open_source: true
+        types: ["Adder"]
         details: {
             contactEmail: "joe@dev.com",
             upstreamVersion: "1.0",
@@ -29,6 +30,10 @@ task add {
                     changes: ["Initial version"]
                 }
             ]
+        }
+        tags: ["add", "ints"]
+        properties: {
+            
         }
     }
     

--- a/src/test/resources/compiler/add_app_meta.wdl
+++ b/src/test/resources/compiler/add_app_meta.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task add_app_meta {
+task add {
     input {
         Int a
         Int b
@@ -14,19 +14,19 @@ task add_app_meta {
         version: "1.0"
         open_source: true
         details: {
-            contact_email: "joe@dev.com",
-            upstream_version: "1.0",
-            upstream_author: "Joe Developer",
-            upstream_url: "https://dev.com/joe",
-            upstream_licenses: ["MIT"],
-            change_log: [
+            contactEmail: "joe@dev.com",
+            upstreamVersion: "1.0",
+            upstreamAuthor: "Joe Developer",
+            upstreamUrl: "https://dev.com/joe",
+            upstreamLicenses: ["MIT"],
+            whatsNew: [
                 { 
                     version: "1.1", 
-                    changes: ["Added paramter --foo", "Added cowsay easter-egg"] 
+                    changes: ["Added parameter --foo", "Added cowsay easter-egg"] 
                 },
                 {
                     version: "1.0", 
-                    changes: ["Intial version"]
+                    changes: ["Initial version"]
                 }
             ]
         }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1066,30 +1066,34 @@ class GenerateIRTest extends FlatSpec with Matchers {
       case _                                => throw new Exception("sanity")
     }
 
-    val cgrepApplet = getAppletByName("add_app_meta", bundle)
+    val cgrepApplet = getAppletByName("add", bundle)
     cgrepApplet.meta shouldBe Some(
         Vector(
-            IR.AppAttrDeveloperNotes("Check out my sick bash expression! Three dolla signs!!!"),
-            IR.AppAttrDescription("This app adds together two integers and returns the sum"),
-            IR.AppAttrOpenSource(true),
-            IR.AppAttrVersion("1.0"),
-            IR.AppAttrDetails(
-                Some("joe@dev.com"),
-                Some("1.0"),
-                Some("Joe Developer"),
-                Some("https://dev.com/joe"),
-                Some(Vector("MIT")),
-                Some(
-                    IR.ChangesReprList(
-                        Vector(IR.VersionChanges("1.1",
-                                                 Vector("Added paramter --foo",
-                                                        "Added cowsay easter-egg")),
-                               IR.VersionChanges("1.0", Vector("Intial version")))
+            IR.TaskAttrDeveloperNotes("Check out my sick bash expression! Three dolla signs!!!"),
+            IR.TaskAttrDescription("This app adds together two integers and returns the sum"),
+            IR.TaskAttrOpenSource(true),
+            IR.TaskAttrVersion("1.0"),
+            IR.TaskAttrDetails(
+                Map(
+                    "contactEmail" -> "joe@dev.com",
+                    "upstreamVersion" -> "1.0",
+                    "upstreamAuthor" -> "Joe Developer",
+                    "upstreamUrl" -> "https://dev.com/joe",
+                    "upstreamLicenses" -> Vector("MIT"),
+                    "whatsNew" -> Vector(
+                        Map(
+                            "version" -> "1.1",
+                            "changes" -> Vector("Added paramter --foo", "Added cowsay easter-egg")
+                        ),
+                        Map(
+                            "version" -> "1.0",
+                            "changes" -> Vector("Intial version")
+                        )
                     )
                 )
             ),
-            IR.AppAttrTitle("Add Ints"),
-            IR.AppAttrSummary("Adds two int together")
+            IR.TaskAttrTitle("Add Ints"),
+            IR.TaskAttrSummary("Adds two int together")
         )
     )
   }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1055,6 +1055,45 @@ class GenerateIRTest extends FlatSpec with Matchers {
     )
   }
 
+  it should "recognize app metadata" in {
+    val path = pathFromBasename("compiler", "add_app_meta.wdl")
+    val retval = Main.compile(
+        path.toString :: cFlags
+    )
+    retval shouldBe a[Main.SuccessfulTerminationIR]
+    val bundle = retval match {
+      case Main.SuccessfulTerminationIR(ir) => ir
+      case _                                => throw new Exception("sanity")
+    }
+
+    val cgrepApplet = getAppletByName("add_app_meta", bundle)
+    cgrepApplet.meta shouldBe Some(
+        Vector(
+            IR.AppAttrDeveloperNotes("Check out my sick bash expression! Three dolla signs!!!"),
+            IR.AppAttrDescription("This app adds together two integers and returns the sum"),
+            IR.AppAttrOpenSource(true),
+            IR.AppAttrVersion("1.0"),
+            IR.AppAttrDetails(
+                Some("joe@dev.com"),
+                Some("1.0"),
+                Some("Joe Developer"),
+                Some("https://dev.com/joe"),
+                Some(Vector("MIT")),
+                Some(
+                    IR.ChangesReprList(
+                        Vector(IR.VersionChanges("1.1",
+                                                 Vector("Added paramter --foo",
+                                                        "Added cowsay easter-egg")),
+                               IR.VersionChanges("1.0", Vector("Intial version")))
+                    )
+                )
+            ),
+            IR.AppAttrTitle("Add Ints"),
+            IR.AppAttrSummary("Adds two int together")
+        )
+    )
+  }
+
   it should "handle streaming files" in {
     val path = pathFromBasename("compiler", "streaming_files.wdl")
     val retval = Main.compile(

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1070,9 +1070,12 @@ class GenerateIRTest extends FlatSpec with Matchers {
     cgrepApplet.meta shouldBe Some(
         Vector(
             IR.TaskAttrDeveloperNotes("Check out my sick bash expression! Three dolla signs!!!"),
-            IR.TaskAttrDescription("This app adds together two integers and returns the sum"),
+            IR.TaskAttrDescription(
+                "Adds two int together. This app adds together two integers and returns the sum"
+            ),
             IR.TaskAttrOpenSource(true),
             IR.TaskAttrVersion("1.0"),
+            IR.TaskAttrCategories(Vector("Assembly")),
             IR.TaskAttrDetails(
                 Map(
                     "contactEmail" -> "joe@dev.com",
@@ -1083,17 +1086,17 @@ class GenerateIRTest extends FlatSpec with Matchers {
                     "whatsNew" -> Vector(
                         Map(
                             "version" -> "1.1",
-                            "changes" -> Vector("Added paramter --foo", "Added cowsay easter-egg")
+                            "changes" -> Vector("Added parameter --foo", "Added cowsay easter-egg")
                         ),
                         Map(
                             "version" -> "1.0",
-                            "changes" -> Vector("Intial version")
+                            "changes" -> Vector("Initial version")
                         )
                     )
                 )
             ),
             IR.TaskAttrTitle("Add Ints"),
-            IR.TaskAttrSummary("Adds two int together")
+            IR.TaskAttrTypes(Vector("Adder"))
         )
     )
   }

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -1073,8 +1073,10 @@ class GenerateIRTest extends FlatSpec with Matchers {
             IR.TaskAttrDescription(
                 "Adds two int together. This app adds together two integers and returns the sum"
             ),
+            IR.TaskAttrTags(Vector("add", "ints")),
             IR.TaskAttrOpenSource(true),
             IR.TaskAttrVersion("1.0"),
+            IR.TaskAttrProperties(Map("foo" -> "bar")),
             IR.TaskAttrCategories(Vector("Assembly")),
             IR.TaskAttrDetails(
                 Map(

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -641,8 +641,8 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     b.label shouldBe Some("A negative integer")
   }
 
-  it should "be able to include license information in details" in {
-    val expected =
+  it should "be able to include information from task meta and extras" in {
+    val expectedUpstreamProjects =
       """
         |[
         |  {
@@ -656,7 +656,15 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         |]
             """.stripMargin.parseJson
 
-    val path = pathFromBasename("compiler", "add.wdl")
+    val expectedWhatsNew =
+      """## Changelog
+        |### Version 1.1
+        |* Added parameter --foo
+        |* Added cowsay easter-egg
+        |### Version 1.0
+        |* Initial version""".stripMargin
+
+    val path = pathFromBasename("compiler", "add_app_meta.wdl")
     val extraPath = pathFromBasename("compiler/extras", "extras_license.json")
 
     val appId = Main.compile(
@@ -670,18 +678,38 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     val dxApplet = DxApplet.getInstance(appId)
-    val desc = dxApplet.describe(Set(Field.Details))
-    val license = desc.details match {
-      case Some(JsObject(x)) =>
-        x.get("upstreamProjects") match {
-          case None    => List.empty
-          case Some(s) => s
+    val desc = dxApplet.describe(
+        Set(
+            Field.Description,
+            Field.Details,
+            Field.DeveloperNotes,
+            Field.Summary,
+            Field.Title
+        )
+    )
 
+    desc.description shouldBe Some("This app adds together two integers and returns the sum")
+    desc.details match {
+      case Some(JsObject(fields)) =>
+        fields.foreach {
+          case ("contactEmail", JsString(value))    => value shouldBe "joe@dev.com"
+          case ("upstreamVersion", JsString(value)) => value shouldBe "1.0"
+          case ("upstreamAuthor", JsString(value))  => value shouldBe "Joe Developer"
+          case ("upstreamUrl", JsString(value))     => value shouldBe "https://dev.com/joe"
+          case ("upstreamLicenses", JsArray(array)) => array shouldBe Vector(JsString("MIT"))
+          case ("upstreamProjects", array: JsArray) =>
+            array shouldBe expectedUpstreamProjects
+          case ("whatsNew", JsString(value))       => value shouldBe expectedWhatsNew
+          case ("instanceTypeDB", JsString(value)) => Unit // ignore
+          case ("runtimeAttrs", JsObject(fields))  => Unit // ignore
+          case ("womSourceCode", JsString(value))  => Unit // ignore
+          case other                               => throw new Exception(s"Unexpected result ${other}")
         }
       case other => throw new Exception(s"Unexpected result ${other}")
     }
-
-    license shouldBe expected
+    desc.developerNotes shouldBe Some("Check out my sick bash expression! Three dolla signs!!!")
+    desc.summary shouldBe Some("Adds two int together")
+    desc.title shouldBe Some("Add Ints")
   }
 
   it should "deep nesting" taggedAs (NativeTestXX) in {

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -682,7 +682,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
             Field.Description,
             Field.Details,
             Field.DeveloperNotes,
+            Field.Properties,
             Field.Summary,
+            Field.Tags,
             Field.Title,
             Field.Types
         )
@@ -710,7 +712,13 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       case other => throw new Exception(s"Unexpected result ${other}")
     }
     desc.developerNotes shouldBe Some("Check out my sick bash expression! Three dolla signs!!!")
+    desc.properties match {
+      case Some(m) =>
+        (m -- Set(Utils.VERSION_PROP, Utils.CHECKSUM_PROP)) shouldBe Map("foo" -> "bar")
+      case _ => throw new Exception("No properties")
+    }
     desc.summary shouldBe Some("Adds two int together")
+    desc.tags shouldBe Some(Vector("add", "ints", "dxWDL"))
     desc.title shouldBe Some("Add Ints")
     desc.types shouldBe Some(Vector("Adder"))
   }

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -673,8 +673,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
           :: "--extras" :: extraPath.toString :: cFlags
     ) match {
       case SuccessfulTermination(x) => x
-      case _                        => throw new Exception("sanity")
-
+      case other                    => throw new Exception(s"Unexpected result ${other}")
     }
 
     val dxApplet = DxApplet.getInstance(appId)
@@ -684,11 +683,14 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
             Field.Details,
             Field.DeveloperNotes,
             Field.Summary,
-            Field.Title
+            Field.Title,
+            Field.Types
         )
     )
 
-    desc.description shouldBe Some("This app adds together two integers and returns the sum")
+    desc.description shouldBe Some(
+        "Adds two int together. This app adds together two integers and returns the sum"
+    )
     desc.details match {
       case Some(JsObject(fields)) =>
         fields.foreach {
@@ -710,6 +712,7 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     desc.developerNotes shouldBe Some("Check out my sick bash expression! Three dolla signs!!!")
     desc.summary shouldBe Some("Adds two int together")
     desc.title shouldBe Some("Add Ints")
+    desc.types shouldBe Some(Vector("Adder"))
   }
 
   it should "deep nesting" taggedAs (NativeTestXX) in {


### PR DESCRIPTION
This PR adds support for specifying app-level metadata in task meta {}. This includes some of the changes in #375. This PR should be merged first and then I will merge #375 on top of it.

Specifically, this PR adds support for extracting the following metadata from task meta:

* title (defaults to task name)
* description
* summary (defaults to the first line of description, up to the first period or 50 characters, whichever comes first)
* developer_notes
* details - currently, these can be specified in extras as well; the ones in extras take precedence over the ones in the WDL
* tags (merged with the default tags added by dxWDL)
* properties (merged with the default properties added by dxWDL)
* types

There are also placeholders for version, categories, and open_source - they are parsed into IR but not used when generating the applet, since they only apply to apps.