### PR TITLE
Simplify a pattern match in Top.scala

### DIFF
--- a/src/main/scala/dx/compiler/Top.scala
+++ b/src/main/scala/dx/compiler/Top.scala
@@ -319,14 +319,13 @@ case class Top(cOpt: CompilerOptions) {
         val ids = cResults.execDict.map { case (_, r) => r.dxExec.getId }.mkString(",")
         (ids, None)
       case Some(wf) if execTree.isDefined =>
-        val primary = wf
         val tree = new Tree(cResults.execDict)
         val treeRepr = execTree.get match { // Safe get because we check isDefined above
           case PrettyTreePrinter =>
             Left(
-                Tree.generateTreeFromJson(tree.apply(primary).asJsObject)
+                Tree.generateTreeFromJson(tree.apply(wf).asJsObject)
             )
-          case JsonTreePrinter => Right(tree.apply(primary)) // Convert to string
+          case JsonTreePrinter => Right(tree.apply(wf)) // Convert to string
         }
         (wf.dxExec.getId, Some(treeRepr))
       case Some(wf) =>

--- a/src/main/scala/dx/compiler/Top.scala
+++ b/src/main/scala/dx/compiler/Top.scala
@@ -319,20 +319,16 @@ case class Top(cOpt: CompilerOptions) {
         val ids = cResults.execDict.map { case (_, r) => r.dxExec.getId }.mkString(",")
         (ids, None)
       case Some(wf) if execTree.isDefined =>
-        cResults.primaryCallable match {
-          case None =>
-            (wf.dxExec.getId, None)
-          case Some(primary) =>
-            val tree = new Tree(cResults.execDict)
-            val treeRepr = execTree.get match { // Safe get because we check isDefined above
-              case PrettyTreePrinter =>
-                Left(
-                    Tree.generateTreeFromJson(tree.apply(primary).asJsObject)
-                )
-              case JsonTreePrinter => Right(tree.apply(primary)) // Convert to string
-            }
-            (wf.dxExec.getId, Some(treeRepr))
+        val primary = wf
+        val tree = new Tree(cResults.execDict)
+        val treeRepr = execTree.get match { // Safe get because we check isDefined above
+          case PrettyTreePrinter =>
+            Left(
+                Tree.generateTreeFromJson(tree.apply(primary).asJsObject)
+            )
+          case JsonTreePrinter => Right(tree.apply(primary)) // Convert to string
         }
+        (wf.dxExec.getId, Some(treeRepr))
       case Some(wf) =>
         (wf.dxExec.getId, None)
     }

--- a/src/main/scala/dx/compiler/Top.scala
+++ b/src/main/scala/dx/compiler/Top.scala
@@ -318,18 +318,18 @@ case class Top(cOpt: CompilerOptions) {
       case None =>
         val ids = cResults.execDict.map { case (_, r) => r.dxExec.getId }.mkString(",")
         (ids, None)
-      case Some(wf) if execTree.isDefined =>
-        val tree = new Tree(cResults.execDict)
-        val treeRepr = execTree.get match { // Safe get because we check isDefined above
-          case PrettyTreePrinter =>
-            Left(
-                Tree.generateTreeFromJson(tree.apply(wf).asJsObject)
-            )
-          case JsonTreePrinter => Right(tree.apply(wf)) // Convert to string
-        }
-        (wf.dxExec.getId, Some(treeRepr))
       case Some(wf) =>
-        (wf.dxExec.getId, None)
+        val treeReprOpt = execTree.map { treePrinter =>
+          val tree = new Tree(cResults.execDict)
+          treePrinter match {
+            case PrettyTreePrinter =>
+              Left(
+                  Tree.generateTreeFromJson(tree.apply(wf).asJsObject)
+              )
+            case JsonTreePrinter => Right(tree.apply(wf)) // Convert to string
+          }
+        }
+        (wf.dxExec.getId, treeReprOpt)
     }
   }
 }


### PR DESCRIPTION
First, a pattern match of the form

```scala
    cResults.primaryCallable match {
      case Some(wf) if execTree.isDefined =>
        cResults.primaryCallable match { // this is a redundant pattern match
          case None =>
            // dead code
          case Some(primary) => // we already know that primary = wf
            SOME_CODE(primary)
```

is simplified to

```scala
    cResults.primaryCallable match {
      case Some(wf) if execTree.isDefined =>
        val primary = wf
        SOME_CODE(primary)
```

Subsequently, code of the form

```scala
      case Some(wf) if execTree.isDefined =>
        val y = SOME_CODE(execTree.get) // Safe get because we check isDefined above
        (x, Some(y))
      case Some(wf) =>
        (x, None)
```

is simplified to

```scala
      case Some(wf) =>
        val yOpt = execTree.map(SOME_CODE)
        (x, yOpt)
```

which also avoids the use of the unsafe `Option#get` method.

The change is presented as 3 individual commits, so that in each commit it is absolutely obvious what's going on.