### PR TITLE
Exclude nano instances

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 1.46.1
+- Do not use AWS nano instances for auxiliarly WDL jobs. They are not strong enough for the task.
+
 ## 1.46 12-Mar-2020
 - Recognize DNAnexus-specific keys in task and workflow metadata
 - Recognize workflow parameter metadata

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "v1.47"
+    version = "v1.46.1"
 }
 
 #

--- a/src/main/scala/dxWDL/util/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/util/InstanceTypeDB.scala
@@ -212,10 +212,15 @@ case class InstanceTypeDB(pricingAvailable: Boolean, instances: Vector[DxInstanc
     }
   }
 
-  // A fast but cheap instance type.
+  // A fast but cheap instance type. Used to run WDL expression
+  // processing, launch jobs, etc.
   //
   def defaultInstanceType: String = {
-    val iType = calcMinimalInstanceType(instances.toSet)
+    // exclude nano instances, they aren't strong enough.
+    val goodEnough = instances.filter { iType =>
+      !iType.name.contains("nano")
+    }
+    val iType = calcMinimalInstanceType(goodEnough.toSet)
     iType.name
   }
 


### PR DESCRIPTION
Exclude AWS nano instances from those that can run WDL auxiliary calculations. For example, expression evaluation, or scatter launch/collect.