### PR TITLE
Add support for runtime hints

### DIFF
--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -378,17 +378,19 @@ object Extras {
     }
   }
 
+  def stringToAccessLevel(name: String): AccessLevel = {
+    for (x <- AccessLevel.values()) {
+      if (x.toString.toLowerCase == name.toLowerCase)
+        return x
+    }
+    throw new Exception(s"Invalid access level ${name}")
+  }
+
   private def checkedParseAccessLevelField(fields: Map[String, JsValue],
                                            fieldName: String): Option[AccessLevel] = {
     checkedParseStringField(fields, fieldName) match {
-      case None =>
-        return None
-      case Some(s) =>
-        for (x <- AccessLevel.values()) {
-          if (x.toString.toLowerCase == s.toLowerCase)
-            return Some(x)
-        }
-        throw new Exception(s"Invalid access level ${s}")
+      case None    => return None
+      case Some(s) => Some(stringToAccessLevel(s))
     }
   }
 

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -27,8 +27,6 @@ object IR {
   // can be used in the meta section of task WDL, and will be parsed out and used when generating
   // the native app.
 
-  val META_TYPE = "type"
-  val META_ID = "id"
   val META_CATEGORIES = "categories"
   val META_DESCRIPTION = "description"
   val META_DETAILS = "details"
@@ -67,6 +65,39 @@ object IR {
   final case class WorkflowAttrProperties(properties: Map[String, String]) extends WorkflowAttr
   final case class WorkflowAttrCallNames(mapping: Map[String, String]) extends WorkflowAttr
   final case class WorkflowAttrRunOnSingleNode(value: Boolean) extends WorkflowAttr
+
+  // The following keywords/types correspond to runtime-related attributes from dxapp.json.
+  // Currently, these are searched for in the runtime section of WDL, but will move to hints in
+  // WDL 2.0.
+
+  val HINT_ACCESS = "dx_access"
+  val HINT_IGNORE_REUSE = "dx_ignore_reuse"
+  val HINT_INSTANCE_TYPE = "dx_instance_type"
+  //val HINT_REGIONS = "dx_regions"
+  val HINT_RESTART = "dx_restart"
+  val HINT_TIMEOUT = "dx_timeout"
+  val HINT_APP_TYPE = "type"
+  val HINT_APP_ID = "id"
+
+  // This key is used in the restart object value to represent "*"
+  val ALL_KEY = "All"
+
+  sealed abstract class RuntimeHint
+  final case class RuntimeHintRestart(max: Option[Int] = None,
+                                      default: Option[Int] = None,
+                                      errors: Option[Map[String, Int]] = None)
+      extends RuntimeHint
+  final case class RuntimeHintTimeout(days: Option[Int] = None,
+                                      hours: Option[Int] = None,
+                                      minutes: Option[Int] = None)
+      extends RuntimeHint
+  final case class RuntimeHintIgnoreReuse(value: Boolean) extends RuntimeHint
+  final case class RuntimeHintAccess(network: Option[Vector[String]] = None,
+                                     project: Option[String] = None,
+                                     allProjects: Option[String] = None,
+                                     developer: Option[Boolean] = None,
+                                     projectCreation: Option[Boolean] = None)
+      extends RuntimeHint
 
   // The following keywords/types correspond to attributes of inputSpec/outputSpec from
   // dxapp.json. These attributes can be used in the parameter_meta section of task WDL, and
@@ -324,6 +355,7 @@ object IR {
     * @param task          Task definition
     * @param womSourceCode WDL/CWL source code for task.
     * @param meta          Additional applet metadata
+    * @param runtimeHints  Runtime hints
     */
   case class Applet(name: String,
                     inputs: Vector[CVar],
@@ -332,7 +364,8 @@ object IR {
                     docker: DockerImage,
                     kind: AppletKind,
                     womSourceCode: String,
-                    meta: Option[Vector[TaskAttr]] = None)
+                    meta: Option[Vector[TaskAttr]] = None,
+                    runtimeHints: Option[Vector[RuntimeHint]] = None)
       extends Callable {
     def inputVars = inputs
     def outputVars = outputs

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -333,7 +333,7 @@ task Add {
             accu
           } else {
             val sourceCode = callable match {
-              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode, _) =>
+              case IR.Applet(_, _, _, _, _, IR.AppletKindTask(_), taskSourceCode, _, _) =>
                 // This is a task, include its source code, instead of a header.
                 val taskDir = ParseWomSourceFile(false).scanForTasks(taskSourceCode)
                 assert(taskDir.size == 1)

--- a/src/main/scala/dxWDL/dx/DxApplet.scala
+++ b/src/main/scala/dxWDL/dx/DxApplet.scala
@@ -20,7 +20,10 @@ case class DxAppletDescribe(project: String,
                             summary: Option[String] = None,
                             title: Option[String] = None,
                             types: Option[Vector[String]] = None,
-                            tags: Option[Vector[String]] = None)
+                            tags: Option[Vector[String]] = None,
+                            runSpec: Option[JsValue] = None,
+                            access: Option[JsValue] = None,
+                            ignoreReuse: Option[Boolean] = None)
     extends DxObjectDescribe
 
 case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable {
@@ -80,14 +83,22 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
     val title = descFields.get("title").flatMap(unwrapString)
     val types = descFields.get("types").flatMap(unwrapStringArray)
     val tags = descFields.get("tags").flatMap(unwrapStringArray)
-    desc.copy(details = details,
-              properties = props,
-              description = description,
-              developerNotes = developerNotes,
-              summary = summary,
-              title = title,
-              types = types,
-              tags = tags)
+    val runSpec = descFields.get("runSpec")
+    val access = descFields.get("access")
+    val ignoreReuse = descFields.get("ignoreReuse").flatMap(unwrapBoolean)
+    desc.copy(
+        details = details,
+        properties = props,
+        description = description,
+        developerNotes = developerNotes,
+        summary = summary,
+        title = title,
+        types = types,
+        tags = tags,
+        runSpec = runSpec,
+        access = access,
+        ignoreReuse = ignoreReuse
+    )
   }
 
   def unwrapString(jsValue: JsValue): Option[String] = {
@@ -101,6 +112,13 @@ case class DxApplet(id: String, project: Option[DxProject]) extends DxExecutable
     jsValue match {
       case JsArray(array) => Some(array.flatMap(unwrapString))
       case _              => None
+    }
+  }
+
+  def unwrapBoolean(jsValue: JsValue): Option[Boolean] = {
+    jsValue match {
+      case JsBoolean(value) => Some(value)
+      case _                => None
     }
   }
 

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -113,9 +113,10 @@ case class IOParameter(
 
 // Extra fields for describe
 object Field extends Enumeration {
-  val Analysis, Applet, ArchivalState, Categories, Created, Description, Details, DeveloperNotes,
-      Folder, Id, InputSpec, Modified, Name, OutputSpec, ParentJob, Parts, Project, Properties,
-      Size, Stages, Summary, Tags, Title, Types, Version = Value
+  val Access, Analysis, Applet, ArchivalState, Categories, Created, Description, Details,
+      DeveloperNotes, Folder, Id, IgnoreReuse, InputSpec, Modified, Name, OutputSpec, ParentJob,
+      Parts, Project, Properties, RunSpec, Size, Stages, Summary, Tags, Title, Types, Version =
+    Value
 }
 
 trait DxObjectDescribe {
@@ -330,6 +331,7 @@ object DxObject {
 
   def requestFields(fields: Set[Field.Value]): JsValue = {
     val fieldStrings = fields.map {
+      case Field.Access         => "access"
       case Field.Analysis       => "analysis"
       case Field.Applet         => "applet"
       case Field.ArchivalState  => "archivalState"
@@ -340,6 +342,7 @@ object DxObject {
       case Field.Details        => "details"
       case Field.Folder         => "folder"
       case Field.Id             => "id"
+      case Field.IgnoreReuse    => "ignoreReuse"
       case Field.InputSpec      => "inputSpec"
       case Field.Modified       => "modified"
       case Field.Name           => "name"
@@ -348,6 +351,7 @@ object DxObject {
       case Field.Parts          => "parts"
       case Field.Project        => "project"
       case Field.Properties     => "properties"
+      case Field.RunSpec        => "runSpec"
       case Field.Size           => "size"
       case Field.Stages         => "stages"
       case Field.Summary        => "summary"

--- a/src/main/scala/dxWDL/exec/JobInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/JobInputOutput.scala
@@ -296,14 +296,14 @@ case class JobInputOutput(dxIoFunctions: DxIoFunctions,
                 //   stream : true
                 // }
                 // We also support two aliases, dx_stream and localizationOptional
-                val streamAttr = value
+                value
                   .filterKeys(
                       Set(PARAM_META_STREAM, PARAM_META_DX_STREAM, PARAM_META_LOCALIZATION_OPTIONAL)
                   )
-                  .headOption
-                streamAttr match {
-                  case Some(MetaValueElement.MetaValueElementBoolean(b)) if b => findFiles(womValue)
-                  case _                                                      => Vector.empty
+                  .headOption match {
+                  case Some((_, MetaValueElement.MetaValueElementBoolean(b))) if b =>
+                    findFiles(womValue)
+                  case _ => Vector.empty
                 }
               case _ =>
                 Vector.empty

--- a/src/main/scala/dxWDL/util/Adjunct.scala
+++ b/src/main/scala/dxWDL/util/Adjunct.scala
@@ -32,8 +32,8 @@ object Adjuncts {
       wdlName = wdlName.dropRight(4)
     }
 
-    val readmeRegexp = s"(?i)readme\\.${wdlName}\\.(.+)\\.md".r
-    val developerNotesRegexp = s"(?i)readme\\.developer\\.${wdlName}\\.(.+)\\.md".r
+    lazy val readmeRegexp = s"(?i)readme\\.${wdlName}\\.(.+)\\.md".r
+    lazy val developerNotesRegexp = s"(?i)readme\\.developer\\.${wdlName}\\.(.+)\\.md".r
 
     parentDir.listFiles
       .flatMap { file =>

--- a/src/test/resources/compiler/add_runtime_hints.wdl
+++ b/src/test/resources/compiler/add_runtime_hints.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task per_task_dx_attributes {
+task add_runtime_hints {
     input {
         Int a
         Int b

--- a/src/test/resources/compiler/add_runtime_hints.wdl
+++ b/src/test/resources/compiler/add_runtime_hints.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+task per_task_dx_attributes {
+    input {
+        Int a
+        Int b
+    }
+    
+    command {
+        echo $((${a} + ${b}))
+    }
+
+    output {
+        Int result = read_int(stdout())
+    }
+
+    runtime {
+        dx_ignore_reuse: true
+        dx_restart: object {
+            default: 1,
+            max: 5,
+            errors: {
+                "UnresponsiveWorker": 2,
+                "ExecutionError": 2,
+            }
+        }
+        dx_timeout: "12H30M"
+        dx_access: object {
+            network: ["*"],
+            developer: true
+        }
+    } 
+}

--- a/src/test/resources/compiler/extras/task_specific_short_timeout.json
+++ b/src/test/resources/compiler/extras/task_specific_short_timeout.json
@@ -1,0 +1,14 @@
+{
+    "per_task_dx_attributes" : {
+      "per_task_dx_attributes": {
+        "runSpec": {
+          "timeoutPolicy": {
+            "*": {
+              "hours": 3
+            }
+          }
+        }
+      }
+    }
+}
+  

--- a/src/test/resources/compiler/extras/task_specific_short_timeout.json
+++ b/src/test/resources/compiler/extras/task_specific_short_timeout.json
@@ -1,6 +1,6 @@
 {
     "per_task_dx_attributes" : {
-      "per_task_dx_attributes": {
+      "add_runtime_hints": {
         "runSpec": {
           "timeoutPolicy": {
             "*": {

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -837,9 +837,23 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         )
     )
 
+    // Sometimes the API only returns the fields with non-zero values
+    def fillOut(obj: JsValue): JsObject = {
+      obj match {
+        case JsObject(fields) =>
+          defaults = Map(
+              "days" -> JsNumber(0),
+              "hours" -> JsNumber(0),
+              "minutes" -> JsNumber(0)
+          )
+          JsObject(defaults ++ fields)
+        case _ => throw new Exception("Expected JsObject")
+      }
+    }
+
     desc.runSpec match {
       case Some(JsObject(fields)) =>
-        fields("timeoutPolicy") shouldBe JsObject(
+        fillOut(fields("timeoutPolicy")) shouldBe JsObject(
             Map(
                 "*" -> JsObject(
                     Map(

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -841,13 +841,13 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     def fillOut(obj: JsValue): JsObject = {
       obj match {
         case JsObject(fields) =>
-          defaults = Map(
+          val defaults = Map(
               "days" -> JsNumber(0),
               "hours" -> JsNumber(0),
               "minutes" -> JsNumber(0)
           )
           JsObject(fields.mapValues {
-            case JsObject(inner) => JsObject(defaults ++ fields)
+            case JsObject(inner) => JsObject(defaults ++ inner)
             case _               => throw new Exception("Expected JsObject")
           })
         case _ => throw new Exception("Expected JsObject")

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -846,7 +846,10 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
               "hours" -> JsNumber(0),
               "minutes" -> JsNumber(0)
           )
-          JsObject(defaults ++ fields)
+          JsObject(fields.mapValues {
+            case JsObject(inner) => JsObject(defaults ++ fields)
+            case _               => throw new Exception("Expected JsObject")
+          })
         case _ => throw new Exception("Expected JsObject")
       }
     }

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -843,7 +843,9 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
             Map(
                 "*" -> JsObject(
                     Map(
-                        "hours" -> JsNumber(3)
+                        "days" -> JsNumber(0),
+                        "hours" -> JsNumber(3),
+                        "minutes" -> JsNumber(0)
                     )
                 )
             )

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -723,6 +723,135 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     desc.types shouldBe Some(Vector("Adder"))
   }
 
+  it should "be able to include runtime hints" in {
+    val path = pathFromBasename("compiler", "add_runtime_hints.wdl")
+
+    val appId = Main.compile(
+        path.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case other                    => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    val dxApplet = DxApplet.getInstance(appId)
+    val desc = dxApplet.describe(
+        Set(
+            Field.Access,
+            Field.IgnoreReuse,
+            Field.RunSpec
+        )
+    )
+
+    desc.runSpec match {
+      case Some(JsObject(fields)) =>
+        fields("executionPolicy") shouldBe JsObject(
+            Map(
+                "restartOn" -> JsObject(
+                    Map(
+                        "*" -> JsNumber(1),
+                        "UnresponsiveWorker" -> JsNumber(2),
+                        "ExecutionError" -> JsNumber(2)
+                    )
+                ),
+                "maxRestarts" -> JsNumber(5)
+            )
+        )
+        fields("timeoutPolicy") shouldBe JsObject(
+            Map(
+                "*" -> JsObject(
+                    Map(
+                        "days" -> JsNumber(0),
+                        "hours" -> JsNumber(12),
+                        "minutes" -> JsNumber(30)
+                    )
+                )
+            )
+        )
+      case _ => throw new Exception("Missing runSpec")
+    }
+    desc.access shouldBe Some(
+        JsObject(
+            Map(
+                "network" -> JsArray(Vector(JsString("*"))),
+                "developer" -> JsBoolean(true)
+            )
+        )
+    )
+    desc.ignoreReuse shouldBe Some(true)
+  }
+
+  it should "be able to include runtime hints and override extras global" in {
+    val path = pathFromBasename("compiler", "add_runtime_hints.wdl")
+    val extraPath = pathFromBasename("compiler/extras", "short_timeout.json")
+
+    val appId = Main.compile(
+        path.toString
+        //:: "--verbose"
+          :: "--extras" :: extraPath.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case other                    => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    val dxApplet = DxApplet.getInstance(appId)
+    val desc = dxApplet.describe(
+        Set(
+            Field.RunSpec
+        )
+    )
+
+    desc.runSpec match {
+      case Some(JsObject(fields)) =>
+        fields("timeoutPolicy") shouldBe JsObject(
+            Map(
+                "*" -> JsObject(
+                    Map(
+                        "days" -> JsNumber(0),
+                        "hours" -> JsNumber(12),
+                        "minutes" -> JsNumber(30)
+                    )
+                )
+            )
+        )
+      case _ => throw new Exception("Missing runSpec")
+    }
+  }
+
+  it should "be able to include runtime hints with extras per-task override" in {
+    val path = pathFromBasename("compiler", "add_runtime_hints.wdl")
+    val extraPath = pathFromBasename("compiler/extras", "task_specific_short_timeout.json")
+
+    val appId = Main.compile(
+        path.toString
+        //:: "--verbose"
+          :: "--extras" :: extraPath.toString :: cFlags
+    ) match {
+      case SuccessfulTermination(x) => x
+      case other                    => throw new Exception(s"Unexpected result ${other}")
+    }
+
+    val dxApplet = DxApplet.getInstance(appId)
+    val desc = dxApplet.describe(
+        Set(
+            Field.RunSpec
+        )
+    )
+
+    desc.runSpec match {
+      case Some(JsObject(fields)) =>
+        fields("timeoutPolicy") shouldBe JsObject(
+            Map(
+                "*" -> JsObject(
+                    Map(
+                        "hours" -> JsNumber(3)
+                    )
+                )
+            )
+        )
+      case _ => throw new Exception("Missing runSpec")
+    }
+  }
+
   it should "be able to include information from workflow meta" in {
     val path = pathFromBasename("compiler", "wf_meta.wdl")
 


### PR DESCRIPTION
This PR adds four runtime hints:

* executionPolicy (which is specified in WDL task runtime using the `dx_restart` key)
* timeoutPolicy (which is specified in WDL task runtime using the `dx_timeout` key)
* access (which is specified in WDL task runtime using the `dx_access` key)
* ignoreReuse  (which is specified in WDL task runtime using the `dx_ignore_reuse` key)