### PR TITLE
Update wdl tools 0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ publishMavenStyle := true
 val root = project.in(file("."))
 
 // reduce the maximum number of errors shown by the Scala compiler
-maxErrors := 7
+maxErrors := 20
 
 //coverageEnabled := true
 
@@ -70,7 +70,7 @@ logLevel in assembly := Level.Info
 assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
-val wdlToolsVersion = "0.3.1"
+val wdlToolsVersion = "0.5.0"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
@@ -11,3 +10,16 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 //
 // workaround for missing static SLF4J binder for logback
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
+// only load git plugin if we're actually in a git repo
+libraryDependencies ++= {
+  if (baseDirectory.value / "../.git" isDirectory)
+    Seq(
+        Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-git" % "1.0.0",
+                                (sbtBinaryVersion in update).value,
+                                (scalaBinaryVersion in update).value)
+    )
+  else {
+    println("sbt-git plugin not loaded")
+    Seq.empty
+  }
+}

--- a/src/main/scala/dx/api/DxApi.scala
+++ b/src/main/scala/dx/api/DxApi.scala
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import dx.api.DxPath.DxPathComponents
 import dx.{AppInternalException, IllegalArgumentException}
 import spray.json._
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{FileUtils, Logger, SysUtils}
 
 // wrapper around DNAnexus Java API
 case class DxApi(logger: Logger = Logger.Quiet, dxEnv: DXEnvironment = DXEnvironment.create()) {
@@ -508,7 +508,7 @@ case class DxApi(logger: Logger = Logger.Quiet, dxEnv: DXEnvironment = DXEnviron
       try {
         // Use dx download. Quote the path, because it may contains spaces.
         val dxDownloadCmd = s"""dx download ${fid} -o "${path.toString}" """
-        val (_, _) = Util.execCommand(dxDownloadCmd, None)
+        logger.ignore(SysUtils.execCommand(dxDownloadCmd, None))
         true
       } catch {
         case e: Throwable =>
@@ -547,7 +547,7 @@ case class DxApi(logger: Logger = Logger.Quiet, dxEnv: DXEnvironment = DXEnviron
         // spaces
         val dxUploadCmd = s"""dx upload "${path.toString}" --brief"""
         logger.traceLimited(s"--  ${dxUploadCmd}")
-        val (outmsg, _) = Util.execCommand(dxUploadCmd, None)
+        val (_, outmsg, _) = SysUtils.execCommand(dxUploadCmd, None)
         if (!outmsg.startsWith("file-"))
           return None
         Some(outmsg.trim())
@@ -593,7 +593,7 @@ case class DxApi(logger: Logger = Logger.Quiet, dxEnv: DXEnvironment = DXEnviron
     val tempFi: Path = Files.createTempFile(s"${dxFile.id}", ".tmp")
     silentFileDelete(tempFi)
     downloadFile(tempFi, dxFile)
-    val content = Util.readFileContent(tempFi)
+    val content = FileUtils.readFileContent(tempFi)
     silentFileDelete(tempFi)
     content
   }

--- a/src/main/scala/dx/api/DxInstanceType.scala
+++ b/src/main/scala/dx/api/DxInstanceType.scala
@@ -43,9 +43,9 @@ case class DxInstanceType(name: String,
                           os: Vector[(String, String)],
                           gpu: Boolean) {
   // Does this instance satisfy the requirements?
-  def satisfies(memReq: Option[Int],
-                diskReq: Option[Int],
-                cpuReq: Option[Int],
+  def satisfies(memReq: Option[Long],
+                diskReq: Option[Long],
+                cpuReq: Option[Long],
                 gpuReq: Option[Boolean]): Boolean = {
     memReq match {
       case Some(x) => if (memoryMB < x) return false
@@ -125,9 +125,9 @@ object DxInstanceType extends DefaultJsonProtocol {
 
 // Request for an instance type
 case class InstanceTypeReq(dxInstanceType: Option[String],
-                           memoryMB: Option[Int],
-                           diskGB: Option[Int],
-                           cpu: Option[Int],
+                           memoryMB: Option[Long],
+                           diskGB: Option[Long],
+                           cpu: Option[Long],
                            gpu: Option[Boolean])
 
 case class InstanceTypeDB(pricingAvailable: Boolean, instances: Vector[DxInstanceType]) {
@@ -158,9 +158,9 @@ case class InstanceTypeDB(pricingAvailable: Boolean, instances: Vector[DxInstanc
   // we use here is:
   // 1) discard all instances that do not have enough resources
   // 2) choose the cheapest instance
-  def chooseAttrs(memoryMB: Option[Int],
-                  diskGB: Option[Int],
-                  cpu: Option[Int],
+  def chooseAttrs(memoryMB: Option[Long],
+                  diskGB: Option[Long],
+                  cpu: Option[Long],
                   gpu: Option[Boolean]): String = {
     // discard all instances that are too weak
     val sufficient: Vector[DxInstanceType] =

--- a/src/main/scala/dx/compiler/DxNI.scala
+++ b/src/main/scala/dx/compiler/DxNI.scala
@@ -53,7 +53,7 @@ import spray.json._
 import wdlTools.generators.code.WdlV1Generator
 import wdlTools.syntax.{CommentMap, SourceLocation}
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
-import wdlTools.util.{StringFileSource, Util}
+import wdlTools.util.{FileUtils, StringFileSource}
 
 import scala.util.matching.Regex
 
@@ -435,7 +435,7 @@ object DxNI {
     }
     val generator = WdlV1Generator()
     val lines = generator.generateDocument(element, header)
-    Util.writeFileContent(outputPath, lines.mkString("\n"))
+    FileUtils.writeFileContent(outputPath, lines.mkString("\n"))
   }
 
   // create headers for calling dx:applets and dx:workflows

--- a/src/main/scala/dx/compiler/Extras.scala
+++ b/src/main/scala/dx/compiler/Extras.scala
@@ -10,7 +10,7 @@ import wdlTools.eval.WdlValues
 import wdlTools.types.{TypedAbstractSyntax => TAT}
 import wdlTools.util.Logger
 
-case class DxExecPolicy(restartOn: Option[Map[String, Int]], maxRestarts: Option[Int]) {
+case class DxExecPolicy(restartOn: Option[Map[String, Long]], maxRestarts: Option[Long]) {
   def toJson: Map[String, JsValue] = {
     val restartOnFields = restartOn match {
       case None => Map.empty
@@ -30,7 +30,7 @@ case class DxExecPolicy(restartOn: Option[Map[String, Int]], maxRestarts: Option
   }
 }
 
-case class DxTimeout(days: Option[Int], hours: Option[Int], minutes: Option[Int]) {
+case class DxTimeout(days: Option[Long], hours: Option[Long], minutes: Option[Long]) {
   def toJson: Map[String, JsValue] = {
     val daysField: Map[String, JsValue] = days match {
       case None    => Map.empty
@@ -304,10 +304,11 @@ object Extras {
   val TASK_DX_ATTRS = Set("runSpec", "details")
   val DX_DETAILS_ATTRS = Set("upstreamProjects")
 
-  private def checkedParseIntField(fields: Map[String, JsValue], fieldName: String): Option[Int] = {
+  private def checkedParseIntField(fields: Map[String, JsValue],
+                                   fieldName: String): Option[Long] = {
     fields.get(fieldName) match {
       case None                => None
-      case Some(JsNumber(bnm)) => Some(bnm.intValue)
+      case Some(JsNumber(bnm)) => Some(bnm.longValue)
       case Some(other)         => throw new Exception(s"Malformed ${fieldName} (${other})")
     }
   }
@@ -371,12 +372,12 @@ object Extras {
   }
 
   private def checkedParseMapStringInt(fields: Map[String, JsValue],
-                                       fieldName: String): Option[Map[String, Int]] = {
+                                       fieldName: String): Option[Map[String, Long]] = {
     val m = checkedParseObjectField(fields, fieldName)
     if (m == JsNull)
       return None
     val m1 = m.asJsObject.fields.map {
-      case (name, JsNumber(nmb)) => name -> nmb.intValue
+      case (name, JsNumber(nmb)) => name -> nmb.longValue
       case (name, other)         => throw new Exception(s"Malformed ${fieldName} (${name} -> ${other})")
     }
     Some(m1)

--- a/src/main/scala/dx/compiler/GenerateIRTask.scala
+++ b/src/main/scala/dx/compiler/GenerateIRTask.scala
@@ -51,8 +51,8 @@ case class GenerateIRTask(dxApi: DxApi,
 
     def evalHintAttr(attrName: String): Option[TAT.MetaValue] = {
       val hintAttributes: Map[String, TAT.MetaValue] = task.hints match {
-        case None                           => Map.empty
-        case Some(TAT.HintsSection(kvs, _)) => kvs
+        case None                          => Map.empty
+        case Some(TAT.MetaSection(kvs, _)) => kvs
       }
       hintAttributes.get(attrName) match {
         case None =>
@@ -185,7 +185,7 @@ case class GenerateIRTask(dxApi: DxApi,
     }
   }
 
-  private def unwrapMetaInteger(value: TAT.MetaValue): Int = {
+  private def unwrapMetaInteger(value: TAT.MetaValue): Long = {
     value match {
       case TAT.MetaValueInt(i, _) => i
       case _                      => throw new Exception("Expected WdlValues.V_Int")
@@ -198,10 +198,10 @@ case class GenerateIRTask(dxApi: DxApi,
   private def parseDuration(duration: String): IR.RuntimeHintTimeout = {
     durationRegexp.findFirstMatchIn(duration) match {
       case Some(result: Regex.Match) =>
-        def group(i: Int): Option[Int] = {
+        def group(i: Int): Option[Long] = {
           result.group(i) match {
             case null      => None
-            case s: String => Some(s.toInt)
+            case s: String => Some(s.toLong)
           }
         }
         IR.RuntimeHintTimeout(group(1), group(2), group(3))
@@ -260,7 +260,7 @@ case class GenerateIRTask(dxApi: DxApi,
   private def lookupInputParam(iName: String, task: TAT.Task): Option[TAT.MetaValue] = {
     task.parameterMeta match {
       case None => None
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         kvs.get(iName)
     }
   }
@@ -349,8 +349,8 @@ case class GenerateIRTask(dxApi: DxApi,
 
     // Handle any dx-specific runtime hints, other than "type" and "id" which are handled above
     val hintAttr: Map[String, TAT.MetaValue] = task.hints match {
-      case None                           => Map.empty
-      case Some(TAT.HintsSection(kvs, _)) => kvs
+      case None                          => Map.empty
+      case Some(TAT.MetaSection(kvs, _)) => kvs
     }
     val runtimeHints = unwrapHints(hintAttr)
 

--- a/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
+++ b/src/main/scala/dx/compiler/GenerateIRWorkflow.scala
@@ -58,7 +58,7 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
     // specified in the parameter meta section.
     val metaValue: Option[TAT.MetaValue] = wf.parameterMeta match {
       case None => None
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         kvs.get(input.name)
     }
     val attr = ParameterMeta.unwrap(metaValue, input.wdlType)
@@ -162,10 +162,10 @@ case class GenerateIRWorkflow(wf: TAT.Workflow,
         }
         val value = constInputToSArg(Some(expr), cVar, env, locked, callFqn) match {
           case IR.SArgConst(WdlValues.V_Array(arrayValue)) if arrayValue.size > indexValue =>
-            arrayValue(indexValue)
+            arrayValue(indexValue.toInt)
           case IR.SArgWorkflowInput(CVar(_, _, Some(WdlValues.V_Array(arrayValue)), _), _)
               if arrayValue.size > indexValue =>
-            arrayValue(indexValue)
+            arrayValue(indexValue.toInt)
           case other =>
             throw new Exception(
                 s"Left-hand side expression ${other} is not a constant nor an identifier"

--- a/src/main/scala/dx/compiler/IR.scala
+++ b/src/main/scala/dx/compiler/IR.scala
@@ -44,7 +44,7 @@ object IR {
   sealed abstract class MetaValue
   final case object MetaValueNull extends MetaValue
   final case class MetaValueBoolean(value: Boolean) extends MetaValue
-  final case class MetaValueInt(value: Int) extends MetaValue
+  final case class MetaValueInt(value: Long) extends MetaValue
   final case class MetaValueFloat(value: Double) extends MetaValue
   final case class MetaValueString(value: String) extends MetaValue
   final case class MetaValueObject(value: Map[String, MetaValue]) extends MetaValue

--- a/src/main/scala/dx/compiler/IR.scala
+++ b/src/main/scala/dx/compiler/IR.scala
@@ -92,13 +92,13 @@ object IR {
   val ALL_KEY = "All"
 
   sealed abstract class RuntimeHint
-  final case class RuntimeHintRestart(max: Option[Int] = None,
-                                      default: Option[Int] = None,
-                                      errors: Option[Map[String, Int]] = None)
+  final case class RuntimeHintRestart(max: Option[Long] = None,
+                                      default: Option[Long] = None,
+                                      errors: Option[Map[String, Long]] = None)
       extends RuntimeHint
-  final case class RuntimeHintTimeout(days: Option[Int] = None,
-                                      hours: Option[Int] = None,
-                                      minutes: Option[Int] = None)
+  final case class RuntimeHintTimeout(days: Option[Long] = None,
+                                      hours: Option[Long] = None,
+                                      minutes: Option[Long] = None)
       extends RuntimeHint
   final case class RuntimeHintIgnoreReuse(value: Boolean) extends RuntimeHint
   final case class RuntimeHintAccess(network: Option[Vector[String]] = None,
@@ -191,7 +191,7 @@ object IR {
   **/
   sealed abstract class ChoiceRepr
   final case class ChoiceReprString(value: String) extends ChoiceRepr
-  final case class ChoiceReprInteger(value: Int) extends ChoiceRepr
+  final case class ChoiceReprInteger(value: Long) extends ChoiceRepr
   final case class ChoiceReprFloat(value: Double) extends ChoiceRepr
   final case class ChoiceReprBoolean(value: Boolean) extends ChoiceRepr
   final case class ChoiceReprFile(value: String, name: Option[String]) extends ChoiceRepr
@@ -214,7 +214,7 @@ object IR {
   **/
   sealed abstract class SuggestionRepr
   sealed case class SuggestionReprString(value: String) extends SuggestionRepr
-  sealed case class SuggestionReprInteger(value: Int) extends SuggestionRepr
+  sealed case class SuggestionReprInteger(value: Long) extends SuggestionRepr
   sealed case class SuggestionReprFloat(value: Double) extends SuggestionRepr
   sealed case class SuggestionReprBoolean(value: Boolean) extends SuggestionRepr
   sealed case class SuggestionReprFile(
@@ -246,7 +246,7 @@ object IR {
   **/
   sealed abstract class DefaultRepr
   final case class DefaultReprString(value: String) extends DefaultRepr
-  final case class DefaultReprInteger(value: Int) extends DefaultRepr
+  final case class DefaultReprInteger(value: Long) extends DefaultRepr
   final case class DefaultReprFloat(value: Double) extends DefaultRepr
   final case class DefaultReprBoolean(value: Boolean) extends DefaultRepr
   final case class DefaultReprFile(value: String) extends DefaultRepr
@@ -306,9 +306,9 @@ object IR {
   case object InstanceTypeDefault extends InstanceType
   case class InstanceTypeConst(
       dxInstanceType: Option[String],
-      memoryMB: Option[Int],
-      diskGB: Option[Int],
-      cpu: Option[Int],
+      memoryMB: Option[Long],
+      diskGB: Option[Long],
+      cpu: Option[Long],
       gpu: Option[Boolean]
   ) extends InstanceType
   case object InstanceTypeRuntime extends InstanceType

--- a/src/main/scala/dx/compiler/InputFile.scala
+++ b/src/main/scala/dx/compiler/InputFile.scala
@@ -30,7 +30,7 @@ import dx.core.languages.wdl.{WdlVarLinks, WdlVarLinksConverter}
 import spray.json._
 import wdlTools.eval.WdlValues
 import wdlTools.types.WdlTypes
-import wdlTools.util.{FileSourceResolver, Logger, Util}
+import wdlTools.util.{FileSourceResolver, FileUtils, Logger}
 
 // scan a WDL JSON input file, and return all the dx:files in it.
 // An input file for workflow foo could look like this:
@@ -127,7 +127,7 @@ case class InputFileScan(bundle: IR.Bundle, dxProject: DxProject, dxApi: DxApi) 
 
   def apply(inputPath: Path): InputFileScanResults = {
     // Read the JSON values from the file
-    val content = Util.readFileContent(inputPath).parseJson
+    val content = FileUtils.readFileContent(inputPath).parseJson
     val inputs: Map[String, JsValue] = content.asJsObject.fields
 
     val allCallables: Vector[IR.Callable] =
@@ -432,7 +432,7 @@ case class InputFile(fileResolver: FileSourceResolver,
     dxApi.logger.trace(s"Embedding defaults into the IR")
 
     // read the default inputs file (xxxx.json)
-    val wdlDefaults: JsObject = Util.readFileContent(defaultInputs).parseJson.asJsObject
+    val wdlDefaults: JsObject = FileUtils.readFileContent(defaultInputs).parseJson.asJsObject
     val defaultFields: Fields = new Fields("default", preprocessInputs(wdlDefaults))
 
     val callablesWithDefaults = bundle.allCallables.map {
@@ -466,7 +466,7 @@ case class InputFile(fileResolver: FileSourceResolver,
     dxApi.logger.trace(s"Translating WDL input file ${inputPath}")
 
     // read the input file xxxx.json
-    val wdlInputs: JsObject = Util.readFileContent(inputPath).parseJson.asJsObject
+    val wdlInputs: JsObject = FileUtils.readFileContent(inputPath).parseJson.asJsObject
     val inputFields = InputFileState(preprocessInputs(wdlInputs))
 
     def handleTask(applet: IR.Applet): Unit = {

--- a/src/main/scala/dx/compiler/Main.scala
+++ b/src/main/scala/dx/compiler/Main.scala
@@ -10,7 +10,7 @@ import dx.core.languages.Language
 import dx.core.getVersion
 import dx.core.util.MainUtils._
 import spray.json._
-import wdlTools.util.{Logger, TraceLevel, Util}
+import wdlTools.util.{FileUtils, Logger, TraceLevel}
 
 object Main {
   private val DEFAULT_RUNTIME_TRACE_LEVEL: Int = TraceLevel.Verbose
@@ -410,7 +410,7 @@ object Main {
     val extras = options.get("extras") match {
       case None => None
       case Some(Vector(p)) =>
-        val contents = Util.readFileContent(Paths.get(p))
+        val contents = FileUtils.readFileContent(Paths.get(p))
         Some(Extras.parse(contents.parseJson, dxApi))
       case _ => throw new Exception("extras specified twice")
     }
@@ -430,7 +430,7 @@ object Main {
     val runtimeTraceLevel =
       getTraceLevel(options.get("runtimeDebugLevel"), DEFAULT_RUNTIME_TRACE_LEVEL)
     if (extras.isDefined) {
-      if (extras.contains("reorg") && (options contains "reorg")) {
+      if (extras.get.customReorgAttributes.isDefined && (options contains "reorg")) {
         throw new InvalidInputException(
             "ERROR: cannot provide --reorg option when reorg is specified in extras."
         )

--- a/src/main/scala/dx/compiler/Main.scala
+++ b/src/main/scala/dx/compiler/Main.scala
@@ -429,16 +429,13 @@ object Main {
     }
     val runtimeTraceLevel =
       getTraceLevel(options.get("runtimeDebugLevel"), DEFAULT_RUNTIME_TRACE_LEVEL)
-    if (extras.isDefined) {
-      if (extras.get.customReorgAttributes.isDefined && (options contains "reorg")) {
-        throw new InvalidInputException(
-            "ERROR: cannot provide --reorg option when reorg is specified in extras."
-        )
-      }
-      if (extras.contains("reorg") && (options contains "locked")) {
-        throw new InvalidInputException(
-            "ERROR: cannot provide --locked option when reorg is specified in extras."
-        )
+    if (extras.isDefined && extras.get.customReorgAttributes.isDefined) {
+      Set("reorg", "locked").foreach { opt =>
+        if (options.contains(opt)) {
+          throw new InvalidInputException(
+              s"ERROR: cannot provide --reorg option when ${opt} is specified in extras."
+          )
+        }
       }
     }
     CompilerOptions(

--- a/src/main/scala/dx/compiler/Native.scala
+++ b/src/main/scala/dx/compiler/Native.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable.TreeMap
 import spray.json._
 import wdlTools.eval.WdlValues
 import wdlTools.types.WdlTypes
-import wdlTools.util.{JsUtils, Logger, TraceLevel, Util}
+import wdlTools.util.{FileUtils, JsUtils, Logger, TraceLevel}
 
 // The end result of the compiler
 object Native {
@@ -56,7 +56,7 @@ case class Native(dxWDLrtId: Option[String],
   private lazy val appCompileDirPath: Path = {
     val p = Files.createTempDirectory("dxWDL_Compile")
     sys.addShutdownHook({
-      Util.deleteRecursive(p)
+      FileUtils.deleteRecursive(p)
     })
     p
   }
@@ -893,7 +893,7 @@ case class Native(dxWDLrtId: Option[String],
         hints
           .flatMap {
             case IR.RuntimeHintRestart(max, default, errors) =>
-              val defaultMap: Option[Map[String, Int]] = default match {
+              val defaultMap: Option[Map[String, Long]] = default match {
                 case Some(i) => Some(Map("*" -> i))
                 case _       => None
               }
@@ -1205,7 +1205,7 @@ case class Native(dxWDLrtId: Option[String],
     if (logger2.traceLevel >= TraceLevel.Verbose) {
       val fName = s"${applet.name}_req.json"
       val trgPath = appCompileDirPath.resolve(fName)
-      Util.writeFileContent(trgPath, JsObject(appletApiRequest).prettyPrint)
+      FileUtils.writeFileContent(trgPath, JsObject(appletApiRequest).prettyPrint)
     }
 
     val buildRequired = isBuildRequired(applet.name, digest)

--- a/src/main/scala/dx/compiler/Top.scala
+++ b/src/main/scala/dx/compiler/Top.scala
@@ -8,7 +8,7 @@ import dx.core.io.{DxFileAccessProtocol, DxFileDescCache, DxPathConfig}
 import dx.core.languages.wdl.{ParseSource, WdlVarLinksConverter}
 import spray.json.JsValue
 import wdlTools.types.{TypedAbstractSyntax => TAT}
-import wdlTools.util.{FileSourceResolver, Util}
+import wdlTools.util.{FileSourceResolver, FileUtils}
 
 import scala.jdk.CollectionConverters._
 
@@ -257,7 +257,7 @@ case class Top(cOpt: CompilerOptions) {
     cOpt.inputs.foreach { path =>
       val dxInputs = inputFile.dxFromInputJson(bundle2, path)
       // write back out as xxxx.dx.json
-      val filename = Util.replaceFileSuffix(path, ".dx.json")
+      val filename = FileUtils.replaceFileSuffix(path, ".dx.json")
       val parent = path.getParent
       val dxInputFile =
         if (parent != null) {
@@ -265,7 +265,7 @@ case class Top(cOpt: CompilerOptions) {
         } else {
           Paths.get(filename)
         }
-      Util.writeFileContent(dxInputFile, dxInputs.prettyPrint)
+      FileUtils.writeFileContent(dxInputFile, dxInputs.prettyPrint)
       logger.trace(s"Wrote dx JSON input file ${dxInputFile}")
     }
     bundle2

--- a/src/main/scala/dx/core/io/DxFileAccessProtocol.scala
+++ b/src/main/scala/dx/core/io/DxFileAccessProtocol.scala
@@ -4,14 +4,14 @@ import java.nio.charset.Charset
 import java.nio.file.Path
 
 import dx.api.{DxApi, DxFile, DxFileDescribe, DxProject}
-import wdlTools.util.{AbstractFileSource, FileAccessProtocol, FileSource, RealFileSource, Util}
+import wdlTools.util.{AbstractFileSource, FileAccessProtocol, FileSource, FileUtils, RealFileSource}
 
 import scala.io.Source
 
 case class DxFileSource(value: String, dxFile: DxFile, dxApi: DxApi, override val encoding: Charset)
     extends AbstractFileSource(encoding)
     with RealFileSource {
-  override lazy val localPath: Path = Util.getPath(dxFile.describe().name)
+  override lazy val localPath: Path = FileUtils.getPath(dxFile.describe().name)
 
   override lazy val size: Long = dxFile.describe().size
 
@@ -97,7 +97,7 @@ object DxFileDescCache {
   */
 case class DxFileAccessProtocol(dxApi: DxApi,
                                 dxFileCache: DxFileDescCache = DxFileDescCache.empty,
-                                encoding: Charset = Util.DefaultEncoding)
+                                encoding: Charset = FileUtils.DefaultEncoding)
     extends FileAccessProtocol {
   val prefixes = Vector(DxFileAccessProtocol.DX_URI_PREFIX)
   private var uriToFileSource: Map[String, DxFileSource] = Map.empty

--- a/src/main/scala/dx/core/io/DxPathConfig.scala
+++ b/src/main/scala/dx/core/io/DxPathConfig.scala
@@ -2,7 +2,7 @@ package dx.core.io
 
 import java.nio.file.Path
 
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{FileUtils, Logger}
 
 // configuration of paths. This is used in several distinct and seemingly disjoint
 // cases:
@@ -59,11 +59,11 @@ case class DxPathConfig(homeDir: Path,
   // create all the directory paths, so we can start using them.
   // This is used when running tasks, but NOT when compiling.
   def createCleanDirs(): Unit = {
-    Util.createDirectories(metaDir)
-    Util.createDirectories(inputFilesDir)
-    Util.createDirectories(outputFilesDir)
-    Util.createDirectories(tmpDir)
-    Util.createDirectories(dxfuseMountpoint)
+    FileUtils.createDirectories(metaDir)
+    FileUtils.createDirectories(inputFilesDir)
+    FileUtils.createDirectories(outputFilesDir)
+    FileUtils.createDirectories(tmpDir)
+    FileUtils.createDirectories(dxfuseMountpoint)
   }
 }
 

--- a/src/main/scala/dx/core/languages/wdl/Evaluator.scala
+++ b/src/main/scala/dx/core/languages/wdl/Evaluator.scala
@@ -1,28 +1,18 @@
 package dx.core.languages.wdl
 
 import dx.core.io.DxPathConfig
-import wdlTools.eval.{Eval, EvalConfig}
+import wdlTools.eval.{Eval, EvalPaths}
 import wdlTools.syntax.WdlVersion
-import wdlTools.types.{TypeCheckingRegime, TypeOptions}
 import wdlTools.util.{FileSourceResolver, Logger}
 
 object Evaluator {
   def make(dxPathConfig: DxPathConfig,
            fileResolver: FileSourceResolver,
            wdlVersion: WdlVersion): Eval = {
-    val evalOpts = TypeOptions(fileResolver = fileResolver,
-                               typeChecking = TypeCheckingRegime.Strict,
-                               antlr4Trace = false,
-                               logger = Logger.Quiet)
-
-    val evalCfg = EvalConfig(
+    val evalCfg = EvalPaths(
         dxPathConfig.homeDir,
-        dxPathConfig.tmpDir,
-        dxPathConfig.stdout,
-        dxPathConfig.stderr,
-        fileResolver
+        dxPathConfig.tmpDir
     )
-
-    Eval(evalOpts, evalCfg, wdlVersion)
+    Eval(evalCfg, Some(wdlVersion), fileResolver, Logger.Quiet)
   }
 }

--- a/src/main/scala/dx/core/languages/wdl/InstanceTypes.scala
+++ b/src/main/scala/dx/core/languages/wdl/InstanceTypes.scala
@@ -24,7 +24,7 @@ object InstanceTypes {
     }
 
     // Examples for memory specification: "4000 MB", "1 GB"
-    val memoryMB: Option[Int] = wdlMemoryMB match {
+    val memoryMB: Option[Long] = wdlMemoryMB match {
       case None                          => None
       case Some(WdlValues.V_String(buf)) =>
         // extract number
@@ -74,7 +74,7 @@ object InstanceTypes {
     }
 
     // Examples: "local-disk 1024 HDD"
-    val diskGB: Option[Int] = wdlDiskGB match {
+    val diskGB: Option[Long] = wdlDiskGB match {
       case None => None
       case Some(WdlValues.V_String(buf)) =>
         val components = buf.split("\\s+")
@@ -95,7 +95,7 @@ object InstanceTypes {
     }
 
     // Examples: "1", "12"
-    val cpu: Option[Int] = wdlCpu match {
+    val cpu: Option[Long] = wdlCpu match {
       case None => None
       case Some(WdlValues.V_String(buf)) =>
         val i: Int =

--- a/src/main/scala/dx/core/languages/wdl/ParseSource.scala
+++ b/src/main/scala/dx/core/languages/wdl/ParseSource.scala
@@ -72,17 +72,6 @@ case class ParseSource(dxApi: DxApi) {
     BInfo(allCallables, sources, adjunctFiles)
   }
 
-  private def makeOptions(importDirs: Vector[Path]): TypeOptions = {
-    val dxProtocol = DxFileAccessProtocol(dxApi)
-    val fileResolver = FileSourceResolver.create(importDirs, Vector(dxProtocol), logger)
-    TypeOptions(
-        fileResolver = fileResolver,
-        logger = logger,
-        followImports = true,
-        typeChecking = WdlTypeCheckingRegime.Strict
-    )
-  }
-
   // recurse into the imported packages
   //
   // Check the uniqueness of tasks, Workflows, and Types
@@ -108,12 +97,18 @@ case class ParseSource(dxApi: DxApi) {
     retval
   }
 
+  private def createFileResolver(importDirs: Vector[Path]): FileSourceResolver = {
+    val dxProtocol = DxFileAccessProtocol(dxApi)
+    FileSourceResolver.create(importDirs, Vector(dxProtocol), logger)
+  }
+
   private def parseWdlFromPath(path: Path, importDirs: Vector[Path]): (TAT.Document, Context) = {
     val srcDir = path.getParent
-    val opts = makeOptions(importDirs :+ srcDir)
-    val parsers = Parsers(opts)
-    val doc = parsers.parseDocument(opts.fileResolver.fromPath(path))
-    TypeInfer(opts).apply(doc)
+    val fileResolver = createFileResolver(importDirs :+ srcDir)
+    val parsers = Parsers(followImports = true, fileResolver = fileResolver, logger = logger)
+    val doc = parsers.parseDocument(fileResolver.fromPath(path))
+    TypeInfer(regime = WdlTypeCheckingRegime.Moderate, fileResolver = fileResolver, logger = logger)
+      .apply(doc)
   }
 
   // Parses the main WDL file and all imports and creates a "bundle" of workflows and tasks.
@@ -155,20 +150,17 @@ case class ParseSource(dxApi: DxApi) {
 
     (tMainDoc.source,
      Language.fromWdlVersion(tMainDoc.version.value),
-     Bundle(primaryCallable, flatInfo.callables, ctxTypes.aliases),
+     Bundle(primaryCallable, flatInfo.callables, ctxTypes.aliases.bindings),
      flatInfo.sources,
      flatInfo.adjunctFiles)
   }
 
-  private def parseWdlFromString(
-      src: String,
-      opts: TypeOptions = makeOptions(Vector.empty)
-  ): (TAT.Document, Context) = {
+  private def parseWdlFromString(src: String): (TAT.Document, Context) = {
     val sourceCode = StringFileSource(src)
     try {
-      val parser = Parsers(opts).getParser(sourceCode)
-      val doc = parser.parseDocument(sourceCode)
-      TypeInfer(opts).apply(doc)
+      val parsers = Parsers(followImports = true, logger = logger)
+      val doc = parsers.parseDocument(sourceCode)
+      TypeInfer(regime = WdlTypeCheckingRegime.Moderate, logger = logger).apply(doc)
     } catch {
       case se: SyntaxException =>
         System.out.println("WDL code is syntactically invalid ----- ")
@@ -224,7 +216,7 @@ case class ParseSource(dxApi: DxApi) {
     val tasks = tDoc.elements.collect {
       case task: TAT.Task => task.name -> task
     }.toMap
-    (tasks, typeCtx.aliases, tDoc)
+    (tasks, typeCtx.aliases.bindings, tDoc)
   }
 
   def parseWdlTask(taskSource: String): (TAT.Task, Map[String, WdlTypes.T], TAT.Document) = {

--- a/src/main/scala/dx/core/languages/wdl/ParseSource.scala
+++ b/src/main/scala/dx/core/languages/wdl/ParseSource.scala
@@ -10,7 +10,6 @@ import wdlTools.types.{
   Context,
   TypeException,
   TypeInfer,
-  TypeOptions,
   WdlTypes,
   TypeCheckingRegime => WdlTypeCheckingRegime,
   TypedAbstractSyntax => TAT

--- a/src/main/scala/dx/core/languages/wdl/PrettyPrintApprox.scala
+++ b/src/main/scala/dx/core/languages/wdl/PrettyPrintApprox.scala
@@ -1,13 +1,13 @@
 package dx.core.languages.wdl
 
-import wdlTools.types.{TypedAbstractSyntax => TAT, Util => TUtil}
+import wdlTools.types.{TypedAbstractSyntax => TAT, Utils => TUtil}
 
 // TODO: I think this is redundant with wdlTools.generators.code.WdlV1Generator
 object PrettyPrintApprox {
   def applyWorkflowElement(node: TAT.WorkflowElement, indent: String): String = {
     node match {
       case TAT.Scatter(varName, expr, body, _) =>
-        val collection = TUtil.exprToString(expr)
+        val collection = TUtil.prettyFormatExpr(expr)
         val innerBlock = body
           .map { node =>
             applyWorkflowElement(node, indent + "  ")
@@ -25,7 +25,7 @@ object PrettyPrintApprox {
               applyWorkflowElement(node, indent + "  ")
             }
             .mkString("\n")
-        s"""|${indent}if (${TUtil.exprToString(expr)}) {
+        s"""|${indent}if (${TUtil.prettyFormatExpr(expr)}) {
             |${innerBlock}
             |${indent}}
             |""".stripMargin
@@ -34,7 +34,7 @@ object PrettyPrintApprox {
         val inputNames = call.inputs
           .map {
             case (key, expr) =>
-              s"${key} = ${TUtil.exprToString(expr)}"
+              s"${key} = ${TUtil.prettyFormatExpr(expr)}"
           }
           .mkString(",")
         val inputs =
@@ -48,22 +48,22 @@ object PrettyPrintApprox {
         }
 
       case TAT.Declaration(_, wdlType, None, _) =>
-        s"${indent} ${TUtil.typeToString(wdlType)}"
+        s"${indent} ${TUtil.prettyFormatType(wdlType)}"
       case TAT.Declaration(_, wdlType, Some(expr), _) =>
-        s"${indent} ${TUtil.typeToString(wdlType)} = ${TUtil.exprToString(expr)}"
+        s"${indent} ${TUtil.prettyFormatType(wdlType)} = ${TUtil.prettyFormatExpr(expr)}"
     }
   }
 
   private def applyInput(iDef: TAT.InputDefinition): String = {
     iDef match {
       case TAT.RequiredInputDefinition(iName, wdlType, _) =>
-        s"${TUtil.typeToString(wdlType)} ${iName}"
+        s"${TUtil.prettyFormatType(wdlType)} ${iName}"
 
       case TAT.OverridableInputDefinitionWithDefault(iName, wdlType, defaultExpr, _) =>
-        s"${TUtil.typeToString(wdlType)} ${iName} = ${TUtil.exprToString(defaultExpr)}"
+        s"${TUtil.prettyFormatType(wdlType)} ${iName} = ${TUtil.prettyFormatExpr(defaultExpr)}"
 
       case TAT.OptionalInputDefinition(iName, wdlType, _) =>
-        s"${TUtil.typeToString(wdlType)} ${iName}"
+        s"${TUtil.prettyFormatType(wdlType)} ${iName}"
     }
   }
 
@@ -75,7 +75,7 @@ object PrettyPrintApprox {
     outputs
       .map {
         case TAT.OutputDefinition(name, wdlType, expr, _) =>
-          s"${TUtil.typeToString(wdlType)} ${name} = ${TUtil.exprToString(expr)}"
+          s"${TUtil.prettyFormatType(wdlType)} ${name} = ${TUtil.prettyFormatExpr(expr)}"
       }
       .mkString("\n")
   }

--- a/src/main/scala/dx/core/languages/wdl/TypeSerialization.scala
+++ b/src/main/scala/dx/core/languages/wdl/TypeSerialization.scala
@@ -1,7 +1,7 @@
 package dx.core.languages.wdl
 
 import wdlTools.types.WdlTypes._
-import wdlTools.types.{Util => TUtil}
+import wdlTools.types.{Utils => TUtil}
 
 // Write a WDL type as a string, and be able to convert back.
 case class TypeSerialization(typeAliases: Map[String, T]) {
@@ -41,7 +41,7 @@ case class TypeSerialization(typeAliases: Map[String, T]) {
 
       // catch-all for other types not currently supported
       case other =>
-        throw new Exception(s"Unsupported WDL type ${TUtil.typeToString(other)}")
+        throw new Exception(s"Unsupported WDL type ${TUtil.prettyFormatType(other)}")
     }
   }
 
@@ -164,7 +164,7 @@ object TypeSerialization {
 
       // catch-all for other types not currently supported
       case other =>
-        throw new Exception(s"Unsupported WDL type ${TUtil.typeToString(other)}")
+        throw new Exception(s"Unsupported WDL type ${TUtil.prettyFormatType(other)}")
     }
   }
 }

--- a/src/main/scala/dx/core/languages/wdl/WdlValueAnalysis.scala
+++ b/src/main/scala/dx/core/languages/wdl/WdlValueAnalysis.scala
@@ -2,7 +2,7 @@ package dx.core.languages.wdl
 
 import dx.api.DxPath
 import wdlTools.eval.{Coercion, WdlValues}
-import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT, Util => TUtil}
+import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT, Utils => TUtil}
 
 object WdlValueAnalysis {
   private class ExprNotConst(message: String) extends RuntimeException(message)
@@ -75,7 +75,7 @@ object WdlValueAnalysis {
         }
       case expr =>
         // anything else require evaluation
-        throw new ExprNotConst(s"${TUtil.exprToString(expr)}")
+        throw new ExprNotConst(s"${TUtil.prettyFormatExpr(expr)}")
     }
   }
 

--- a/src/main/scala/dx/core/languages/wdl/WdlVarLinks.scala
+++ b/src/main/scala/dx/core/languages/wdl/WdlVarLinks.scala
@@ -11,7 +11,7 @@ import dx.api.{DxApi, DxExecution, DxFile, DxUtils, DxWorkflowStage}
 import dx.core.io.{DxFileDescCache, DxFileSource}
 import dx.core.languages.IORef
 import spray.json._
-import wdlTools.eval.{Serialize => WdlSerialize, WdlValues}
+import wdlTools.eval.{WdlValueSerde, WdlValues}
 import wdlTools.types.WdlTypes
 import wdlTools.util.{FileSourceResolver, LocalFileSource}
 
@@ -338,7 +338,7 @@ case class WdlVarLinksConverter(dxApi: DxApi,
       } else {
         bindName
       }
-    (bindEncName, WdlSerialize.toJson(wdlValue))
+    (bindEncName, WdlValueSerde.serialize(wdlValue))
   }
 
   // create input/output fields that bind the variable name [bindName] to

--- a/src/main/scala/dx/exec/JobInputOutput.scala
+++ b/src/main/scala/dx/exec/JobInputOutput.scala
@@ -7,7 +7,7 @@ import dx.api.{DxApi, DxFile}
 import dx.core.io._
 import dx.core.languages.wdl.WdlVarLinksConverter
 import spray.json.{JsNull, JsValue}
-import wdlTools.eval.{Eval, WdlValues, Context => EvalContext}
+import wdlTools.eval.{Eval, WdlValueBindings, WdlValues}
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import wdlTools.util.{FileSource, FileSourceResolver, LocalFileSource, RealFileSource}
 
@@ -22,7 +22,7 @@ case class JobInputOutput(dxPathConfig: DxPathConfig,
   private def evaluateWdlExpression(expr: TAT.Expr,
                                     wdlType: WdlTypes.T,
                                     env: Map[String, WdlValues.V]): WdlValues.V = {
-    evaluator.applyExprAndCoerce(expr, wdlType, EvalContext(env))
+    evaluator.applyExprAndCoerce(expr, wdlType, WdlValueBindings(env))
   }
 
   // Read the job-inputs JSON file, and convert the variables

--- a/src/main/scala/dx/exec/Main.scala
+++ b/src/main/scala/dx/exec/Main.scala
@@ -9,7 +9,7 @@ import dx.core.io.{DxFileAccessProtocol, DxFileDescCache, DxPathConfig}
 import dx.core.languages.wdl.{Evaluator, ParseSource, WdlVarLinksConverter}
 import dx.core.util.MainUtils._
 import dx.core.util.CompressionUtils
-import wdlTools.util.{FileSourceResolver, JsUtils, Logger, TraceLevel, Util}
+import wdlTools.util.{FileSourceResolver, FileUtils, JsUtils, Logger, TraceLevel}
 import spray.json._
 
 object Main {
@@ -40,7 +40,7 @@ object Main {
                          dxApi: DxApi): Termination = {
     // Parse the inputs, convert to WDL values. Delay downloading files
     // from the platform, we may not need to access them.
-    val inputLines: String = Util.readFileContent(jobInputPath)
+    val inputLines: String = FileUtils.readFileContent(jobInputPath)
     val originalInputs: JsValue = inputLines.parseJson
 
     val (task, typeAliases, document) = ParseSource(dxApi).parseWdlTask(taskSourceCode)
@@ -108,7 +108,7 @@ object Main {
         val json = JsObject(outputFields.filter {
           case (_, jsValue) => jsValue != null && jsValue != JsNull
         })
-        Util.writeFileContent(jobOutputPath, json.prettyPrint)
+        FileUtils.writeFileContent(jobOutputPath, json.prettyPrint)
         Success(s"success ${op}")
 
       case ExecAction.TaskRelaunch =>
@@ -116,7 +116,7 @@ object Main {
         val json = JsObject(outputFields.filter {
           case (_, jsValue) => jsValue != null && jsValue != JsNull
         })
-        Util.writeFileContent(jobOutputPath, json.prettyPrint)
+        FileUtils.writeFileContent(jobOutputPath, json.prettyPrint)
         Success(s"success ${op}")
 
       case _ =>
@@ -139,7 +139,7 @@ object Main {
                                  dxApi: DxApi): Termination = {
     // Parse the inputs, convert to WDL values. Delay downloading files
     // from the platform, we may not need to access them.
-    val inputLines: String = Util.readFileContent(jobInputPath)
+    val inputLines: String = FileUtils.readFileContent(jobInputPath)
     val inputsRaw: JsValue = inputLines.parseJson
 
     val (wf, taskDir, typeAliases, document) =
@@ -230,7 +230,7 @@ object Main {
     // write outputs, ignore null values, these could occur for optional
     // values that were not specified.
     val json = JsObject(outputFields)
-    Util.writeFileContent(jobOutputPath, json.prettyPrint)
+    FileUtils.writeFileContent(jobOutputPath, json.prettyPrint)
 
     Success(s"success ${op}")
   }
@@ -260,7 +260,7 @@ object Main {
       dxApi: DxApi,
       jobInfoPath: Path
   ): (String, InstanceTypeDB, JsValue, Option[WdlRuntimeAttrs], Option[Boolean]) = {
-    val jobInfo = Util.readFileContent(jobInfoPath).parseJson
+    val jobInfo = FileUtils.readFileContent(jobInfoPath).parseJson
     val executable: DxExecutable = jobInfo.asJsObject.fields.get("executable") match {
       case None =>
         dxApi.logger.trace(
@@ -322,7 +322,7 @@ object Main {
             "message" -> JsUtils.sanitizedString(e.getMessage)
         )
     ).prettyPrint
-    Util.writeFileContent(jobErrorPath, errMsg)
+    FileUtils.writeFileContent(jobErrorPath, errMsg)
 
     // Write out a full stack trace to standard error.
     System.err.println(exceptionToString(e))
@@ -340,7 +340,7 @@ object Main {
         val streamAllFiles = parseStreamAllFiles(args(3))
         val (jobInputPath, jobOutputPath, jobErrorPath, jobInfoPath) = jobFilesOfHomeDir(homeDir)
         val dxPathConfig = buildRuntimePathConfig(streamAllFiles, logger)
-        val inputs: JsValue = Util.readFileContent(jobInputPath).parseJson
+        val inputs: JsValue = FileUtils.readFileContent(jobInputPath).parseJson
         val allFilesReferenced = inputs.asJsObject.fields.flatMap {
           case (_, jsElem) => dxApi.findFiles(jsElem)
         }.toVector

--- a/src/main/scala/dx/exec/WfFragRunner.scala
+++ b/src/main/scala/dx/exec/WfFragRunner.scala
@@ -44,7 +44,7 @@ import dx.core.io.{DxFileDescCache, DxPathConfig, ExecLinkInfo}
 import dx.core.languages.wdl._
 import dx.core.getVersion
 import spray.json._
-import wdlTools.eval.{Eval, WdlValues, Context => EvalContext}
+import wdlTools.eval.{Eval, WdlValueBindings, WdlValues}
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import wdlTools.util.{FileSourceResolver, TraceLevel}
 
@@ -86,7 +86,7 @@ case class WfFragRunner(wf: TAT.Workflow,
                                     env: Map[String, (WdlTypes.T, WdlValues.V)]): WdlValues.V = {
     // strip the types
     val envStripped = env.map { case (k, (_, v)) => k -> v }
-    evaluator.applyExprAndCoerce(expr, wdlType, EvalContext(envStripped))
+    evaluator.applyExprAndCoerce(expr, wdlType, WdlValueBindings(envStripped))
   }
 
   private def getCallLinkInfo(call: TAT.Call): ExecLinkInfo = {

--- a/src/main/scala/dx/exec/WfOutputs.scala
+++ b/src/main/scala/dx/exec/WfOutputs.scala
@@ -5,7 +5,7 @@ import dx.core.{REORG_STATUS, REORG_STATUS_COMPLETE}
 import dx.core.languages.wdl.{Block, PrettyPrintApprox, WdlVarLinksConverter}
 import dx.core.getVersion
 import spray.json.{JsString, JsValue}
-import wdlTools.eval.{Eval, WdlValues, Context => EvalContext}
+import wdlTools.eval.{Eval, WdlValueBindings, WdlValues}
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 
 case class WfOutputs(wf: TAT.Workflow,
@@ -16,7 +16,7 @@ case class WfOutputs(wf: TAT.Workflow,
   private def evaluateWdlExpression(expr: TAT.Expr,
                                     wdlType: WdlTypes.T,
                                     env: Map[String, WdlValues.V]): WdlValues.V = {
-    evaluator.applyExprAndCoerce(expr, wdlType, EvalContext(env))
+    evaluator.applyExprAndCoerce(expr, wdlType, WdlValueBindings(env))
   }
 
   def apply(envInitial: Map[String, (WdlTypes.T, WdlValues.V)],

--- a/src/test/scala/dx/api/DxPathTest.scala
+++ b/src/test/scala/dx/api/DxPathTest.scala
@@ -3,7 +3,7 @@ package dx.api
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{Logger, SysUtils}
 
 class DxPathTest extends AnyFlatSpec with Matchers {
   val dxApi: DxApi = DxApi(Logger.Quiet)
@@ -22,7 +22,7 @@ class DxPathTest extends AnyFlatSpec with Matchers {
 
   // describe a file on the platform using the dx-toolkit. This is a baseline for comparison
   private def describeDxFilePath(path: String): String = {
-    val (stdout, _) = Util.execCommand(s"dx describe ${path} --json")
+    val (_, stdout, _) = SysUtils.execCommand(s"dx describe ${path} --json")
     val id = stdout.parseJson.asJsObject.fields.get("id") match {
       case Some(JsString(x)) => x.replaceAll("\"", "")
       case other             => throw new Exception(s"Unexpected result ${other}")

--- a/src/test/scala/dx/compiler/ExtrasTest.scala
+++ b/src/test/scala/dx/compiler/ExtrasTest.scala
@@ -8,14 +8,14 @@ import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import wdlTools.eval.WdlValues
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{Logger, SysUtils}
 
 class ExtrasTest extends AnyFlatSpec with Matchers {
   private val dxApi_QUIET = DxApi(Logger.Quiet)
   private val dxApi_LOUD = DxApi(Logger.Verbose)
 
   private def getIdFromName(name: String): String = {
-    val (stdout, _) = Util.execCommand(s"dx describe ${name} --json")
+    val (_, stdout, _) = SysUtils.execCommand(s"dx describe ${name} --json")
     stdout.parseJson.asJsObject match {
       case JsObject(x) => JsObject(x).fields("id").convertTo[String]
     }
@@ -169,7 +169,7 @@ class ExtrasTest extends AnyFlatSpec with Matchers {
     val js = runSpec.parseJson
     val extras = Extras.parse(js, dxApi_LOUD)
 
-    val restartPolicy =
+    val restartPolicy: Map[String, Long] =
       Map("UnresponsiveWorker" -> 2, "JMInternalError" -> 0, "ExecutionError" -> 4)
     extras.defaultTaskDxAttributes should be(
         Some(

--- a/src/test/scala/dx/compiler/GenerateIRTest.scala
+++ b/src/test/scala/dx/compiler/GenerateIRTest.scala
@@ -50,7 +50,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
   private def getParamMeta(task: TAT.Task, iDef: TAT.InputDefinition): Option[TAT.MetaValue] = {
     task.parameterMeta match {
       case None => None
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         kvs.get(iDef.name)
     }
   }
@@ -462,7 +462,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
     )
 
     inside(cgrepTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe sansText
     }
 
@@ -551,7 +551,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
           )
       )
     inside(cgrepTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe sansText
     }
 
@@ -967,7 +967,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
           "s" -> IR.MetaValueString("This is help for s")
       )
     inside(cgrepTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe sansText
     }
 
@@ -989,7 +989,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
     val diffTask = getTaskByName("help_input_params_diff", bundle)
 
     inside(diffTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map(
             "a" -> IR.MetaValueObject(
                 Map(
@@ -1201,7 +1201,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
 
     val cgrepTask = getTaskByName("cgrep", bundle)
     inside(cgrepTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map("in_file" -> IR.MetaValueString("stream"))
     }
 
@@ -1214,7 +1214,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
 
     val diffTask = getTaskByName("diff", bundle)
     inside(diffTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map(
             "a" -> IR.MetaValueString("stream"),
             "b" -> IR.MetaValueString("stream")
@@ -1235,7 +1235,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
 
     val cgrepTask = getTaskByName("cgrep", bundle)
     inside(cgrepTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map(
             "in_file" -> IR.MetaValueObject(
                 Map("stream" -> IR.MetaValueBoolean(true))
@@ -1252,7 +1252,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
 
     val diffTask = getTaskByName("diff", bundle)
     inside(diffTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map(
             "a" -> IR.MetaValueObject(
                 Map("stream" -> IR.MetaValueBoolean(true))
@@ -1276,7 +1276,7 @@ class GenerateIRTest extends AnyFlatSpec with Matchers {
     }
     val diffTask = getTaskByName("diff", bundle)
     inside(diffTask.parameterMeta) {
-      case Some(TAT.ParameterMetaSection(kvs, _)) =>
+      case Some(TAT.MetaSection(kvs, _)) =>
         translateMetaKVs(kvs) shouldBe Map("a" -> IR.MetaValueString("stream"),
                                            "b" -> IR.MetaValueString("stream"))
     }

--- a/src/test/scala/dx/compiler/NativeTest.scala
+++ b/src/test/scala/dx/compiler/NativeTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{Logger, SysUtils}
 
 import scala.io.Source
 
@@ -77,9 +77,9 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val topDir = Paths.get(System.getProperty("user.dir"))
     nativeApplets.foreach { app =>
       try {
-        val (_, _) = Util.execCommand(
+        val _ = SysUtils.execCommand(
             s"dx build $topDir/test/applets/$app --destination ${testProject}:/${unitTestsPath}/applets/",
-            quiet = true
+            logger = Logger.Quiet
         )
       } catch {
         case _: Throwable =>
@@ -914,7 +914,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, _) = Util.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (_, stdout, _) = SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
 
     val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
       case Some(JsObject(x)) =>
@@ -941,7 +941,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, _) = Util.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (_, stdout, _) = SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
 
     val timeout = stdout.parseJson.asJsObject.fields.get("runSpec") match {
       case Some(JsObject(x)) =>
@@ -964,7 +964,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the timeout is what it should be
-    val (stdout, _) = Util.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
+    val (_, stdout, _) = SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${appId} --json")
     val obj = stdout.parseJson.asJsObject
     val obj2 = obj.fields("runSpec").asJsObject
     val obj3 = obj2.fields("systemRequirements").asJsObject
@@ -1029,7 +1029,7 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
     val appletId = getAppletId(s"/${unitTestsPath}/applets/functional_reorg_test")
     // upload random file
-    val (uploadOut, _) = Util.execCommand(
+    val (_, uploadOut, _) = SysUtils.execCommand(
         s"dx upload ${path.toString} --destination /reorg_tests --brief"
     )
     val fileId = uploadOut.trim
@@ -1122,8 +1122,8 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the job reuse flag is set
-    val (stdout, _) =
-      Util.execCommand(s"dx describe ${dxTestProject.getId}:${appletId} --json")
+    val (_, stdout, _) =
+      SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${appletId} --json")
     val ignoreReuseFlag = stdout.parseJson.asJsObject.fields.get("ignoreReuse")
     ignoreReuseFlag shouldBe Some(JsBoolean(true))
   }
@@ -1149,8 +1149,8 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the job reuse flag is set
-    val (stdout, _) =
-      Util.execCommand(s"dx describe ${dxTestProject.getId}:${wfId} --json")
+    val (_, stdout, _) =
+      SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${wfId} --json")
     val ignoreReuseFlag = stdout.parseJson.asJsObject.fields.get("ignoreReuse")
     ignoreReuseFlag shouldBe Some(JsArray(JsString("*")))
   }
@@ -1175,8 +1175,8 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the delayWorkspaceDestruction flag is set
-    val (stdout, _) =
-      Util.execCommand(s"dx describe ${dxTestProject.getId}:${appletId} --json")
+    val (_, stdout, _) =
+      SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${appletId} --json")
     val details = stdout.parseJson.asJsObject.fields("details")
     val delayWD = details.asJsObject.fields.get("delayWorkspaceDestruction")
     delayWD shouldBe Some(JsTrue)
@@ -1202,8 +1202,8 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     }
 
     // make sure the flag is set on the resulting workflow
-    val (stdout, _) =
-      Util.execCommand(s"dx describe ${dxTestProject.getId}:${wfId} --json")
+    val (_, stdout, _) =
+      SysUtils.execCommand(s"dx describe ${dxTestProject.getId}:${wfId} --json")
     val details = stdout.parseJson.asJsObject.fields("details")
     val delayWD = details.asJsObject.fields.get("delayWorkspaceDestruction")
     delayWD shouldBe Some(JsTrue)

--- a/src/test/scala/dx/compiler/SortTypeAliasesTest.scala
+++ b/src/test/scala/dx/compiler/SortTypeAliasesTest.scala
@@ -7,7 +7,7 @@ import dx.core.languages.wdl
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.types.WdlTypes
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{FileUtils, Logger}
 
 class SortTypeAliasesTest extends AnyFlatSpec with Matchers {
   private def pathFromBasename(dir: String, basename: String): Path = {
@@ -20,7 +20,7 @@ class SortTypeAliasesTest extends AnyFlatSpec with Matchers {
 
   it should "sort type aliases properly" in {
     val path = pathFromBasename("struct", "many_structs.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (_, _, typeAliases: Map[String, WdlTypes.T], _) =
       wdl.ParseSource(dxApi).parseWdlWorkflow(wfSourceCode)
 

--- a/src/test/scala/dx/core/languages/wdl/BlockTest.scala
+++ b/src/test/scala/dx/core/languages/wdl/BlockTest.scala
@@ -7,7 +7,7 @@ import dx.core.languages.wdl.{Bundle => WdlBundle}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
-import wdlTools.util.{Logger, Util}
+import wdlTools.util.{FileUtils, Logger}
 
 class BlockTest extends AnyFlatSpec with Matchers {
   private val logger = Logger.Quiet
@@ -27,7 +27,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate closure correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -43,7 +43,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate outputs correctly" in {
     val path = pathFromBasename("util", "block_closure.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -65,7 +65,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate outputs correctly II" in {
     val path = pathFromBasename("compiler", "wf_linear.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -77,7 +77,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "handle block zero" in {
     val path = pathFromBasename("util", "block_zero.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -88,7 +88,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "block with two calls or more" in {
     val path = pathFromBasename("util", "block_with_three_calls.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size should be(1)
@@ -96,7 +96,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "split a block with an expression after a call" in {
     val path = pathFromBasename("util", "expression_after_call.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size should be(2)
@@ -104,7 +104,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate closure correctly for WDL draft-2" in {
     val path = pathFromBasename("draft2", "block_closure.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -116,7 +116,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate closure correctly for WDL draft-2 II" in {
     val path = pathFromBasename("draft2", "shapes.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -126,7 +126,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate closure for a workflow with expression outputs" in {
     val path = pathFromBasename("compiler", "wf_with_output_expressions.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfOutputs = wf.outputs.map(Block.translate)
     Block.outputClosure(wfOutputs).keys.toSet should be(Set("a", "b"))
@@ -134,7 +134,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "calculate output closure for a workflow" in {
     val path = pathFromBasename("compiler", "cast.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfOutputs = wf.outputs.map(Block.translate)
     Block.outputClosure(wfOutputs).keys.toSet should be(
@@ -144,7 +144,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "identify simple calls even if they have optionals" in {
     val path = pathFromBasename("util", "missing_inputs_to_direct_call.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
 
@@ -168,7 +168,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   ignore should "get subblocks" in {
     val path = pathFromBasename("nested", "two_levels.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val b0 = Block.getSubBlock(Vector(0), wf.body)
@@ -252,7 +252,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "sort a block correctly in the presence of conditionals" taggedAs EdgeTest in {
     val path = pathFromBasename("draft2", "conditionals3.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val blocks = Block.splitWorkflow(wf)
@@ -302,7 +302,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "handle an empty workflow" in {
     val path = pathFromBasename("util", "empty_workflow.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val blocks = Block.splitWorkflow(wf)
     blocks.size shouldBe 0
@@ -310,7 +310,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "detect when inputs are used as outputs" in {
     val path = pathFromBasename("util", "inputs_used_as_outputs.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val wfInputs = wf.inputs.map(Block.translate)
     val wfOutputs = wf.outputs.map(Block.translate)
@@ -319,7 +319,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "create correct inputs for a workflow with an unpassed argument" in {
     val path = pathFromBasename("bugs", "unpassed_argument_propagation.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
     val names = wf.inputs.map(_.name).toSet
     names shouldBe Set.empty[String]
@@ -327,7 +327,7 @@ class BlockTest extends AnyFlatSpec with Matchers {
 
   it should "figure out when a block has no calls" taggedAs EdgeTest in {
     val path = pathFromBasename("block", "b1.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = parseWdlSourceFile.parseWdlWorkflow(wfSourceCode)
 
     val b0 = Block.getSubBlock(Vector(0), wf.body)

--- a/src/test/scala/dx/exec/TaskRunnerTest.scala
+++ b/src/test/scala/dx/exec/TaskRunnerTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 import spray.json._
 import wdlTools.eval.WdlValues
 import wdlTools.types.{TypedAbstractSyntax => TAT}
-import wdlTools.util.{FileSourceResolver, Logger, Util}
+import wdlTools.util.{FileSourceResolver, FileUtils, Logger, SysUtils}
 
 // This test module requires being logged in to the platform.
 // It compiles WDL scripts without the runtime library.
@@ -115,7 +115,7 @@ class TaskRunnerTest extends AnyFlatSpec with Matchers {
       try {
         val inputsFile = pathFromBasename(s"${wdlName}_input.json")
         assert(Files.exists(inputsFile))
-        Util.readFileContent(inputsFile).parseJson.asJsObject.fields
+        FileUtils.readFileContent(inputsFile).parseJson.asJsObject.fields
       } catch {
         case _: Throwable =>
           Map.empty
@@ -126,7 +126,7 @@ class TaskRunnerTest extends AnyFlatSpec with Matchers {
       try {
         val outputsFile = pathFromBasename(s"${wdlName}_output.json")
         assert(Files.exists(outputsFile))
-        Some(Util.readFileContent(outputsFile).parseJson.asJsObject.fields)
+        Some(FileUtils.readFileContent(outputsFile).parseJson.asJsObject.fields)
       } catch {
         case _: Throwable =>
           None
@@ -134,8 +134,8 @@ class TaskRunnerTest extends AnyFlatSpec with Matchers {
 
     // Create a clean temp directory for the task to use
     val jobHomeDir: Path = Files.createTempDirectory("dxwdl_applet_test")
-    Util.deleteRecursive(jobHomeDir)
-    Util.createDirectories(jobHomeDir)
+    FileUtils.deleteRecursive(jobHomeDir)
+    FileUtils.createDirectories(jobHomeDir)
     val dxPathConfig = DxPathConfig.apply(jobHomeDir, streamAllFiles = false, logger)
     dxPathConfig.createCleanDirs()
 
@@ -197,7 +197,7 @@ class TaskRunnerTest extends AnyFlatSpec with Matchers {
     // execute the shell script in a child job
     val script: Path = dxPathConfig.script
     if (Files.exists(script)) {
-      val (_, _) = Util.execCommand(script.toString, None)
+      val _ = SysUtils.execCommand(script.toString, None)
     }
 
     // epilog

--- a/src/test/scala/dx/exec/WfFragRunnerTest.scala
+++ b/src/test/scala/dx/exec/WfFragRunnerTest.scala
@@ -10,9 +10,9 @@ import dx.core.languages.wdl.{Block, Evaluator, ParseSource, WdlVarLinksConverte
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
-import wdlTools.eval.{WdlValues, Context => EvalContext}
+import wdlTools.eval.{WdlValueBindings, WdlValues}
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
-import wdlTools.util.{FileSourceResolver, Logger, Util}
+import wdlTools.util.{FileSourceResolver, FileUtils, Logger}
 
 // This test module requires being logged in to the platform.
 // It compiles WDL scripts without the runtime library.
@@ -88,7 +88,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
                             language: Language.Value): WdlValues.V = {
     // build an object capable of evaluating WDL expressions
     val evaluator = Evaluator.make(dxPathConfig, fileResolver, Language.toWdlVersion(language))
-    evaluator.applyExpr(expr, EvalContext(env))
+    evaluator.applyExpr(expr, WdlValueBindings(env))
   }
 
   it should "second block in a linear workflow" in {
@@ -116,7 +116,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate a scatter without a call" in {
     val path = pathFromBasename("frag_runner", "scatter_no_call.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -154,7 +154,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate a conditional without a call" in {
     val path = pathFromBasename("frag_runner", "conditional_no_call.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -176,7 +176,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate a nested conditional/scatter without a call" in {
     val path = pathFromBasename("frag_runner", "nested_no_call.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -196,7 +196,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "create proper names for scatter results" in {
     val path = pathFromBasename("frag_runner", "strings.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (wf, _, _, _) = ParseSource(dxApi).parseWdlWorkflow(wfSourceCode)
 
     val scatters = wf.body.collect {
@@ -210,7 +210,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "Make sure calls cannot be handled by evalExpressions" in {
     val path = pathFromBasename("draft2", "shapes.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -225,7 +225,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate expressions that define variables" in {
     val path = pathFromBasename("draft2", "conditionals3.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -277,7 +277,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate call inputs properly" in {
     val path = pathFromBasename("draft2", "various_calls.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
 
@@ -315,7 +315,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate call constant inputs" in {
     val path = pathFromBasename("nested", "two_levels.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
 
@@ -327,7 +327,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "expressions with structs" in {
     val path = pathFromBasename("frag_runner", "House.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (wf, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -358,7 +358,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "fill in missing optionals" in {
     val path = pathFromBasename("frag_runner", "missing_args.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (_, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -373,7 +373,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "evaluate expressions in correct order" in {
     val path = pathFromBasename("frag_runner", "scatter_variable_not_found.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (_, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)
@@ -385,7 +385,7 @@ class WfFragRunnerTest extends AnyFlatSpec with Matchers {
 
   it should "handle pair field access (left/right)" taggedAs EdgeTest in {
     val path = pathFromBasename("frag_runner", "scatter_with_eval.wdl")
-    val wfSourceCode = Util.readFileContent(path)
+    val wfSourceCode = FileUtils.readFileContent(path)
 
     val (dxPathConfig, fileResolver) = setup()
     val (_, fragRunner) = setupFragRunner(dxPathConfig, fileResolver, wfSourceCode)


### PR DESCRIPTION
Update to latest WDL tools:
* Code reorg (e.g. wdlTools.util.Utils was split into FileUtils and SystemUtils) and some functions renamed (e.g. `exprToString` -> `prettyFormatExpr`)
* WDL `Int`s are now represented as Scala `Long`s
* TypedAbstractSyntax was simplified and some classes removed/unified
* `Eval` API changed, and `Context` was removed in favor of the more generic `Bindings` class