### PR TITLE
Handle null repo

### DIFF
--- a/src/main/scala/dxWDL/compiler/DxNI.scala
+++ b/src/main/scala/dxWDL/compiler/DxNI.scala
@@ -150,7 +150,15 @@ case class DxNI(verbose: Verbose, language: Language.Value) {
   private def search(dxProject: DxProject, folder: String, recursive: Boolean): Vector[String] = {
     val dxObjectsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(None, verbose)
-        .apply(Some(dxProject), Some(folder), recursive, None, Vector.empty, Vector.empty, true, Vector.empty, Set.empty)
+        .apply(Some(dxProject),
+               Some(folder),
+               recursive,
+               None,
+               Vector.empty,
+               Vector.empty,
+               true,
+               Vector.empty,
+               Set.empty)
 
     // we just want the applets
     val dxAppletsInFolder: Map[DxApplet, DxAppletDescribe] = dxObjectsInFolder.collect {

--- a/src/main/scala/dxWDL/dx/DxFile.scala
+++ b/src/main/scala/dxWDL/dx/DxFile.scala
@@ -166,19 +166,22 @@ object DxFile {
                             extraFields: Set[Field.Value],
                             project: Option[DxProject]): Map[DxFile, DxFileDescribe] = {
     val ids = objs.map(file => file.getId)
-    val dxFindDataObjects = DxFindDataObjects(None, Verbose(on = false, quiet = true, keywords = Set.empty))
+    val dxFindDataObjects =
+      DxFindDataObjects(None, Verbose(on = false, quiet = true, keywords = Set.empty))
 
-    dxFindDataObjects.apply(
-      dxProject = project,
-      folder = None,
-      recurse = true,
-      klassRestriction = Some("file"),
-      withProperties = Vector.empty,
-      nameConstraints = Vector.empty,
-      withInputOutputSpec = true,
-      idConstraints = ids,
-      extrafields = extraFields
-    ).asInstanceOf[Map[DxFile, DxFileDescribe]]
+    dxFindDataObjects
+      .apply(
+          dxProject = project,
+          folder = None,
+          recurse = true,
+          klassRestriction = Some("file"),
+          withProperties = Vector.empty,
+          nameConstraints = Vector.empty,
+          withInputOutputSpec = true,
+          idConstraints = ids,
+          extrafields = extraFields
+      )
+      .asInstanceOf[Map[DxFile, DxFileDescribe]]
   }
 
   // Describe the names of all the files in one batch. This is much more efficient

--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -161,14 +161,14 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
     if (withInputOutputSpec) {
       fields ++= Set(Field.InputSpec, Field.OutputSpec)
     }
-    val reqFields = Map("visibility" -> JsString("either"),
-                        "describe" -> DxObject.requestFields(fields))
+    val reqFields =
+      Map("visibility" -> JsString("either"), "describe" -> DxObject.requestFields(fields))
     val projField = dxProject match {
-      case None => Map.empty
+      case None    => Map.empty
       case Some(p) => Map("project" -> JsString(p.getId))
     }
     val scopeField = scope match {
-      case None => Map.empty
+      case None    => Map.empty
       case Some(s) => Map("scope" -> s)
     }
     val limitField = limit match {
@@ -214,7 +214,9 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       if (idConstraints.isEmpty) {
         Map.empty
       } else {
-        Map("id" -> JsArray(idConstraints.map { x: String => JsString(x)}))
+        Map("id" -> JsArray(idConstraints.map { x: String =>
+          JsString(x)
+        }))
       }
 
     val request = JsObject(
@@ -253,29 +255,28 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
             nameConstraints: Vector[String], // the object name has to be one of these strings
             withInputOutputSpec: Boolean, // should the IO spec be described?
             idConstraints: Vector[String],
-            extrafields: Set[Field.Value]
-  ): Map[DxDataObject, DxObjectDescribe] = {
+            extrafields: Set[Field.Value]): Map[DxDataObject, DxObjectDescribe] = {
     klassRestriction.map { k =>
       if (!(Set("record", "file", "applet", "workflow") contains k))
         throw new Exception("class limitation must be one of {record, file, applet, workflow}")
     }
 
     val scope: Option[JsValue] = dxProject match {
-      case None => None
+      case None    => None
       case Some(p) => Some(buildScope(p, folder, recurse))
     }
     var allResults = Map.empty[DxDataObject, DxObjectDescribe]
     var cursor: Option[JsValue] = None
     do {
       val (results, next) = submitRequest(scope,
-                                  dxProject,
-                                  cursor,
-                                  klassRestriction,
-                                  withProperties,
-                                  nameConstraints,
-                                  withInputOutputSpec,
-                                  idConstraints,
-                                  extrafields)
+                                          dxProject,
+                                          cursor,
+                                          klassRestriction,
+                                          withProperties,
+                                          nameConstraints,
+                                          withInputOutputSpec,
+                                          idConstraints,
+                                          extrafields)
       allResults = allResults ++ results
       cursor = next
     } while (cursor != None);

--- a/src/main/scala/dxWDL/exec/TaskRunner.scala
+++ b/src/main/scala/dxWDL/exec/TaskRunner.scala
@@ -262,9 +262,11 @@ case class TaskRunner(task: CallableTaskDefinition,
         repo match {
           case Some(r) => Some(r)
           case None =>
-            val dockerLoadRegexp = "^Loaded image: (.+)$".r
+            val dockerRepoRegexp = "^Loaded image: (.+)$".r
+            val dockerHashRegexp = "^Loaded image ID: (.+)$".r
             outstr.trim match {
-              case dockerLoadRegexp(r) => Some(r)
+              case dockerRepoRegexp(r) => Some(r)
+              case dockerHashRegexp(h) => Some(h)
               case _ =>
                 throw new Exception(
                     s"Could not determine the repo name from either the manifest or the 'docker load' output ${outstr}"

--- a/src/main/scala/dxWDL/util/Block.scala
+++ b/src/main/scala/dxWDL/util/Block.scala
@@ -101,7 +101,15 @@ case class Block(nodes: Vector[GraphNode]) {
     // There can be no calls in the first nodes
     val allButLast: Vector[GraphNode] = this.nodes.dropRight(1)
     val allCalls = Block.deepFindCalls(allButLast)
-    assert(allCalls.size == 0)
+    if (allCalls.nonEmpty) {
+      throw new Exception(s"""Invalid block: calls made prior to last node
+                             |Block:
+                             |${prettyPrint}
+                             |
+                             |Calls:
+                             |${allCalls}
+                             |""".stripMargin)
+    }
   }
 
   // Create a human readable name for a block of statements

--- a/src/main/scala/dxWDL/util/InstanceTypeDB.scala
+++ b/src/main/scala/dxWDL/util/InstanceTypeDB.scala
@@ -475,10 +475,9 @@ object InstanceTypeDB extends DefaultJsonProtocol {
 
     val rep =
       try {
-        if(billTo.startsWith("org")) {
+        if (billTo.startsWith("org")) {
           DXAPI.orgDescribe(billTo, req, classOf[JsonNode])
-        }
-        else {
+        } else {
           DXAPI.userDescribe(billTo, req, classOf[JsonNode])
         }
       } catch {

--- a/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
+++ b/src/main/scala/dxWDL/util/ParseWomSourceFile.scala
@@ -321,20 +321,18 @@ case class ParseWomSourceFile(verbose: Boolean) {
   // in this file.
   def scanForTasks(sourceCode: String): Map[String, String] = {
     var lines = sourceCode.split("\n").toList
-    val taskDir = HashMap.empty[String, String]
-
-    while (!lines.isEmpty) {
+    var taskDir = Map.empty[String, String]
+    while (lines.nonEmpty) {
       val retval = findNextTask(lines)
-
       // TODO: add a WOM syntax check that this is indeed a task.
       retval match {
-        case None => return taskDir.toMap
+        case None => return taskDir
         case Some((remainingLines, taskName, taskLines)) =>
-          taskDir(taskName) = taskLines
+          taskDir += (taskName -> taskLines)
           lines = remainingLines
       }
     }
-    return taskDir.toMap
+    taskDir
   }
 
   // Go through one WDL source file, and return a map from task name

--- a/src/test/scala/dxWDL/compiler/NativeTest.scala
+++ b/src/test/scala/dxWDL/compiler/NativeTest.scala
@@ -87,15 +87,17 @@ class NativeTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     val folder = Paths.get(path).getParent().toAbsolutePath().toString()
     val basename = Paths.get(path).getFileName().toString()
     val verbose = Verbose(false, true, Set.empty)
-    val results = DxFindDataObjects(Some(10), verbose).apply(Some(dxTestProject),
-                                                             Some(folder),
-                                                             recurse = false,
-                                                             klassRestriction = None,
-                                                             withProperties = Vector.empty,
-                                                             nameConstraints = Vector(basename),
-                                                             withInputOutputSpec = false,
-                                                             Vector.empty,
-                                                             Set.empty)
+    val results = DxFindDataObjects(Some(10), verbose).apply(
+        Some(dxTestProject),
+        Some(folder),
+        recurse = false,
+        klassRestriction = None,
+        withProperties = Vector.empty,
+        nameConstraints = Vector(basename),
+        withInputOutputSpec = false,
+        Vector.empty,
+        Set.empty
+    )
     results.size shouldBe (1)
     val desc = results.values.head
     desc.id

--- a/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
+++ b/src/test/scala/dxWDL/dx/DxdaManifestTest.scala
@@ -43,19 +43,22 @@ class DxdaManifestTest extends FlatSpec with Matchers {
     val manifest: DxdaManifest = DxdaManifest.apply(filesInManifest)
 
     // compare to data obtained with dx-toolkit
-    val expected: Vector[JsValue] = resolvedObjects.map {
-      case (dxPath, dataObj) =>
-        val dxFile = dataObj.asInstanceOf[DxFile]
-        val local: Path = fileDir(dxPath)
+    val expected: Vector[JsValue] = resolvedObjects
+      .map {
+        case (dxPath, dataObj) =>
+          val dxFile = dataObj.asInstanceOf[DxFile]
+          val local: Path = fileDir(dxPath)
 
-        // add the target folder and name
-        val fields = Map(
-            "id" -> JsString(dxFile.getId),
-            "name" -> JsString(local.toFile().getName()),
-            "folder" -> JsString(local.toFile().getParent())
-        )
-        JsObject(fields)
-    }.toVector.reverse
+          // add the target folder and name
+          val fields = Map(
+              "id" -> JsString(dxFile.getId),
+              "name" -> JsString(local.toFile().getName()),
+              "folder" -> JsString(local.toFile().getParent())
+          )
+          JsObject(fields)
+      }
+      .toVector
+      .reverse
 
     manifest shouldBe (DxdaManifest(
         JsObject(dxTestProject.getId -> JsArray(expected))

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -248,7 +248,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
                  |]""".stripMargin.trim
 
     val repo = TaskRunnerUtils.readManifestGetDockerImageName(buf)
-    repo should equal(Some("ubuntu_18_04_minimal:latest")) c
+    repo should equal(Some("ubuntu_18_04_minimal:latest"))
   }
 
   it should "handle structs" in {

--- a/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dxWDL/exec/TaskRunnerTest.scala
@@ -248,7 +248,7 @@ class TaskRunnerTest extends FlatSpec with Matchers {
                  |]""".stripMargin.trim
 
     val repo = TaskRunnerUtils.readManifestGetDockerImageName(buf)
-    repo should equal("ubuntu_18_04_minimal:latest")
+    repo should equal(Some("ubuntu_18_04_minimal:latest")) c
   }
 
   it should "handle structs" in {

--- a/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
+++ b/src/test/scala/dxWDL/util/InstanceTypeDBTest.scala
@@ -420,7 +420,8 @@ class InstanceTypeDBTest extends FlatSpec with Matchers {
     val userBilltoProject = DxProject("project-FqP0vf00bxKykykX5pVXB1YQ") // project name: dxWDL_public_test
     val orgBilltoProject = DxProject("project-FQ7BqkQ0FyXgJxGP2Bpfv3vK") // project name: dxWDL_CI
 
-    val userResult = InstanceTypeDB.query(userBilltoProject, Verbose(on = false, quiet = true, null))
+    val userResult =
+      InstanceTypeDB.query(userBilltoProject, Verbose(on = false, quiet = true, null))
     val orgResult = InstanceTypeDB.query(orgBilltoProject, Verbose(on = false, quiet = true, null))
 
     userResult.pricingAvailable shouldBe true


### PR DESCRIPTION
TaskRunner fails if `RepoTags` is missing or has a null value in the manifest of the docker tarball. However, `docker load` prints out the repo name. This change uses the results of `docker load` if the attempt to read the repo if reading from the manifest fails.

There's also some code reformatting here due to my scalafmt git hook. The only real changes are in TaskRunner and TaskRunnerTest.