### PR TITLE
Purge (almost) all references to WOM

### DIFF
--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -686,13 +686,13 @@ object Main extends App {
                          defaultRuntimeAttributes: Option[WdlRuntimeAttrs],
                          delayWorkspaceDestruction: Option[Boolean],
                          rtDebugLvl: Int): Termination = {
-    // Parse the inputs, convert to WOM values. Delay downloading files
+    // Parse the inputs, convert to JSON values. Delay downloading files
     // from the platform, we may not need to access them.
     val verbose = rtDebugLvl > 0
     val inputLines: String = Utils.readFileContent(jobInputPath)
     val originalInputs: JsValue = inputLines.parseJson
 
-    val (task, typeAliases, document) = ParseWomSourceFile(verbose).parseWdlTask(taskSourceCode)
+    val (task, typeAliases, document) = ParseWdlSourceFile(verbose).parseWdlTask(taskSourceCode)
 
     // setup the utility directories that the task-runner employs
     dxPathConfig.createCleanDirs()
@@ -767,7 +767,7 @@ object Main extends App {
 
   // Execute a part of a workflow
   private def workflowFragAction(op: InternalOp.Value,
-                                 womSourceCode: String,
+                                 wdlSourceCode: String,
                                  instanceTypeDB: InstanceTypeDB,
                                  metaInfo: JsValue,
                                  jobInputPath: Path,
@@ -781,13 +781,13 @@ object Main extends App {
     //val dxProject = DxUtils.dxEnv.getProjectContext()
     val verbose = rtDebugLvl > 0
 
-    // Parse the inputs, convert to WOM values. Delay downloading files
+    // Parse the inputs, convert to JSON values. Delay downloading files
     // from the platform, we may not need to access them.
     val inputLines: String = Utils.readFileContent(jobInputPath)
     val inputsRaw: JsValue = inputLines.parseJson
 
     val (wf, taskDir, typeAliases, document) =
-      ParseWomSourceFile(verbose).parseWdlWorkflow(womSourceCode)
+      ParseWdlSourceFile(verbose).parseWdlWorkflow(wdlSourceCode)
 
     // setup the utility directories that the frag-runner employs
     val fragInputOutput =
@@ -879,7 +879,7 @@ object Main extends App {
     SuccessfulTermination(s"success ${op}")
   }
 
-  // Get the WOM source code, and the instance type database from the
+  // Get the WDL source code, and the instance type database from the
   // details field stored on the platform
   private def retrieveFromDetails(
       jobInfoPath: Path
@@ -902,8 +902,8 @@ object Main extends App {
     }
 
     val details: JsValue = applet.describe(Set(Field.Details)).details.get
-    val JsString(womSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
-    val womSourceCode = Utils.base64DecodeAndGunzip(womSourceCodeEncoded)
+    val JsString(wdlSourceCodeEncoded) = details.asJsObject.fields("womSourceCode")
+    val wdlSourceCode = Utils.base64DecodeAndGunzip(wdlSourceCodeEncoded)
 
     val JsString(instanceTypeDBEncoded) = details.asJsObject.fields("instanceTypeDB")
     val dbRaw = Utils.base64DecodeAndGunzip(instanceTypeDBEncoded)
@@ -921,7 +921,7 @@ object Main extends App {
         case Some(JsBoolean(flag)) => Some(flag)
         case None                  => None
       }
-    (womSourceCode, instanceTypeDB, details, runtimeAttrs, delayWorkspaceDestruction)
+    (wdlSourceCode, instanceTypeDB, details, runtimeAttrs, delayWorkspaceDestruction)
   }
 
   // Make a list of all the files cloned for access by this applet.
@@ -958,9 +958,9 @@ object Main extends App {
         val fileInfoDir = runtimeBulkFileDescribe(jobInputPath)
         val dxIoFunctions = DxIoFunctions(fileInfoDir, dxPathConfig, rtDebugLvl)
 
-        // Get the WOM source code (currently WDL, could be also CWL in the future)
-        // Parse the inputs, convert to WOM values.
-        val (womSourceCode,
+        // Get the WDL source code (currently WDL, could be also CWL in the future)
+        // Parse the inputs, convert to JSON values.
+        val (wdlSourceCode,
              instanceTypeDB,
              metaInfo,
              defaultRuntimeAttrs,
@@ -974,7 +974,7 @@ object Main extends App {
                 InternalOp.WfCustomReorgOutputs =>
               workflowFragAction(
                   op,
-                  womSourceCode,
+                  wdlSourceCode,
                   instanceTypeDB,
                   metaInfo,
                   jobInputPath,
@@ -989,7 +989,7 @@ object Main extends App {
                 InternalOp.TaskInstantiateCommand | InternalOp.TaskEpilog |
                 InternalOp.TaskRelaunch =>
               taskAction(op,
-                         womSourceCode,
+                         wdlSourceCode,
                          instanceTypeDB,
                          jobInputPath,
                          jobOutputPath,

--- a/src/main/scala/dxWDL/base/Extras.scala
+++ b/src/main/scala/dxWDL/base/Extras.scala
@@ -230,28 +230,28 @@ case class WdlHintAttrs(m: Map[String, TAT.MetaValue])
 // support automatic conversion to/from JsValue
 object WdlRuntimeAttrs extends DefaultJsonProtocol {
   implicit object WdlRuntimeAttrsFormat extends RootJsonFormat[WdlRuntimeAttrs] {
-    private def readWomValue(value: JsValue): WdlValues.V = value match {
+    private def readWdlValue(value: JsValue): WdlValues.V = value match {
       case JsBoolean(b)  => WdlValues.V_Boolean(b.booleanValue)
       case JsNumber(nmb) => WdlValues.V_Int(nmb.intValue)
       case JsString(s)   => WdlValues.V_String(s)
       case other         => throw new Exception(s"Unsupported json value ${other}")
     }
-    private def writeWomValue(wValue: WdlValues.V): JsValue = wValue match {
+    private def writeWdlValue(wValue: WdlValues.V): JsValue = wValue match {
       case WdlValues.V_Boolean(b) => JsBoolean(b)
       case WdlValues.V_Int(i)     => JsNumber(i)
       case WdlValues.V_String(s)  => JsString(s)
-      case other                  => throw new Exception(s"Unsupported wom value value ${other}")
+      case other                  => throw new Exception(s"Unsupported WDL value ${other}")
     }
 
     def read(jsv: JsValue): WdlRuntimeAttrs = {
-      val m = jsv.asJsObject.fields.map { case (k, v) => k -> readWomValue(v) }
+      val m = jsv.asJsObject.fields.map { case (k, v) => k -> readWdlValue(v) }
       WdlRuntimeAttrs(m)
     }
 
     def write(wra: WdlRuntimeAttrs): JsValue = {
       val fields = wra.m.map {
         case (k, v) =>
-          k -> writeWomValue(v)
+          k -> writeWdlValue(v)
       }
       JsObject(fields)
     }

--- a/src/main/scala/dxWDL/base/ParseWdlSourceFile.scala
+++ b/src/main/scala/dxWDL/base/ParseWdlSourceFile.scala
@@ -17,7 +17,7 @@ import wdlTools.types.{
 import scala.io.Source
 
 // Read, parse, and typecheck a WDL source file. This includes loading all imported files.
-case class ParseWomSourceFile(verbose: Boolean) {
+case class ParseWdlSourceFile(verbose: Boolean) {
 
   private case class BInfo(callables: Map[String, TAT.Callable],
                            sources: Map[String, TAT.Document],
@@ -120,7 +120,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
   // Also returns 1) a mapping of input files to source documents; 2) a mapping of input files to
   // "adjuncts" (such as README files); and 3) a vector of sub-bundles (one per import).
   def apply(mainFile: Path, imports: List[Path]): (Language.Value,
-                                                   WomBundle,
+                                                   WdlBundle,
                                                    Map[String, TAT.Document],
                                                    Map[String, Vector[Adjuncts.AdjunctFile]]) = {
     // Resolves for:
@@ -153,7 +153,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
     val flatInfo: BInfo = dfsFlatten(tMainDoc)
 
     (Language.fromWdlVersion(tMainDoc.version.value),
-     WomBundle(primaryCallable, flatInfo.callables, ctxTypes.aliases),
+     WdlBundle(primaryCallable, flatInfo.callables, ctxTypes.aliases),
      flatInfo.sources,
      flatInfo.adjunctFiles)
   }
@@ -238,7 +238,7 @@ case class ParseWomSourceFile(verbose: Boolean) {
   }
 
   // Extract the only task from a namespace
-  def getMainTask(bundle: WomBundle): TAT.Task = {
+  def getMainTask(bundle: WdlBundle): TAT.Task = {
     bundle.primaryCallable match {
       case None                 => throw new Exception("found no callable")
       case Some(task: TAT.Task) => task

--- a/src/main/scala/dxWDL/base/WdlTypeSerialization.scala
+++ b/src/main/scala/dxWDL/base/WdlTypeSerialization.scala
@@ -3,8 +3,8 @@ package dxWDL.base
 import wdlTools.types.WdlTypes._
 import wdlTools.types.{Util => TUtil}
 
-// Write a wom type as a string, and be able to convert back.
-case class WomTypeSerialization(typeAliases: Map[String, T]) {
+// Write a WdlType as a string, and be able to convert back.
+case class WdlTypeSerialization(typeAliases: Map[String, T]) {
   def toString(t: T): String = {
     t match {
       // Base case: primitive types.
@@ -122,12 +122,12 @@ case class WomTypeSerialization(typeAliases: Map[String, T]) {
         typeAliases(name)
 
       case _ =>
-        throw new Exception(s"Cannot convert ${str} to a wom type")
+        throw new Exception(s"Cannot convert ${str} to a WDL type")
     }
   }
 }
 
-object WomTypeSerialization {
+object WdlTypeSerialization {
   // Get a human readable type name
   // Int ->   "Int"
   // Array[Int] -> "Array[Int]"

--- a/src/main/scala/dxWDL/base/package.scala
+++ b/src/main/scala/dxWDL/base/package.scala
@@ -29,7 +29,7 @@ object CompilerFlag extends Enumeration {
 //  keywords -- specific words to trace
 //  quiet:      if true, do not print warnings and informational messages
 case class Verbose(on: Boolean, quiet: Boolean, keywords: Set[String]) {
-  lazy val keywordsLo: Set[String] = keywords.map(_.toLowerCase).toSet
+  lazy val keywordsLo: Set[String] = keywords.map(_.toLowerCase)
 
   // check in a case insensitive fashion
   def containsKey(word: String): Boolean = {
@@ -90,6 +90,6 @@ object Language extends Enumeration {
   }
 }
 
-case class WomBundle(primaryCallable: Option[TAT.Callable],
+case class WdlBundle(primaryCallable: Option[TAT.Callable],
                      allCallables: Map[String, TAT.Callable],
                      typeAliases: Map[String, WdlTypes.T])

--- a/src/main/scala/dxWDL/compiler/IR.scala
+++ b/src/main/scala/dxWDL/compiler/IR.scala
@@ -278,7 +278,7 @@ object IR {
   //
   case class CVar(
       name: String,
-      womType: WdlTypes.T,
+      wdlType: WdlTypes.T,
       default: Option[WdlValues.V],
       attrs: Option[Vector[IOAttr]] = None
   ) {

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -127,7 +127,7 @@ case class Native(dxWDLrtId: Option[String],
     val defaultVals: Map[String, JsValue] = cVar.default match {
       case None => Map.empty
       case Some(wdlValue) =>
-        val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wdlValue)
+        val wvl = wdlVarLinksConverter.importFromWDL(cVar.wdlType, wdlValue)
         wdlVarLinksConverter.genFields(wvl, name).toMap
     }
 
@@ -304,7 +304,7 @@ case class Native(dxWDLrtId: Option[String],
         case _ => mkComplex(optional)
       }
     }
-    cVar.womType match {
+    cVar.wdlType match {
       case WdlTypes.T_Optional(t) => handleType(t, optional = true)
       case t                      => handleType(t, optional = false)
     }
@@ -1049,7 +1049,7 @@ case class Native(dxWDLrtId: Option[String],
               "blockPath" -> JsArray(blockPath.map(JsNumber(_))),
               "fqnDictTypes" -> JsObject(fqnDictTypes.map {
                 case (k, t) =>
-                  val tStr = WomTypeSerialization(typeAliases).toString(t)
+                  val tStr = WdlTypeSerialization(typeAliases).toString(t)
                   k -> JsString(tStr)
               })
           )
@@ -1058,7 +1058,7 @@ case class Native(dxWDLrtId: Option[String],
             IR.AppletKindWorkflowOutputReorg =>
           // meta information used for running workflow fragments
           val fqnDictTypes = JsObject(applet.inputVars.map { cVar =>
-            val tStr = WomTypeSerialization(typeAliases).toString(cVar.womType)
+            val tStr = WdlTypeSerialization(typeAliases).toString(cVar.wdlType)
             cVar.name -> JsString(tStr)
           }.toMap)
           Map("fqnDictTypes" -> fqnDictTypes)
@@ -1071,7 +1071,7 @@ case class Native(dxWDLrtId: Option[String],
       .sortWith(_.name < _.name)
       .flatMap(cVar => cVarToSpec(cVar))
 
-    // put the wom source code into the details field.
+    // put the WDL source code into the details field.
     // Add the pricing model, and make the prices opaque.
     val generator = WdlV1Generator()
     val sourceLines = generator.generateDocument(applet.document)
@@ -1087,7 +1087,6 @@ case class Native(dxWDLrtId: Option[String],
     val (taskMeta, taskDetails) = buildTaskMetadata(applet, defaultTags)
 
     // Compute all the bits that get merged together into 'details'
-    // TODO: rename field, now that we're no longer using WOM
     val auxInfo = Map("womSourceCode" -> JsString(sourceCode),
                       "instanceTypeDB" -> JsString(dbOpaqueInstance),
                       "runtimeAttrs" -> runtimeAttrs)
@@ -1229,15 +1228,15 @@ case class Native(dxWDLrtId: Option[String],
             // in a value at runtime.
             m
           case IR.SArgConst(wValue) =>
-            val wvl = wdlVarLinksConverter.importFromWDL(cVar.womType, wValue)
+            val wvl = wdlVarLinksConverter.importFromWDL(cVar.wdlType, wValue)
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
           case IR.SArgLink(dxStage, argName) =>
-            val wvl = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
+            val wvl = WdlVarLinks(cVar.wdlType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
           case IR.SArgWorkflowInput(argName) =>
-            val wvl = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
+            val wvl = WdlVarLinks(cVar.wdlType, DxlWorkflowInput(argName.dxVarName))
             val fields = wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
             m ++ fields.toMap
         }
@@ -1290,10 +1289,10 @@ case class Native(dxWDLrtId: Option[String],
             s"Constant workflow outputs not currently handled (${cVar}, ${sArg}, ${wdlValue})"
         )
       case IR.SArgLink(dxStage, argName: CVar) =>
-        val wvl = WdlVarLinks(cVar.womType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
+        val wvl = WdlVarLinks(cVar.wdlType, DxlStage(dxStage, IORef.Output, argName.dxVarName))
         wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
       case IR.SArgWorkflowInput(argName: CVar) =>
-        val wvl = WdlVarLinks(cVar.womType, DxlWorkflowInput(argName.dxVarName))
+        val wvl = WdlVarLinks(cVar.wdlType, DxlWorkflowInput(argName.dxVarName))
         wdlVarLinksConverter.genFields(wvl, cVar.dxVarName)
       case other =>
         throw new Exception(s"Bad value for sArg ${other}")
@@ -1417,7 +1416,6 @@ case class Native(dxWDLrtId: Option[String],
     val generator = WdlV1Generator()
     val sourceLines = generator.generateElement(wf.document)
     val sourceCode = Utils.gzipAndBase64Encode(sourceLines.mkString("\n"))
-    // TODO: rename field, now that we're no longer using WOM
     val sourceCodeField: Map[String, JsValue] = Map("womSourceCode" -> JsString(sourceCode))
 
     // link to applets used by the fragments. This notifies the platform that they

--- a/src/main/scala/dxWDL/compiler/ParameterMeta.scala
+++ b/src/main/scala/dxWDL/compiler/ParameterMeta.scala
@@ -7,7 +7,7 @@ import dxWDL.dx._
 
 object ParameterMeta {
 
-  // Convert a WOM Vector[MetaValue] of Strings into a Vector of Strings
+  // Convert a Vector[MetaValue] of Strings into a Vector of Strings
   // Anything not a string will be filtered out.
   private def unwrapMetaStringArray(array: Vector[TAT.MetaValue]): Vector[String] = {
     array.flatMap {
@@ -23,14 +23,14 @@ object ParameterMeta {
   // Array[T]          T
   // Array[Array[T]]   T
   @scala.annotation.tailrec
-  private def unwrapWomArrayType(womType: WdlTypes.T): WdlTypes.T = {
-    womType match {
-      case WdlTypes.T_Array(t, _) => unwrapWomArrayType(t)
+  private def unwrapWdlArrayType(wdlType: WdlTypes.T): WdlTypes.T = {
+    wdlType match {
+      case WdlTypes.T_Array(t, _) => unwrapWdlArrayType(t)
       case x                      => x
     }
   }
 
-  // Convert a patterns WOM object value to IR
+  // Convert a patterns object value to IR
   private def metaPatternsObjToIR(obj: Map[String, TAT.MetaValue]): IR.IOAttrPatterns = {
     val name = obj.get("name") match {
       case Some(TAT.MetaValueArray(array, _)) =>
@@ -62,7 +62,7 @@ object ParameterMeta {
   // OR
   // choices: [{name: 'file1', value: "dx://file-XXX"}, {name: 'file2', value: "dx://file-YYY"}]
   private def metaChoicesArrayToIR(array: Vector[TAT.MetaValue],
-                                   womType: WdlTypes.T): Vector[IR.ChoiceRepr] = {
+                                   wdlType: WdlTypes.T): Vector[IR.ChoiceRepr] = {
     if (array.isEmpty) {
       Vector()
     } else {
@@ -72,13 +72,13 @@ object ParameterMeta {
             throw new Exception("Annotated choice must have a 'value' key")
           } else {
             metaChoiceValueToIR(
-                womType = womType,
+                wdlType = wdlType,
                 value = fields("value"),
                 name = fields.get("name")
             )
           }
         case rawElement: TAT.MetaValue =>
-          metaChoiceValueToIR(womType = womType, value = rawElement)
+          metaChoiceValueToIR(wdlType = wdlType, value = rawElement)
         case _ =>
           throw new Exception(
               "Choices array must contain only raw values or annotated values (hash with "
@@ -88,10 +88,10 @@ object ParameterMeta {
     }
   }
 
-  private def metaChoiceValueToIR(womType: WdlTypes.T,
+  private def metaChoiceValueToIR(wdlType: WdlTypes.T,
                                   value: TAT.MetaValue,
                                   name: Option[TAT.MetaValue] = None): IR.ChoiceRepr = {
-    (womType, value) match {
+    (wdlType, value) match {
       case (WdlTypes.T_String, TAT.MetaValueString(str, _)) =>
         IR.ChoiceReprString(value = str)
       case (WdlTypes.T_Int, TAT.MetaValueInt(i, _)) =>
@@ -126,21 +126,21 @@ object ParameterMeta {
   // suggestions: [
   //  {name: 'file1', value: "dx://file-XXX"}, {name: 'file2', value: "dx://file-YYY"}]
   private def metaSuggestionsArrayToIR(array: Vector[TAT.MetaValue],
-                                       womType: WdlTypes.T): Vector[IR.SuggestionRepr] = {
+                                       wdlType: WdlTypes.T): Vector[IR.SuggestionRepr] = {
     if (array.isEmpty) {
       Vector()
     } else {
       array.map {
         case TAT.MetaValueObject(fields, _) =>
           metaSuggestionValueToIR(
-              womType = womType,
+              wdlType = wdlType,
               name = fields.get("name"),
               value = fields.get("value"),
               project = fields.get("project"),
               path = fields.get("path")
           )
         case rawElement: TAT.MetaValue =>
-          metaSuggestionValueToIR(womType = womType, value = Some(rawElement))
+          metaSuggestionValueToIR(wdlType = wdlType, value = Some(rawElement))
         case _ =>
           throw new Exception(
               "Suggestions array must contain only raw values or annotated (hash) values"
@@ -149,12 +149,12 @@ object ParameterMeta {
     }
   }
 
-  private def metaSuggestionValueToIR(womType: WdlTypes.T,
+  private def metaSuggestionValueToIR(wdlType: WdlTypes.T,
                                       value: Option[TAT.MetaValue],
                                       name: Option[TAT.MetaValue] = None,
                                       project: Option[TAT.MetaValue] = None,
                                       path: Option[TAT.MetaValue] = None): IR.SuggestionRepr = {
-    (womType, value) match {
+    (wdlType, value) match {
       case (WdlTypes.T_String, Some(TAT.MetaValueString(str, _))) =>
         IR.SuggestionReprString(value = str)
       case (WdlTypes.T_Int, Some(TAT.MetaValueInt(i, _))) =>
@@ -222,8 +222,8 @@ object ParameterMeta {
     }
   }
 
-  private def metaDefaultToIR(value: TAT.MetaValue, womType: WdlTypes.T): IR.DefaultRepr = {
-    (womType, value) match {
+  private def metaDefaultToIR(value: TAT.MetaValue, wdlType: WdlTypes.T): IR.DefaultRepr = {
+    (wdlType, value) match {
       case (WdlTypes.T_String, TAT.MetaValueString(str, _)) =>
         IR.DefaultReprString(value = str)
       case (WdlTypes.T_Int, TAT.MetaValueInt(i, _)) =>
@@ -245,10 +245,10 @@ object ParameterMeta {
     }
   }
 
-  // Extract the parameter_meta info from the WOM structure
+  // Extract the parameter_meta info from the tAST structure
   // The parameter's WdlTypes.T is passed in since some parameter metadata values are required to
   // have the same type as the parameter.
-  def unwrap(paramMeta: Option[TAT.MetaValue], womType: WdlTypes.T): Option[Vector[IR.IOAttr]] = {
+  def unwrap(paramMeta: Option[TAT.MetaValue], wdlType: WdlTypes.T): Option[Vector[IR.IOAttr]] = {
     paramMeta match {
       case None => None
       // If the parameter metadata is a string, treat it as help
@@ -274,19 +274,19 @@ object ParameterMeta {
             Some(metaPatternsObjToIR(obj))
           // Try to parse the choices key, which will be an array of either values or objects
           case (IR.PARAM_META_CHOICES, TAT.MetaValueArray(array, _)) =>
-            val wt = unwrapWomArrayType(womType)
+            val wt = unwrapWdlArrayType(wdlType)
             Some(IR.IOAttrChoices(metaChoicesArrayToIR(array, wt)))
           case (IR.PARAM_META_SUGGESTIONS, TAT.MetaValueArray(array, _)) =>
-            val wt = unwrapWomArrayType(womType)
+            val wt = unwrapWdlArrayType(wdlType)
             Some(IR.IOAttrSuggestions(metaSuggestionsArrayToIR(array, wt)))
           case (IR.PARAM_META_TYPE, dx_type: TAT.MetaValue) =>
-            val wt = unwrapWomArrayType(womType)
+            val wt = unwrapWdlArrayType(wdlType)
             wt match {
               case WdlTypes.T_File => Some(IR.IOAttrType(metaConstraintToIR(dx_type)))
               case _               => throw new Exception("'dx_type' can only be specified for File parameters")
             }
           case (IR.PARAM_META_DEFAULT, default: TAT.MetaValue) =>
-            Some(IR.IOAttrDefault(metaDefaultToIR(default, womType)))
+            Some(IR.IOAttrDefault(metaDefaultToIR(default, wdlType)))
           case _ => None
         }.toVector)
       }

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -161,9 +161,9 @@ case class Top(cOpt: CompilerOptions) {
     (allResults.path2file, allFiles)
   }
 
-  private def womToIR(source: Path): IR.Bundle = {
+  private def wdlToIR(source: Path): IR.Bundle = {
     val (language, everythingBundle, allSources, adjunctFiles) =
-      ParseWomSourceFile(verbose.on).apply(source, cOpt.importDirs)
+      ParseWdlSourceFile(verbose.on).apply(source, cOpt.importDirs)
 
     // validate
     everythingBundle.allCallables.foreach { case (_, c) => validate(c) }
@@ -226,7 +226,7 @@ case class Top(cOpt: CompilerOptions) {
   // compile and generate intermediate code only
   def applyOnlyIR(source: Path, dxProject: DxProject): IR.Bundle = {
     // generate IR
-    val bundle: IR.Bundle = womToIR(source)
+    val bundle: IR.Bundle = wdlToIR(source)
 
     // lookup platform files in bulk
     val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)
@@ -242,7 +242,7 @@ case class Top(cOpt: CompilerOptions) {
             dxProject: DxProject,
             runtimePathConfig: DxPathConfig,
             execTree: Option[TreePrinter]): (String, Option[Either[String, JsValue]]) = {
-    val bundle: IR.Bundle = womToIR(source)
+    val bundle: IR.Bundle = wdlToIR(source)
 
     // lookup platform files in bulk
     val (path2dxFile, fileInfoDir) = bulkFileDescribe(bundle, dxProject)

--- a/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
+++ b/src/main/scala/dxWDL/compiler/WdlCodeGen.scala
@@ -184,10 +184,10 @@ case class WdlCodeGen(verbose: Verbose,
         .map { cVar =>
           cVar.default match {
             case None =>
-              TAT.RequiredInputDefinition(cVar.name, cVar.womType, dummyTextSource)
+              TAT.RequiredInputDefinition(cVar.name, cVar.wdlType, dummyTextSource)
             case Some(wValue) =>
               TAT.OverridableInputDefinitionWithDefault(cVar.name,
-                                                        cVar.womType,
+                                                        cVar.wdlType,
                                                         wdlValueToExpr(wValue),
                                                         dummyTextSource)
           }
@@ -197,8 +197,8 @@ case class WdlCodeGen(verbose: Verbose,
       callable.outputVars
         .sortWith(_.name < _.name)
         .map { cVar =>
-          val defaultVal = genDefaultValueOfType(cVar.womType)
-          TAT.OutputDefinition(cVar.name, cVar.womType, defaultVal, dummyTextSource)
+          val defaultVal = genDefaultValueOfType(cVar.wdlType)
+          TAT.OutputDefinition(cVar.name, cVar.wdlType, defaultVal, dummyTextSource)
         }
 
     language match {

--- a/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
+++ b/src/main/scala/dxWDL/dx/ExecLinkInfo.scala
@@ -17,14 +17,14 @@ object ExecLinkInfo {
   // Serialize applet input definitions, so they could be used
   // at runtime.
   def writeJson(ali: ExecLinkInfo, typeAliases: Map[String, WdlTypes.T]): JsValue = {
-    val womTypeConverter = WomTypeSerialization(typeAliases)
+    val wdlTypeConverter = WdlTypeSerialization(typeAliases)
 
     val appInputDefs: Map[String, JsString] = ali.inputs.map {
-      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
-    }.toMap
+      case (name, wdlType) => name -> JsString(wdlTypeConverter.toString(wdlType))
+    }
     val appOutputDefs: Map[String, JsString] = ali.outputs.map {
-      case (name, womType) => name -> JsString(womTypeConverter.toString(womType))
-    }.toMap
+      case (name, wdlType) => name -> JsString(wdlTypeConverter.toString(wdlType))
+    }
     JsObject(
         "name" -> JsString(ali.name),
         "inputs" -> JsObject(appInputDefs.to(TreeMap)),
@@ -34,7 +34,7 @@ object ExecLinkInfo {
   }
 
   def readJson(aplInfo: JsValue, typeAliases: Map[String, WdlTypes.T]): ExecLinkInfo = {
-    val womTypeConverter = WomTypeSerialization(typeAliases)
+    val wdlTypeConverter = WdlTypeSerialization(typeAliases)
 
     val name = aplInfo.asJsObject.fields("name") match {
       case JsString(x) => x
@@ -45,7 +45,7 @@ object ExecLinkInfo {
       .asJsObject
       .fields
       .map {
-        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
+        case (key, JsString(wdlTypeStr)) => key -> wdlTypeConverter.fromString(wdlTypeStr)
         case _                           => throw new Exception("Bad JSON")
       }
       .toMap
@@ -54,7 +54,7 @@ object ExecLinkInfo {
       .asJsObject
       .fields
       .map {
-        case (key, JsString(womTypeStr)) => key -> womTypeConverter.fromString(womTypeStr)
+        case (key, JsString(wdlTypeStr)) => key -> wdlTypeConverter.fromString(wdlTypeStr)
         case _                           => throw new Exception("Bad JSON")
       }
       .toMap

--- a/src/main/scala/dxWDL/exec/TaskRunner.scala
+++ b/src/main/scala/dxWDL/exec/TaskRunner.scala
@@ -98,8 +98,8 @@ case class TaskRunner(task: TAT.Task,
                      dxUrl2path: Map[Furl, Path]): Unit = {
     val locInputsM: Map[String, JsValue] = localizedInputs.map {
       case (name, (t, v)) =>
-        val wdlTypeRepr = WomTypeSerialization(typeAliases).toString(t)
-        val value = WomValueSerialization(typeAliases).toJSON(t, v)
+        val wdlTypeRepr = WdlTypeSerialization(typeAliases).toString(t)
+        val value = WdlValueSerialization(typeAliases).toJSON(t, v)
         (name, JsArray(JsString(wdlTypeRepr), value))
     }
     val dxUrlM: Map[String, JsValue] = dxUrl2path.map {
@@ -129,8 +129,8 @@ case class TaskRunner(task: TAT.Task,
     }
     val localizedInputs = locInputsM.map {
       case (key, JsArray(Vector(JsString(wdlTypeRepr), jsVal))) =>
-        val t = WomTypeSerialization(typeAliases).fromString(wdlTypeRepr)
-        val value = WomValueSerialization(typeAliases).fromJSON(jsVal)
+        val t = WdlTypeSerialization(typeAliases).fromString(wdlTypeRepr)
+        val value = WdlValueSerialization(typeAliases).fromJSON(jsVal)
         key -> (t, value)
       case (_, other) =>
         throw new Exception(s"sanity: bad deserialization value ${other}")
@@ -505,8 +505,8 @@ case class TaskRunner(task: TAT.Task,
     // convert the WDL values to JSON
     val outputFields: Map[String, JsValue] = outputs
       .map {
-        case (outputVarName, (wdlType, womValue)) =>
-          val wvl = wdlVarLinksConverter.importFromWDL(wdlType, womValue)
+        case (outputVarName, (wdlType, wdlValue)) =>
+          val wvl = wdlVarLinksConverter.importFromWDL(wdlType, wdlValue)
           wdlVarLinksConverter.genFields(wvl, outputVarName)
       }
       .toList

--- a/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
+++ b/src/main/scala/dxWDL/exec/WfFragInputOutput.scala
@@ -18,8 +18,8 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
                              typeAliases: Map[String, WdlTypes.T],
                              wdlVersion: WdlVersion,
                              runtimeDebugLevel: Int) {
-  val verbose = runtimeDebugLevel >= 1
-  val jobInputOutput = JobInputOutput(dxIoFunctions, typeAliases, wdlVersion, runtimeDebugLevel)
+  val jobInputOutput: JobInputOutput =
+    JobInputOutput(dxIoFunctions, typeAliases, wdlVersion, runtimeDebugLevel)
 
   private def loadWorkflowMetaInfo(
       metaInfo: Map[String, JsValue]
@@ -31,7 +31,7 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
         fields.map {
           case (key, ali) =>
             key -> ExecLinkInfo.readJson(ali, typeAliases)
-        }.toMap
+        }
       case other => throw new Exception(s"Bad value ${other}")
     }
     val blockPath: Vector[Int] = metaInfo.get("blockPath") match {
@@ -40,7 +40,7 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
         arr.map {
           case JsNumber(n) => n.toInt
           case _           => throw new Exception("Bad value ${arr}")
-        }.toVector
+        }
       case other => throw new Exception(s"Bad value ${other}")
     }
     val fqnDictTypes: Map[String, WdlTypes.T] = metaInfo.get("fqnDictTypes") match {
@@ -49,19 +49,19 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
           case (key, JsString(value)) =>
             // Transform back to a fully qualified name with dots
             val orgKeyName = Utils.revTransformVarName(key)
-            val womType = WomTypeSerialization(typeAliases).fromString(value)
-            orgKeyName -> womType
+            val wdlType = WdlTypeSerialization(typeAliases).fromString(value)
+            orgKeyName -> wdlType
           case other => throw new Exception(s"Bad value ${other}")
-        }.toMap
+        }
       case other => throw new Exception(s"Bad value ${other}")
     }
 
     (execLinkInfo, blockPath, fqnDictTypes)
   }
 
-  // 1. Convert the inputs to WOM values
+  // 1. Convert the inputs to WdlValues
   // 2. Setup an environment to evaluate the sub-block. This should
-  //    look to the WOM code as if all previous code had been evaluated.
+  //    look to the WDL code as if all previous code had been evaluated.
   def loadInputs(inputs: JsValue, metaInfo: JsValue): WfFragInput = {
     val regularFields: Map[String, JsValue] = inputs.asJsObject.fields
       .filter { case (fieldName, _) => !fieldName.endsWith(Utils.FLAT_FILES_SUFFIX) }
@@ -70,19 +70,18 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
     // for the subblock
     val (execLinkInfo, blockPath, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
 
-    // What remains are inputs from other stages. Convert from JSON
-    // to wom values
+    // What remains are inputs from other stages. Convert from JSON to WdlValues
     val env: Map[String, (WdlTypes.T, WdlValues.V)] = regularFields.map {
       case (name, jsValue) =>
         val fqn = Utils.revTransformVarName(name)
-        val womType = fqnDictTypes.get(fqn) match {
+        val wdlType = fqnDictTypes.get(fqn) match {
           case None =>
             throw new Exception(s"Did not find variable ${fqn} (${name}) in the block environment")
           case Some(x) => x
         }
-        val value = jobInputOutput.unpackJobInput(fqn, womType, jsValue)
-        fqn -> (womType, value)
-    }.toMap
+        val value = jobInputOutput.unpackJobInput(fqn, wdlType, jsValue)
+        fqn -> (wdlType, value)
+    }
 
     WfFragInput(blockPath, env, execLinkInfo)
   }
@@ -94,19 +93,19 @@ case class WfFragInputOutput(dxIoFunctions: DxIoFunctions,
 
     val (_, _, fqnDictTypes) = loadWorkflowMetaInfo(metaInfo.asJsObject.fields)
 
-    // Convert from JSON to wom values
+    // Convert from JSON to DxFiles
     regularFields
       .map {
         case (name, jsValue) =>
           val fqn = Utils.revTransformVarName(name)
-          val womType = fqnDictTypes.get(fqn) match {
+          val wdlType = fqnDictTypes.get(fqn) match {
             case None =>
               throw new Exception(
                   s"Did not find variable ${fqn} (${name}) in the block environment"
               )
             case Some(x) => x
           }
-          jobInputOutput.unpackJobInputFindRefFiles(womType, jsValue)
+          jobInputOutput.unpackJobInputFindRefFiles(wdlType, jsValue)
       }
       .toVector
       .flatten

--- a/src/main/scala/dxWDL/exec/WfInputs.scala
+++ b/src/main/scala/dxWDL/exec/WfInputs.scala
@@ -28,15 +28,15 @@ case class WfInputs(wf: TAT.Workflow,
     Utils.appletLog(
         verbose,
         s"""|Artificial applet for unlocked workflow inputs
-            |${WomPrettyPrintApproxWdl.graphInputs(wf.inputs)}
+            |${TypedAstPrettyPrintApproxWdl.graphInputs(wf.inputs)}
             |""".stripMargin
     )
 
     // convert the WDL values to JSON
     val outputFields: Map[String, JsValue] = inputs
       .map {
-        case (outputVarName, (womType, womValue)) =>
-          val wvl = wdlVarLinksConverter.importFromWDL(womType, womValue)
+        case (outputVarName, (wdlType, wdlValue)) =>
+          val wvl = wdlVarLinksConverter.importFromWDL(wdlType, wdlValue)
           wdlVarLinksConverter.genFields(wvl, outputVarName)
       }
       .toList

--- a/src/main/scala/dxWDL/exec/WfOutputs.scala
+++ b/src/main/scala/dxWDL/exec/WfOutputs.scala
@@ -23,10 +23,10 @@ case class WfOutputs(wf: TAT.Workflow,
 
   private val evaluator = WdlEvaluator.make(dxIoFunctions, document.version.value)
 
-  private def evaluateWomExpression(expr: TAT.Expr,
-                                    womType: WdlTypes.T,
+  private def evaluateWdlExpression(expr: TAT.Expr,
+                                    wdlType: WdlTypes.T,
                                     env: Map[String, WdlValues.V]): WdlValues.V = {
-    evaluator.applyExprAndCoerce(expr, womType, EvalContext(env))
+    evaluator.applyExprAndCoerce(expr, wdlType, EvalContext(env))
   }
 
   def apply(envInitial: Map[String, (WdlTypes.T, WdlValues.V)],
@@ -36,7 +36,7 @@ case class WfOutputs(wf: TAT.Workflow,
     Utils.appletLog(
         verbose,
         s"""|Evaluating workflow outputs
-            |${WomPrettyPrintApproxWdl.graphOutputs(wf.outputs)}
+            |${TypedAstPrettyPrintApproxWdl.graphOutputs(wf.outputs)}
             |""".stripMargin
     )
 
@@ -64,7 +64,7 @@ case class WfOutputs(wf: TAT.Workflow,
     var envFull = envInitialFilled
     val outputs: Map[String, (WdlTypes.T, WdlValues.V)] = wfOutputs.map {
       case Block.OutputDefinition(name, wdlType, expr) =>
-        val value = evaluateWomExpression(expr, wdlType, envFull)
+        val value = evaluateWdlExpression(expr, wdlType, envFull)
         envFull += (name -> value)
         name -> (wdlType, value)
     }.toMap

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -545,7 +545,7 @@ object Block {
   def isSimpleOutput(outputNode: OutputDefinition, definedVars: Set[String]): Boolean = {
     outputNode.expr match {
       // A constant or a reference to a variable
-      case expr if WomValueAnalysis.isTrivialExpression(expr)      => true
+      case expr if WdlValueAnalysis.isTrivialExpression(expr)      => true
       case TAT.ExprIdentifier(id, _, _) if definedVars contains id => true
 
       //for example, c1 is call, and the output section is:
@@ -601,7 +601,7 @@ object Block {
     val node = nodes.head
     node match {
       case call: TAT.Call if trivialExpressionsOnly =>
-        call.inputs.values.forall(expr => WomValueAnalysis.isTrivialExpression(expr))
+        call.inputs.values.forall(expr => WdlValueAnalysis.isTrivialExpression(expr))
       case _: TAT.Call =>
         // any input expression is allowed
         true

--- a/src/main/scala/dxWDL/util/DxPathConfig.scala
+++ b/src/main/scala/dxWDL/util/DxPathConfig.scala
@@ -26,9 +26,6 @@ case class DxPathConfig(homeDir: Path,
                         tmpDir: Path,
                         // Where a JSON representation of the instance data base is stored
                         instanceTypeDB: Path,
-                        // Source WOM code. We could get it from the details field, but that
-                        // would require an additional API call. This is a private copy.
-                        womSourceCodeEncoded: Path,
                         stdout: Path,
                         stderr: Path,
                         // bash script for running the docker image the user specified
@@ -75,7 +72,6 @@ object DxPathConfig {
     val tmpDir: Path = homeDir.resolve("job_scratch_space")
 
     val instanceTypeDB = homeDir.resolve("instance_type_db.json")
-    val womSourceCodeEncoded = homeDir.resolve("source.wdl.uu64")
 
     val stdout = metaDir.resolve("stdout")
     val stderr = metaDir.resolve("stderr")
@@ -96,7 +92,6 @@ object DxPathConfig {
         outputFilesDir,
         tmpDir,
         instanceTypeDB,
-        womSourceCodeEncoded,
         stdout,
         stderr,
         dockerSubmitScript,

--- a/src/main/scala/dxWDL/util/Furl.scala
+++ b/src/main/scala/dxWDL/util/Furl.scala
@@ -1,6 +1,6 @@
 // FURL:  File Uniform Resource Locator
 //
-// In wom, a file is represented by a string. This encodes
+// In WDL, a file is represented by a string. This encodes
 // several different access protocols, filesystems, and clouds.
 //
 //  file name                              location

--- a/src/main/scala/dxWDL/util/TypedAstPrettyPrintApproxWdl.scala
+++ b/src/main/scala/dxWDL/util/TypedAstPrettyPrintApproxWdl.scala
@@ -1,11 +1,13 @@
-/** Pretty printing WOM as, approximately, the original WDL.
+/** Pretty printing typed AST as, approximately, the original WDL.
   */
 package dxWDL.util
 
 import wdlTools.types.{TypedAbstractSyntax => TAT, Util => TUtil}
 
-object WomPrettyPrintApproxWdl {
+object TypedAstPrettyPrintApproxWdl {
 
+  // TODO: this function should no longer be necessary - the wdlTools code formatter
+  //  can be used instead. This function is currently only used in logging statements.
   def applyWorkflowElement(node: TAT.WorkflowElement, indent: String): String = {
     node match {
       case TAT.Scatter(varName, expr, body, _) =>
@@ -58,14 +60,14 @@ object WomPrettyPrintApproxWdl {
 
   private def applyInput(iDef: TAT.InputDefinition): String = {
     iDef match {
-      case TAT.RequiredInputDefinition(iName, womType, _) =>
-        s"${TUtil.typeToString(womType)} ${iName}"
+      case TAT.RequiredInputDefinition(iName, wdlType, _) =>
+        s"${TUtil.typeToString(wdlType)} ${iName}"
 
-      case TAT.OverridableInputDefinitionWithDefault(iName, womType, defaultExpr, _) =>
-        s"${TUtil.typeToString(womType)} ${iName} = ${TUtil.exprToString(defaultExpr)}"
+      case TAT.OverridableInputDefinitionWithDefault(iName, wdlType, defaultExpr, _) =>
+        s"${TUtil.typeToString(wdlType)} ${iName} = ${TUtil.exprToString(defaultExpr)}"
 
-      case TAT.OptionalInputDefinition(iName, womType, _) =>
-        s"${TUtil.typeToString(womType)} ${iName}"
+      case TAT.OptionalInputDefinition(iName, wdlType, _) =>
+        s"${TUtil.typeToString(wdlType)} ${iName}"
     }
   }
 

--- a/src/main/scala/dxWDL/util/WdlValueAnalysis.scala
+++ b/src/main/scala/dxWDL/util/WdlValueAnalysis.scala
@@ -6,7 +6,7 @@ import wdlTools.eval.Coercion
 
 import dxWDL.base.Utils
 
-object WomValueAnalysis {
+object WdlValueAnalysis {
 
   private class ExprNotConst(message: String) extends RuntimeException(message)
 

--- a/src/test/scala/dxWDL/base/ParseWdlSourceFileTest.scala
+++ b/src/test/scala/dxWDL/base/ParseWdlSourceFileTest.scala
@@ -6,8 +6,8 @@ import wdlTools.types.{TypedAbstractSyntax => TAT}
 
 // These tests involve compilation -without- access to the platform.
 //
-class ParseWomSourceFileTest extends AnyFlatSpec with Matchers {
-  private val parseWomSourceFile = ParseWomSourceFile(false)
+class ParseWdlSourceFileTest extends AnyFlatSpec with Matchers {
+  private val parseWdlSourceFile = ParseWdlSourceFile(false)
 
   private def validateTaskMeta(task: TAT.Task): Unit = {
     val kvs = task.meta match {
@@ -39,7 +39,7 @@ class ParseWomSourceFileTest extends AnyFlatSpec with Matchers {
          |
          |""".stripMargin
 
-    val (task: TAT.Task, _, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: TAT.Task, _, _) = parseWdlSourceFile.parseWdlTask(srcCode)
     validateTaskMeta(task)
   }
 
@@ -64,7 +64,7 @@ class ParseWomSourceFileTest extends AnyFlatSpec with Matchers {
          |
          |""".stripMargin
 
-    val (task: TAT.Task, _, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: TAT.Task, _, _) = parseWdlSourceFile.parseWdlTask(srcCode)
     validateTaskMeta(task)
   }
 
@@ -89,7 +89,7 @@ class ParseWomSourceFileTest extends AnyFlatSpec with Matchers {
          |
          |""".stripMargin
 
-    val (task: TAT.Task, _, _) = parseWomSourceFile.parseWdlTask(srcCode)
+    val (task: TAT.Task, _, _) = parseWdlSourceFile.parseWdlTask(srcCode)
     validateTaskMeta(task)
   }
 }

--- a/src/test/scala/dxWDL/base/WdlTypeSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WdlTypeSerializationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.types.WdlTypes
 
-class WomTypeSerializationTest extends AnyFlatSpec with Matchers {
+class WdlTypeSerializationTest extends AnyFlatSpec with Matchers {
 
   val testCases: List[WdlTypes.T] = List(
       // Primitive types
@@ -26,7 +26,7 @@ class WomTypeSerializationTest extends AnyFlatSpec with Matchers {
   )
 
   it should "work for various WDL types" in {
-    val typeSerialize = WomTypeSerialization(Map.empty)
+    val typeSerialize = WdlTypeSerialization(Map.empty)
 
     for (t <- testCases) {
       typeSerialize.fromString(typeSerialize.toString(t)) should be(t)
@@ -48,7 +48,7 @@ class WomTypeSerializationTest extends AnyFlatSpec with Matchers {
 
   it should "work for structs" in {
     val typeAliases: Map[String, WdlTypes.T] = Map("Person" -> personType, "House" -> houseType)
-    val typeSerialize = WomTypeSerialization(typeAliases)
+    val typeSerialize = WdlTypeSerialization(typeAliases)
 
     for (t <- structTestCases) {
       typeSerialize.fromString(typeSerialize.toString(t)) should be(t)
@@ -64,7 +64,7 @@ class WomTypeSerializationTest extends AnyFlatSpec with Matchers {
 
   it should "detect bad type descriptions" in {
     val typeAliases: Map[String, WdlTypes.T] = Map("Person" -> personType, "House" -> houseType)
-    val typeSerialize = WomTypeSerialization(typeAliases)
+    val typeSerialize = WdlTypeSerialization(typeAliases)
 
     for (typeDesc <- badTypeNames) {
       assertThrows[Exception] {

--- a/src/test/scala/dxWDL/base/WdlValueSerializationTest.scala
+++ b/src/test/scala/dxWDL/base/WdlValueSerializationTest.scala
@@ -6,13 +6,13 @@ import spray.json._
 import wdlTools.eval.WdlValues._
 import wdlTools.types.WdlTypes._
 
-class WomValueSerializationTest extends AnyFlatSpec with Matchers {
+class WdlValueSerializationTest extends AnyFlatSpec with Matchers {
   val personType =
     T_Struct("Person", Map("name" -> T_String, "age" -> T_Int))
   val houseType =
     T_Struct("House", Map("street" -> T_String, "zip code" -> T_Int, "owner" -> personType))
   val typeAliases: Map[String, T] = Map("Person" -> personType, "House" -> houseType)
-  val valueSerializer = WomValueSerialization(typeAliases)
+  val valueSerializer = WdlValueSerialization(typeAliases)
 
   val valueTestCases: List[(T, V)] = List(
       // primitive types

--- a/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dxWDL/compiler/GenerateIRTest.scala
@@ -410,7 +410,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
   }
 
   // Check parameter_meta pattern: ["array"]
-  it should "recognize pattern in parameters_meta via WOM" in {
+  it should "recognize pattern in parameters_meta via WDL" in {
     val path = pathFromBasename("compiler", "pattern_params.wdl")
     val retval = Main.compile(
         path.toString :: cFlags
@@ -493,7 +493,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
   }
 
   // Check parameter_meta pattern: {"object"}
-  it should "recognize pattern object in parameters_meta via WOM" in {
+  it should "recognize pattern object in parameters_meta via WDL" in {
     val path = pathFromBasename("compiler", "pattern_obj_params.wdl")
     val retval = Main.compile(
         path.toString :: cFlags
@@ -935,7 +935,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
     // TODO: make assertion about exception message
   }
 
-  it should "recognize help, group, and label in parameters_meta via WOM" in {
+  it should "recognize help, group, and label in parameters_meta via WDL" in {
     val path = pathFromBasename("compiler", "help_input_params.wdl")
     val retval = Main.compile(
         path.toString :: cFlags
@@ -1061,8 +1061,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
   }
 
   // This is actually more of a test to confirm that symbols that are not input
-  // variables are ignored. WOM doesn't include a paramMeta member for the output
-  // var class anyways, so it's basically impossible for this to happen
+  // variables are ignored.
   it should "ignore help in parameters_meta via CVar for output CVars" in {
     val path = pathFromBasename("compiler", "help_output_params.wdl")
     val retval = Main.compile(
@@ -1451,8 +1450,6 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
 
     val samtools = wf.inputs.find { case (cVar, _) => cVar.name == "samtools_memory" }
     inside(samtools) {
-      /*case Some((cVar, _)) =>
-       cVar.womType shouldBe (WdlTypes.T_Optional(WdlTypes.T_String))*/
       case None => ()
     }
   }

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.BeforeAndAfterAll
 import scala.io.Source
 import dxWDL.Main
 import dxWDL.Main.SuccessfulTermination
-import dxWDL.base.{ParseWomSourceFile, Utils, Verbose}
+import dxWDL.base.{ParseWdlSourceFile, Utils, Verbose}
 import dxWDL.dx._
 import spray.json._
 
@@ -168,7 +168,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         src.close()
       }
 
-    val (tasks, _, _) = ParseWomSourceFile(false).parseWdlTasks(content)
+    val (tasks, _, _) = ParseWdlSourceFile(false).parseWdlTasks(content)
 
     tasks.keySet shouldBe Set(
         "native_sum",
@@ -204,7 +204,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         src.close()
       }
 
-    val (tasks, _, _) = ParseWomSourceFile(false).parseWdlTasks(content)
+    val (tasks, _, _) = ParseWdlSourceFile(false).parseWdlTasks(content)
 
     tasks.keySet shouldBe Set("native_sum")
   }
@@ -239,7 +239,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         src.close()
       }
 
-    val (tasks, _, _) = ParseWomSourceFile(false).parseWdlTasks(content)
+    val (tasks, _, _) = ParseWdlSourceFile(false).parseWdlTasks(content)
 
     tasks.keySet shouldBe Set("native_sum")
   }
@@ -268,8 +268,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     in_file.help shouldBe Some("The input file to be searched")
     in_file.group shouldBe Some("Common")
     in_file.label shouldBe Some("Input file")
-    // out_file would be part of the outputSpec, but wom currently doesn't
-    // support parameter_meta for output vars
+    //TODO: add support for output files in parameterMeta
     //out_file.pattern shouldBe Some(Vector("*.txt", "*.tsv"))
   }
 
@@ -301,8 +300,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     in_file.help shouldBe Some("The input file to be searched")
     in_file.group shouldBe Some("Common")
     in_file.label shouldBe Some("Input file")
-    // out_file would be part of the outputSpec, but wom currently doesn't
-    // support parameter_meta for output vars
+    //TODO: add support for output files in parameterMeta
     //out_file.pattern shouldBe Some(Vector("*.txt", "*.tsv"))
   }
 

--- a/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dxWDL/compiler/SortTypeAliasesTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.types.WdlTypes
 
 import dxWDL.base.{Utils, Verbose}
-import dxWDL.base.ParseWomSourceFile
+import dxWDL.base.ParseWdlSourceFile
 
 class SortTypeAliasesTest extends AnyFlatSpec with Matchers {
   private def pathFromBasename(dir: String, basename: String): Path = {
@@ -20,7 +20,7 @@ class SortTypeAliasesTest extends AnyFlatSpec with Matchers {
     val path = pathFromBasename("struct", "many_structs.wdl")
     val wfSourceCode = Utils.readFileContent(path)
     val (_, _, typeAliases: Map[String, WdlTypes.T], _) =
-      ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+      ParseWdlSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
     val defs: Vector[(String, WdlTypes.T)] = SortTypeAliases(verbose).apply(typeAliases.toVector)
     val defNames = defs.map { case (name, _) => name }.toVector

--- a/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/WfFragRunnerTest.scala
@@ -8,7 +8,7 @@ import spray.json._
 import wdlTools.eval.{Context => EvalContext, WdlValues}
 import wdlTools.types.{TypedAbstractSyntax => TAT, WdlTypes}
 
-import dxWDL.base.{Language, ParseWomSourceFile, RunnerWfFragmentMode, Utils, WdlRuntimeAttrs}
+import dxWDL.base.{Language, ParseWdlSourceFile, RunnerWfFragmentMode, Utils, WdlRuntimeAttrs}
 import dxWDL.dx.ExecLinkInfo
 import dxWDL.util.{Block, DxIoFunctions, DxInstanceType, DxPathConfig, InstanceTypeDB, WdlEvaluator}
 
@@ -38,7 +38,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
                               dxIoFunctions: DxIoFunctions,
                               wfSourceCode: String): (TAT.Workflow, WfFragRunner) = {
     val (wf, taskDir, typeAliases, document) =
-      ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+      ParseWdlSourceFile(false).parseWdlWorkflow(wfSourceCode)
     val fragInputOutput =
       WfFragInputOutput(dxIoFunctions, null, typeAliases, document.version.value, runtimeDebugLevel)
     val fragRunner = WfFragRunner(
@@ -65,7 +65,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
     Paths.get(p)
   }
 
-  def evaluateWomExpression(expr: TAT.Expr,
+  def evaluateWdlExpression(expr: TAT.Expr,
                             env: Map[String, WdlValues.V],
                             dxIoFunctions: DxIoFunctions,
                             language: Language.Value): WdlValues.V = {
@@ -78,10 +78,10 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
     val source: Path = pathFromBasename("frag_runner", "wf_linear.wdl")
     val (_, dxIoFunctions) = setup()
 
-    val (language, womBundle, _, _) =
-      ParseWomSourceFile(false).apply(source, List.empty)
+    val (language, wdlBundle, _, _) =
+      ParseWdlSourceFile(false).apply(source, List.empty)
 
-    val wf: TAT.Workflow = womBundle.primaryCallable match {
+    val wf: TAT.Workflow = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -99,7 +99,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
       case eNode: TAT.Declaration => eNode
     }
     val expr: TAT.Expr = decls.head.expr.get
-    val value: WdlValues.V = evaluateWomExpression(expr, env, dxIoFunctions, language)
+    val value: WdlValues.V = evaluateWdlExpression(expr, env, dxIoFunctions, language)
     value should be(WdlValues.V_Int(9))
   }
 
@@ -186,7 +186,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
   it should "create proper names for scatter results" in {
     val path = pathFromBasename("frag_runner", "strings.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = ParseWdlSourceFile(false).parseWdlWorkflow(wfSourceCode)
 
     val scatters = wf.body.collect {
       case x: TAT.Scatter => x
@@ -221,7 +221,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
     val subBlocks = Block.splitWorkflow(wf)
     /*
         val results = fragRunner.evalExpressions(subBlocks(0).nodes,
-                                                 Map.empty[String, WomValue])
+                                                 Map.empty[String, WdlValue])
  Utils.ignore(results)*/
     Utils.ignore(subBlocks)
   }

--- a/src/test/scala/dxWDL/util/BlockTest.scala
+++ b/src/test/scala/dxWDL/util/BlockTest.scala
@@ -6,11 +6,11 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.types.WdlTypes
 import wdlTools.types.{TypedAbstractSyntax => TAT}
 
-import dxWDL.base.{ParseWomSourceFile, Utils, WomBundle}
+import dxWDL.base.{ParseWdlSourceFile, Utils, WdlBundle}
 import dxWDL.util.Block
 
 class BlockTest extends AnyFlatSpec with Matchers {
-  private val parseWomSourceFile = ParseWomSourceFile(false)
+  private val parseWdlSourceFile = ParseWdlSourceFile(false)
 
   private def pathFromBasename(dir: String, basename: String): Path = {
     val p = getClass.getResource(s"/${dir}/${basename}").getPath
@@ -26,7 +26,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate closure correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     /*System.out.println(s"""|block #0 =
@@ -42,7 +42,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate outputs correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     mapFromOutputs(blocks(1).outputs) should be(
@@ -63,7 +63,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate outputs correctly II" in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     mapFromOutputs(blocks(1).outputs) should be(
@@ -75,7 +75,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "handle block zero" in {
     val path = pathFromBasename("util", "block_zero.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     mapFromOutputs(blocks(0).outputs) should be(
@@ -86,7 +86,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "block with two calls or more" in {
     val path = pathFromBasename("util", "block_with_three_calls.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size should be(1)
   }
@@ -94,7 +94,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "split a block with an expression after a call" in {
     val path = pathFromBasename("util", "expression_after_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size should be(2)
   }
@@ -102,7 +102,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate closure correctly for WDL draft-2" in {
     val path = pathFromBasename("draft2", "block_closure.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     blocks(1).inputs.map(_.name).toSet should be(Set("flag", "rain"))
@@ -114,7 +114,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate closure correctly for WDL draft-2 II" in {
     val path = pathFromBasename("draft2", "shapes.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     blocks(0).inputs.map(_.name).toSet should be(Set("num"))
@@ -124,7 +124,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate closure for a workflow with expression outputs" in {
     val path = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfOutputs = wf.outputs.map(Block.translate)
     Block.outputClosure(wfOutputs).keys.toSet should be(Set("a", "b"))
   }
@@ -132,7 +132,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "calculate output closure for a workflow" in {
     val path = pathFromBasename("compiler", "cast.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfOutputs = wf.outputs.map(Block.translate)
     Block.outputClosure(wfOutputs).keys.toSet should be(
         Set("Add.result", "SumArray.result", "SumArray2.result", "JoinMisc.result")
@@ -142,7 +142,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "identify simple calls even if they have optionals" in {
     val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
     for (i <- 0 to 2) {
@@ -152,8 +152,8 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "categorize correctly calls to subworkflows" in {
     val path = pathFromBasename("subworkflows", "trains.wdl")
-    val (_, womBundle, _, _) = parseWomSourceFile.apply(path, List.empty)
-    val wf = womBundle.primaryCallable match {
+    val (_, wdlBundle, _, _) = parseWdlSourceFile.apply(path, List.empty)
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("Could not find the workflow in the source")
     }
@@ -166,7 +166,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   ignore should "get subblocks" in {
     val path = pathFromBasename("nested", "two_levels.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val b0 = Block.getSubBlock(Vector(0), wf.body)
     Block.categorize(b0) shouldBe a[Block.ScatterFullBlock]
@@ -189,10 +189,10 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "handle calls to imported modules II" in {
     val path = pathFromBasename("draft2", "block_category.wdl")
-    val (_, womBundle: WomBundle, _, _) =
-      parseWomSourceFile.apply(path, List.empty)
+    val (_, wdlBundle: WdlBundle, _, _) =
+      parseWdlSourceFile.apply(path, List.empty)
 
-    val wf = womBundle.primaryCallable match {
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -202,10 +202,10 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "handle calls to imported modules" in {
     val path = pathFromBasename("draft2", "conditionals1.wdl")
-    val (_, womBundle: WomBundle, _, _) =
-      parseWomSourceFile.apply(path, List.empty)
+    val (_, wdlBundle: WdlBundle, _, _) =
+      parseWdlSourceFile.apply(path, List.empty)
 
-    val wf = womBundle.primaryCallable match {
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -224,10 +224,10 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "compile a workflow calling a subworkflow as a direct call" in {
     val path = pathFromBasename("draft2", "movies.wdl")
-    val (_, womBundle: WomBundle, _, _) =
-      parseWomSourceFile.apply(path, List.empty)
+    val (_, wdlBundle: WdlBundle, _, _) =
+      parseWdlSourceFile.apply(path, List.empty)
 
-    val wf = womBundle.primaryCallable match {
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -235,22 +235,13 @@ class BlockTest extends AnyFlatSpec with Matchers {
     // Find the fragment block to execute
     val block = Block.getSubBlock(Vector(0), wf.body)
 
-    /*
-        val dbgBlock = block.nodes.map{
-            WomPrettyPrintApproxWdl.apply(_)
-        }.mkString("\n")
-        System.out.println(s"""|Block:
-                               |${dbgBlock}
-                               |""".stripMargin)
-     */
-
     Block.categorize(block) shouldBe a[Block.CallDirect]
   }
 
   it should "sort a block correctly in the presence of conditionals" taggedAs (EdgeTest) in {
     val path = pathFromBasename("draft2", "conditionals3.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val blocks = Block.splitWorkflow(wf)
 
@@ -266,9 +257,9 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "find the correct number of scatters" in {
     val path = pathFromBasename("draft2", "conditionals_base.wdl")
-    val (_, womBundle, _, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, wdlBundle, _, _) = parseWdlSourceFile.apply(path, List.empty)
 
-    val wf = womBundle.primaryCallable match {
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -281,9 +272,9 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "sort a subblock properly" in {
     val path = pathFromBasename("draft2", "conditionals4.wdl")
-    val (_, womBundle, _, _) = parseWomSourceFile.apply(path, List.empty)
+    val (_, wdlBundle, _, _) = parseWdlSourceFile.apply(path, List.empty)
 
-    val wf = womBundle.primaryCallable match {
+    val wf = wdlBundle.primaryCallable match {
       case Some(wf: TAT.Workflow) => wf
       case _                      => throw new Exception("sanity")
     }
@@ -300,7 +291,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "handle an empty workflow" in {
     val path = pathFromBasename("util", "empty_workflow.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size shouldBe (0)
   }
@@ -308,7 +299,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "detect when inputs are used as outputs" in {
     val path = pathFromBasename("util", "inputs_used_as_outputs.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfInputs = wf.inputs.map(Block.translate)
     val wfOutputs = wf.outputs.map(Block.translate)
     Block.inputsUsedAsOutputs(wfInputs, wfOutputs) shouldBe (Set("lane"))
@@ -317,7 +308,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "create correct inputs for a workflow with an unpassed argument" in {
     val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val names = wf.inputs.map(_.name).toSet
     names shouldBe (Set.empty[String])
   }
@@ -325,15 +316,12 @@ class BlockTest extends AnyFlatSpec with Matchers {
   it should "figure out when a block has no calls" taggedAs (EdgeTest) in {
     val path = pathFromBasename("block", "b1.wdl")
     val wfSourceCode = Utils.readFileContent(path)
-    val (wf, _, _, _) = parseWomSourceFile.parseWdlWorkflow(wfSourceCode)
+    val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val b0 = Block.getSubBlock(Vector(0), wf.body)
     Block.categorize(b0) shouldBe a[Block.ScatterFullBlock]
 
     val b00 = Block.getSubBlock(Vector(0, 0), wf.body)
-
-//    val bl33 = WomPrettyPrintApproxWdl.apply(b00.nodes)
-//    System.out.println(bl33)
 
     Block.categorize(b00) shouldBe a[Block.CondOneCall]
   }

--- a/src/test/scala/dxWDL/util/WdlPrettyPrintApproxWdlTest.scala
+++ b/src/test/scala/dxWDL/util/WdlPrettyPrintApproxWdlTest.scala
@@ -4,25 +4,30 @@ import java.io.File
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import dxWDL.base.ParseWomSourceFile
-import dxWDL.util.WomPrettyPrintApproxWdl
+import dxWDL.base.ParseWdlSourceFile
 
-class WomPrettyPrintApproxWdlTest extends AnyFlatSpec with Matchers {
+class WdlPrettyPrintApproxWdlTest extends AnyFlatSpec with Matchers {
 
   private def tryToPrintFile(path: File): Unit = {
-    val wfSourceCode = scala.io.Source.fromFile(path).mkString
+    val src = scala.io.Source.fromFile(path)
+    val wfSourceCode =
+      try {
+        src.mkString
+      } finally {
+        src.close()
+      }
     try {
-      val (wf, _, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wfSourceCode)
+      val (wf, _, _, _) = ParseWdlSourceFile(false).parseWdlWorkflow(wfSourceCode)
       val blocks = Block.splitWorkflow(wf)
 
-      WomPrettyPrintApproxWdl.graphInputs(wf.inputs)
-      WomPrettyPrintApproxWdl.graphOutputs(wf.outputs)
+      TypedAstPrettyPrintApproxWdl.graphInputs(wf.inputs)
+      TypedAstPrettyPrintApproxWdl.graphOutputs(wf.outputs)
       blocks.foreach { b =>
-        WomPrettyPrintApproxWdl.block(b)
+        TypedAstPrettyPrintApproxWdl.block(b)
       }
     } catch {
       // Some of the source files are invalid, or contain tasks and not workflows
-      case e: Throwable => ()
+      case _: Throwable => ()
     }
   }
 

--- a/src/test/scala/dxWDL/util/WdlValueAnalysisTest.scala
+++ b/src/test/scala/dxWDL/util/WdlValueAnalysisTest.scala
@@ -5,15 +5,15 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.eval.WdlValues
 import wdlTools.types.{TypedAbstractSyntax => TAT, WdlTypes}
 
-import dxWDL.base.ParseWomSourceFile
+import dxWDL.base.ParseWdlSourceFile
 
-class WomValueAnalysisTest extends AnyFlatSpec with Matchers {
+class WdlValueAnalysisTest extends AnyFlatSpec with Matchers {
 
   def parseExpressions(wdlCode: String): Vector[TAT.Declaration] = {
-    val (wf: TAT.Workflow, _, _, _) = ParseWomSourceFile(false).parseWdlWorkflow(wdlCode)
+    val (wf: TAT.Workflow, _, _, _) = ParseWdlSourceFile(false).parseWdlWorkflow(wdlCode)
     wf.body.collect {
       case d: TAT.Declaration => d
-    }.toVector
+    }
   }
 
   it should "evalConst" in {
@@ -41,7 +41,7 @@ class WomValueAnalysisTest extends AnyFlatSpec with Matchers {
         "file2" -> None
     )
 
-    // The workflow is a convenient packaging around WOM
+    // The workflow is a convenient packaging around WDL
     // expressions. When we parse the workflow, the expressions lose
     // their relative ordering, and become a graph. That's why we need
     // to keep track of a map from identifier name to expected result.
@@ -75,21 +75,21 @@ class WomValueAnalysisTest extends AnyFlatSpec with Matchers {
       val id: String = decl.name
       val expected: Option[WdlValues.V] = allExpectedResults(id)
       val expr: TAT.Expr = decl.expr.get
-      val womType: WdlTypes.T = decl.wdlType
+      val wdlType: WdlTypes.T = decl.wdlType
 
-      val retval = WomValueAnalysis.ifConstEval(womType, expr)
-      retval shouldBe (expected)
+      val retval = WdlValueAnalysis.ifConstEval(wdlType, expr)
+      retval shouldBe expected
 
       // Check that evalConst works
       expected match {
         case None =>
           assertThrows[Exception] {
-            WomValueAnalysis.evalConst(womType, expr)
+            WdlValueAnalysis.evalConst(wdlType, expr)
           }
-          WomValueAnalysis.isExpressionConst(womType, expr) shouldBe (false)
+          WdlValueAnalysis.isExpressionConst(wdlType, expr) shouldBe false
         case Some(x) =>
-          WomValueAnalysis.evalConst(womType, expr) shouldBe (x)
-          WomValueAnalysis.isExpressionConst(womType, expr) shouldBe (true)
+          WdlValueAnalysis.evalConst(wdlType, expr) shouldBe x
+          WdlValueAnalysis.isExpressionConst(wdlType, expr) shouldBe true
       }
     }
   }
@@ -106,7 +106,7 @@ class WomValueAnalysisTest extends AnyFlatSpec with Matchers {
     val declarations = parseExpressions(wdlCode)
     val node = declarations.head
     assertThrows[Exception] {
-      WomValueAnalysis.ifConstEval(node.wdlType, node.expr.get)
+      WdlValueAnalysis.ifConstEval(node.wdlType, node.expr.get)
     }
   }
 
@@ -124,6 +124,6 @@ class WomValueAnalysisTest extends AnyFlatSpec with Matchers {
 
     val declarations = parseExpressions(wdlCode)
     for (node <- declarations)
-      WomValueAnalysis.ifConstEval(node.wdlType, node.expr.get)
+      WdlValueAnalysis.ifConstEval(node.wdlType, node.expr.get)
   }
 }


### PR DESCRIPTION
The only references to WOM I am not able to get rid of confidently are 

* womSourceCode in details of generated workflows/applets
* womType, womValue used in WdlValueSerialization