### PR TITLE
Special handling for structs when creating output closures

### DIFF
--- a/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
@@ -637,7 +637,8 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
         val lVar = env.get(name) match {
           case None =>
             throw new Exception(s"could not find variable $name in the environment ${env.keys}")
-          case Some(lVar) => name -> lVar
+          case Some(lVar) =>
+            name -> lVar
         }
         lVar
     }

--- a/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
@@ -177,7 +177,7 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
           if env.contains(s"$id.$field") =>
         env(s"$id.$field").sArg
 
-      case Some(TAT.ExprGetName(expr, id, _, _)) =>
+      case Some(TAT.ExprGetName(expr, field, _, _)) =>
         val lhs = constInputToSArg(Some(expr), cVar, env, locked, callFqn)
         val lhsWdlValue = lhs match {
           case IR.SArgConst(wdlValue)                                 => wdlValue
@@ -188,18 +188,18 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
             )
         }
         val wdlValue = lhsWdlValue match {
-          case WdlValues.V_Object(members) if members.contains(id) => members(id)
+          case WdlValues.V_Object(members) if members.contains(field) => members(field)
           case WdlValues.V_Pair(l, r) =>
-            id match {
+            field match {
               case "left"  => l
               case "right" => r
               case _ =>
-                throw new Exception(s"Pair member name must be 'left' or 'right', not ${id}")
+                throw new Exception(s"Pair member name must be 'left' or 'right', not ${field}")
             }
-          case WdlValues.V_Call(_, members) if members.contains(id)   => members(id)
-          case WdlValues.V_Struct(_, members) if members.contains(id) => members(id)
+          case WdlValues.V_Call(_, members) if members.contains(field)   => members(field)
+          case WdlValues.V_Struct(_, members) if members.contains(field) => members(field)
           case other =>
-            throw new Exception(s"Cannot resolve id ${id} for value ${other}")
+            throw new Exception(s"Cannot resolve id ${field} for value ${other}")
         }
         IR.SArgConst(wdlValue)
 

--- a/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
@@ -635,7 +635,8 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
     val closureInputVars: Map[String, LinkedVar] = closure.map {
       case (name, _) =>
         val lVar = env.get(name) match {
-          case None       => throw new Exception(s"could not find variable $name in the environment")
+          case None =>
+            throw new Exception(s"could not find variable $name in the environment ${env.keys}")
           case Some(lVar) => name -> lVar
         }
         lVar

--- a/src/main/scala/dx/compiler/Main.scala
+++ b/src/main/scala/dx/compiler/Main.scala
@@ -117,12 +117,10 @@ object Main {
       case (Some(p), Some(d)) => (p, d)
     }
 
-    if (folderRaw.isEmpty) {
+    if (folderRaw.isEmpty)
       throw new Exception(s"Cannot specify empty folder")
-    }
-    if (!folderRaw.startsWith("/")) {
+    if (!folderRaw.startsWith("/"))
       throw new Exception(s"Folder must start with '/'")
-    }
     val dxFolder = folderRaw
     val dxProject =
       try {

--- a/src/main/scala/dx/compiler/Main.scala
+++ b/src/main/scala/dx/compiler/Main.scala
@@ -117,10 +117,12 @@ object Main {
       case (Some(p), Some(d)) => (p, d)
     }
 
-    if (folderRaw.isEmpty)
+    if (folderRaw.isEmpty) {
       throw new Exception(s"Cannot specify empty folder")
-    if (!folderRaw.startsWith("/"))
+    }
+    if (!folderRaw.startsWith("/")) {
       throw new Exception(s"Folder must start with '/'")
+    }
     val dxFolder = folderRaw
     val dxProject =
       try {

--- a/src/main/scala/dx/core/languages/wdl/Block.scala
+++ b/src/main/scala/dx/core/languages/wdl/Block.scala
@@ -325,7 +325,9 @@ object Block {
         // name.
 
         // Note: this case was added to fix bug/APPS-104 - there may be other expressions
-        // besides structs that need to not have the member name added when withMember = false
+        // besides structs that need to not have the member name added when withMember = false.
+        // It may also be the case that the bug is with construction of the environment rather
+        // than here with the closure.
         case TAT.ExprGetName(expr, _, _, _)
             if !withMember && unwrapOptional(expr.wdlType).isInstanceOf[WdlTypes.T_Struct] =>
           inner(expr)

--- a/src/main/scala/dx/core/languages/wdl/Block.scala
+++ b/src/main/scala/dx/core/languages/wdl/Block.scala
@@ -319,10 +319,10 @@ object Block {
         case TAT.ExprApply(_, _, elements, _, _) =>
           elements.flatMap(inner)
 
-        // What we do with the remaining types of expressions depends on the
-        // value of withMember. When we are generating a closure, we only need
-        // the parent struct, not the member. Otherwise, we need to add the member
-        // name.
+        // Access the field of a call/struct/etc. What we do here depends on the
+        // value of withMember. When we the expression value is a struct and we
+        // are generating a closure, we only need the parent struct, not the member.
+        // Otherwise, we need to add the member name.
 
         // Note: this case was added to fix bug/APPS-104 - there may be other expressions
         // besides structs that need to not have the member name added when withMember = false.


### PR DESCRIPTION
When creating the closure for an output section, it appears that for references to structs, only the struct name, not the specific member accessed, gets added to the environment. So we have to add a special case when constructing the closure.

Note that this may in fact be a bug with how we build the environment, not the closure. We should make a note of this in case any more bugs of this nature crop up.