### PR TITLE
Break up large scatters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 1.49 (dev)
 
 * Remove size limit on scatters. Instead, scatters are broken up into chunks, with up to 500 jobs in each chunk. This allows scatters of any size while minimizing load on the API server.
+* Describe executions during call to system/findExecutions, rather than as a separate call, to fix error when describing more than 1000 scatter jobs 
 
 ## 1.48.2 09-Aug-2020
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## 1.49 (dev)
+
+* Remove size limit on scatters. Instead, scatters are broken up into chunks, with up to 500 jobs in each chunk. This allows scatters of any size while minimizing load on the API server.
+
+## 1.48.2 09-Aug-2020
+
+* Upgrade dxfuse to v0.22.3 to retry 502 errors inside jobs.
+* Upgrade dx-download-agent to v0.5.1 to fix retry.
+
+## 1.48.1 09-Jul-2020
+
+* Upgrade of dx-download-agent to v0.4.0 to fix progress reporting errors and symlink downloads.
+
+## 1.48 24-Jun-2020
+
+* Upgrade of dx-download-agent which retries 502 errors in jobs
+* Optimized bulk description of files by replacing system/describeDataObjects with system/findDataObjects API call and scoping file search to projects
+
 ## 1.47.2 05-Jun-2020
 - Upgrade dx-download-agent (includes a fix to the early database close issue) 
 - Fix to describing billTo of a project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,21 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 
 // This prevents the SLF dialog from appearing when starting
 // an SBT session
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.24"
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
+// only load git plugin if we're actually in a git repo
+libraryDependencies ++= {
+  if (baseDirectory.value / "../.git" isDirectory)
+    Seq(
+        Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-git" % "1.0.0",
+                                (sbtBinaryVersion in update).value,
+                                (scalaBinaryVersion in update).value)
+    )
+  else {
+    println("sbt-git plugin not loaded")
+    Seq.empty
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "v1.48.2"
+    version = "v1.49.0"
 }
 
 #

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -10,8 +10,6 @@ import dxWDL.compiler.Tree
 import dxWDL.dx._
 import dxWDL.util._
 
-import scala.tools.nsc.interactive.Pickler.~
-
 object Main extends App {
   sealed trait Termination
   case class SuccessfulTermination(output: String) extends Termination

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -871,7 +871,7 @@ object Main extends App {
         Utils.trace(true, s"""|applet field not found locally, performing
                               |an API call.
                               |""".stripMargin)
-        val dxJob = DxJob(DxUtils.dxEnv.getJob())
+        val dxJob = DxJob(DxUtils.dxEnv.getJob)
         dxJob.describe().applet
       case Some(JsString(x)) =>
         DxApplet(x, None)

--- a/src/main/scala/dxWDL/Main.scala
+++ b/src/main/scala/dxWDL/Main.scala
@@ -10,6 +10,8 @@ import dxWDL.compiler.Tree
 import dxWDL.dx._
 import dxWDL.util._
 
+import scala.tools.nsc.interactive.Pickler.~
+
 object Main extends App {
   sealed trait Termination
   case class SuccessfulTermination(output: String) extends Termination
@@ -413,14 +415,16 @@ object Main extends App {
       case None => Utils.DEFAULT_JOBS_PER_SCATTER
       case Some(x) =>
         val size = x.head.toInt
-        if (size >= 1 && size <= Utils.MAX_JOBS_PER_SCATTER) {
-          size
-        } else {
+        if (size < 1) {
+          Utils.DEFAULT_JOBS_PER_SCATTER
+        } else if (size > Utils.MAX_JOBS_PER_SCATTER) {
           Utils.warning(
               verbose,
               s"The number of jobs per scatter must be between 1-${Utils.MAX_JOBS_PER_SCATTER}"
           )
           Utils.MAX_JOBS_PER_SCATTER
+        } else {
+          size
         }
     }
 

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -38,7 +38,6 @@ object Utils {
   val MAX_STRING_LEN = 32 * 1024 // Long strings cause problems with bash and the UI
   val MAX_STAGE_NAME_LEN = 60 // maximal length of a workflow stage name
   val MAX_NUM_FILES_MOVE_LIMIT = 1000
-  val SCATTER_LIMIT = 500
   val UBUNTU_VERSION = "16.04"
   val VERSION_PROP = "dxWDL_version"
   val REORG_CONFIG = "reorg_conf___"

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -43,6 +43,7 @@ object Utils {
   val REORG_CONFIG = "reorg_conf___"
   val REORG_STATUS = "reorg_status___"
   val REORG_STATUS_COMPLETE = "completed"
+  val CONTINUE_START = "continue_start___"
 
   var traceLevel = 0
 

--- a/src/main/scala/dxWDL/base/Utils.scala
+++ b/src/main/scala/dxWDL/base/Utils.scala
@@ -44,6 +44,9 @@ object Utils {
   val REORG_STATUS = "reorg_status___"
   val REORG_STATUS_COMPLETE = "completed"
   val CONTINUE_START = "continue_start___"
+  val DEFAULT_JOBS_PER_SCATTER = 500
+  val MAX_JOBS_PER_SCATTER = 1000
+  val SCATTER_CHUNK_SIZE = "scatterChunkSize"
 
   var traceLevel = 0
 

--- a/src/main/scala/dxWDL/base/package.scala
+++ b/src/main/scala/dxWDL/base/package.scala
@@ -55,7 +55,8 @@ case class CompilerOptions(archive: Boolean,
                            streamAllFiles: Boolean,
                            execTree: Option[TreePrinter],
                            runtimeDebugLevel: Option[Int],
-                           verbose: Verbose)
+                           verbose: Verbose,
+                           scatterChunkSize: Int = Utils.DEFAULT_JOBS_PER_SCATTER)
 
 // Different ways of using the mini-workflow runner.
 //   Launch:     there are WDL calls, lanuch the dx:executables.

--- a/src/main/scala/dxWDL/base/package.scala
+++ b/src/main/scala/dxWDL/base/package.scala
@@ -61,7 +61,7 @@ case class CompilerOptions(archive: Boolean,
 //   Launch:     there are WDL calls, lanuch the dx:executables.
 //   Collect:    the dx:exucutables are done, collect the results.
 object RunnerWfFragmentMode extends Enumeration {
-  val Launch, Collect = Value
+  val Launch, Continue, Collect = Value
 }
 
 object Language extends Enumeration {

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -484,6 +484,10 @@ case class Native(dxWDLrtId: Option[String],
         |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal wfFragment $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
         |}
         |
+        |continue() {
+        |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal continue $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
+        |}
+        |
         |collect() {
         |    java -jar $${DX_FS_ROOT}/dxWDL.jar internal collect $${HOME} ${rtDebugLvl.toString} ${streamAllFiles.toString}
         |}""".stripMargin.trim

--- a/src/main/scala/dxWDL/compiler/Native.scala
+++ b/src/main/scala/dxWDL/compiler/Native.scala
@@ -43,7 +43,8 @@ case class Native(dxWDLrtId: Option[String],
                   force: Boolean,
                   archive: Boolean,
                   locked: Boolean,
-                  verbose: Verbose) {
+                  verbose: Verbose,
+                  scatterChunkSize: Int = Utils.DEFAULT_JOBS_PER_SCATTER) {
   private val verbose2: Boolean = verbose.containsKey("Native")
   private val rtDebugLvl = runtimeDebugLevel.getOrElse(Utils.DEFAULT_RUNTIME_DEBUG_LEVEL)
   private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, fileInfoDir, typeAliases)
@@ -1065,7 +1066,8 @@ case class Native(dxWDLrtId: Option[String],
                 case (k, t) =>
                   val tStr = WomTypeSerialization(typeAliases).toString(t)
                   k -> JsString(tStr)
-              }.toMap)
+              }),
+              Utils.SCATTER_CHUNK_SIZE -> JsNumber(scatterChunkSize)
           )
 
         case IR.AppletKindWfInputs | IR.AppletKindWfOutputs | IR.AppletKindWfCustomReorgOutputs |

--- a/src/main/scala/dxWDL/compiler/Top.scala
+++ b/src/main/scala/dxWDL/compiler/Top.scala
@@ -109,7 +109,8 @@ case class Top(cOpt: CompilerOptions) {
                cOpt.force,
                cOpt.archive,
                cOpt.locked,
-               cOpt.verbose).apply(bundle)
+               cOpt.verbose,
+               cOpt.scatterChunkSize).apply(bundle)
   }
 
   // check the declarations in [graph], and make sure they

--- a/src/main/scala/dxWDL/dx/DxJob.scala
+++ b/src/main/scala/dxWDL/dx/DxJob.scala
@@ -13,6 +13,7 @@ case class DxJobDescribe(project: String,
                          details: Option[JsValue],
                          applet: DxApplet,
                          parentJob: Option[DxJob],
+                         originJob: Option[DxJob],
                          analysis: Option[DxAnalysis])
     extends DxObjectDescribe
 
@@ -26,6 +27,7 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
                             Field.Modified,
                             Field.Applet,
                             Field.ParentJob,
+                            Field.OriginJob,
                             Field.Analysis)
     val allFields = fields ++ defaultFields
     val request = JsObject(projSpec + ("fields" -> DxObject.requestFields(allFields)))
@@ -51,6 +53,7 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
                         None,
                         DxApplet.getInstance(applet),
                         None,
+                        None,
                         None)
         case _ =>
           throw new Exception(s"Malformed JSON ${descJs}")
@@ -64,13 +67,23 @@ case class DxJob(id: String, project: Option[DxProject] = None) extends DxObject
       case Some(JsString(x)) => Some(DxJob.getInstance(x))
       case Some(other)       => throw new Exception(s"should be a job ${other}")
     }
+    val originJob: Option[DxJob] = descJs.asJsObject.fields.get("originJob") match {
+      case None              => None
+      case Some(JsNull)      => None
+      case Some(JsString(x)) => Some(DxJob.getInstance(x))
+      case Some(other)       => throw new Exception(s"should be a job ${other}")
+    }
     val analysis = descJs.asJsObject.fields.get("analysis") match {
       case None              => None
       case Some(JsNull)      => None
       case Some(JsString(x)) => Some(DxAnalysis.getInstance(x))
       case Some(other)       => throw new Exception(s"should be an analysis ${other}")
     }
-    desc.copy(details = details, properties = props, parentJob = parentJob, analysis = analysis)
+    desc.copy(details = details,
+              properties = props,
+              parentJob = parentJob,
+              originJob = originJob,
+              analysis = analysis)
   }
 }
 

--- a/src/main/scala/dxWDL/dx/DxUtils.scala
+++ b/src/main/scala/dxWDL/dx/DxUtils.scala
@@ -130,7 +130,8 @@ object DxUtils {
                 inputs: JsValue,
                 dependsOn: Vector[DxExecution],
                 delayWorkspaceDestruction: Option[Boolean],
-                verbose: Boolean): DxJob = {
+                verbose: Boolean,
+                name: Option[String] = None): DxJob = {
     val fields = Map(
         "function" -> JsString(entryPoint),
         "input" -> inputs
@@ -153,11 +154,15 @@ object DxUtils {
         }.toVector
         Map("dependsOn" -> JsArray(execIds))
       }
-    val dwd = delayWorkspaceDestruction match {
+    val dwdFields = delayWorkspaceDestruction match {
       case Some(true) => Map("delayWorkspaceDestruction" -> JsTrue)
       case _          => Map.empty
     }
-    val req = JsObject(fields ++ instanceFields ++ dependsFields ++ dwd)
+    val nameFields = name match {
+      case Some(n) => Map("name" -> JsString(n))
+      case None    => Map.empty
+    }
+    val req = JsObject(fields ++ instanceFields ++ dependsFields ++ dwdFields ++ nameFields)
     Utils.appletLog(verbose, s"subjob request=${req.prettyPrint}")
 
     val retval: JsonNode = DXAPI.jobNew(jsonNodeOfJsValue(req), classOf[JsonNode])

--- a/src/main/scala/dxWDL/dx/DxUtils.scala
+++ b/src/main/scala/dxWDL/dx/DxUtils.scala
@@ -131,7 +131,8 @@ object DxUtils {
                 dependsOn: Vector[DxExecution],
                 delayWorkspaceDestruction: Option[Boolean],
                 verbose: Boolean,
-                name: Option[String] = None): DxJob = {
+                name: Option[String] = None,
+                details: Option[JsValue] = None): DxJob = {
     val fields = Map(
         "function" -> JsString(entryPoint),
         "input" -> inputs
@@ -162,7 +163,13 @@ object DxUtils {
       case Some(n) => Map("name" -> JsString(n))
       case None    => Map.empty
     }
-    val req = JsObject(fields ++ instanceFields ++ dependsFields ++ dwdFields ++ nameFields)
+    val detailsField = details match {
+      case Some(d) => Map("details" -> d)
+      case None    => Map.empty
+    }
+    val req = JsObject(
+        fields ++ instanceFields ++ dependsFields ++ dwdFields ++ nameFields ++ detailsField
+    )
     Utils.appletLog(verbose, s"subjob request=${req.prettyPrint}")
 
     val retval: JsonNode = DXAPI.jobNew(jsonNodeOfJsValue(req), classOf[JsonNode])

--- a/src/main/scala/dxWDL/dx/package.scala
+++ b/src/main/scala/dxWDL/dx/package.scala
@@ -115,8 +115,8 @@ case class IOParameter(
 object Field extends Enumeration {
   val Access, Analysis, Applet, ArchivalState, Categories, Created, Description, Details,
       DeveloperNotes, ExecutableName, Folder, Id, IgnoreReuse, Inputs, InputSpec, Modified, Name,
-      Output, Outputs, OutputSpec, ParentJob, Parts, Project, Properties, RunSpec, Size, Stages,
-      Summary, Tags, Title, Types, Version = Value
+      OriginJob, Output, Outputs, OutputSpec, ParentJob, Parts, Project, Properties, RunSpec, Size,
+      Stages, Summary, Tags, Title, Types, Version = Value
 }
 
 trait DxObjectDescribe {
@@ -348,6 +348,7 @@ object DxObject {
       case Field.InputSpec      => "inputSpec"
       case Field.Modified       => "modified"
       case Field.Name           => "name"
+      case Field.OriginJob      => "originJob"
       case Field.Output         => "output"
       case Field.Outputs        => "outputs"
       case Field.OutputSpec     => "outputSpec"

--- a/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
@@ -85,48 +85,64 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
                           instanceTypeDB: InstanceTypeDB,
                           delayWorkspaceDestruction: Option[Boolean],
                           runtimeDebugLevel: Int,
-                          typeAliases: Map[String, WomType]) {
+                          typeAliases: Map[String, WomType],
+                          jobDesc: DxJobDescribe) {
   //private val verbose = runtimeDebugLevel >= 1
   private val maxVerboseLevel = runtimeDebugLevel == 2
   private val verbose = Verbose(runtimeDebugLevel >= 1, quiet = false, Set.empty)
   private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, Map.empty, typeAliases)
-
-  private def siblingJobs: Vector[DxExecution] = {
-    val currentJobId = DxUtils.dxEnv.getJob
-    val parentJob = DxJob(currentJobId).describe().parentJob match {
-      case Some(job) => job
-      case None =>
-        throw new Exception(s"Can't get parent job for $currentJobId")
+  private val ParentsKey = "parents___"
+  private def jsStringArrayToVector(jsv: Option[JsValue]): Vector[String] = {
+    jsv match {
+      case Some(JsArray(array)) =>
+        array.map {
+          case JsString(id) => id
+          case other =>
+            throw new Exception(s"Invalid value ${other} - expected String")
+        }
+      case None => Vector.empty
+      case other =>
+        throw new Exception(s"Invalid value ${other} - expected Array[String]")
     }
-    findChildExecutions(Some(parentJob), currentJobId).map(_.exec)
+  }
+
+  // stick the IDs of all the parent jobs and all the child jobs to exclude
+  // (i.e. the continue/collect jobs) into details - we'll use these in the
+  // collect step
+  private def createSubjobDetails: JsValue = {
+    val parents = jobDesc.details match {
+      case Some(JsObject(fields)) if fields.contains(ParentsKey) =>
+        jsStringArrayToVector(fields.get(ParentsKey))
+      case _ =>
+        Vector.empty
+    }
+    // add the current job to the list of parents
+    val allParents = parents :+ DxUtils.dxEnv.getJob
+    JsObject(Map(ParentsKey -> JsArray(allParents.map(JsString(_)))))
   }
 
   // Launch a subjob to continue a large scatter
   def launchContinue(childJobs: Vector[DxExecution],
                      start: Int,
-                     exportTypes: Map[String, WomType],
-                     isContinuation: Boolean = false): Map[String, WdlVarLinks] = {
+                     exportTypes: Map[String, WomType]): Map[String, WdlVarLinks] = {
     assert(childJobs.nonEmpty)
 
     val inputsWithStart = JsObject(
         inputsRaw.asJsObject.fields + (Utils.CONTINUE_START -> JsNumber(start))
     )
-    val allChildJobs = if (isContinuation) {
-      siblingJobs ++ childJobs
-    } else {
-      childJobs
-    }
-    val name = s"continue($start)"
 
     // Run a sub-job with the "collect" entry point.
     // We need to provide the exact same inputs.
-    val dxSubJob: DxJob = DxUtils.runSubJob("continue",
-                                            Some(instanceTypeDB.defaultInstanceType),
-                                            inputsWithStart,
-                                            allChildJobs,
-                                            delayWorkspaceDestruction,
-                                            maxVerboseLevel,
-                                            Some(name))
+    val dxSubJob: DxJob = DxUtils.runSubJob(
+        "continue",
+        Some(instanceTypeDB.defaultInstanceType),
+        inputsWithStart,
+        childJobs,
+        delayWorkspaceDestruction,
+        maxVerboseLevel,
+        Some(s"continue_scatter($start)"),
+        Some(createSubjobDetails)
+    )
 
     // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
     // is exactly the same as the parent, we can immediately exit the parent job.
@@ -138,25 +154,21 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
 
   // Launch a subjob to collect the outputs
   def launchCollect(childJobs: Vector[DxExecution],
-                    exportTypes: Map[String, WomType],
-                    isContinuation: Boolean = false): Map[String, WdlVarLinks] = {
+                    exportTypes: Map[String, WomType]): Map[String, WdlVarLinks] = {
     assert(childJobs.nonEmpty)
-
-    val allChildJobs = if (isContinuation) {
-      siblingJobs ++ childJobs
-    } else {
-      childJobs
-    }
 
     // Run a sub-job with the "collect" entry point.
     // We need to provide the exact same inputs.
-    val dxSubJob: DxJob = DxUtils.runSubJob("collect",
-                                            Some(instanceTypeDB.defaultInstanceType),
-                                            inputsRaw,
-                                            allChildJobs,
-                                            delayWorkspaceDestruction,
-                                            maxVerboseLevel,
-                                            Some("collect"))
+    val dxSubJob: DxJob = DxUtils.runSubJob(
+        "collect",
+        Some(instanceTypeDB.defaultInstanceType),
+        inputsRaw,
+        childJobs,
+        delayWorkspaceDestruction,
+        maxVerboseLevel,
+        Some("collect_scatter"),
+        Some(createSubjobDetails)
+    )
 
     // Return promises (JBORs) for all the outputs. Since the signature of the sub-job
     // is exactly the same as the parent, we can immediately exit the parent job.
@@ -166,10 +178,10 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
     }
   }
 
-  private def parseOneResult(value: JsValue, excludeId: String): Option[ChildExecDesc] = {
+  private def parseOneResult(value: JsValue, excludeIds: Set[String]): Option[ChildExecDesc] = {
     val fields = value.asJsObject.fields
     val (exec, desc) = fields.get("id") match {
-      case Some(JsString(id)) if id == excludeId =>
+      case Some(JsString(id)) if excludeIds.contains(id) =>
         Utils.trace(verbose.on, s"Ignoring result for job ${id}")
         return None
       case Some(JsString(id)) if id.startsWith("job-") =>
@@ -196,14 +208,14 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
   }
 
   private def submitRequest(
-      parentJob: Option[DxJob],
+      parentJobId: Option[String],
       cursor: JsValue,
-      excludeId: String,
+      excludeIds: Set[String],
       limit: Option[Int]
   ): (Vector[ChildExecDesc], JsValue) = {
-    val parentField: Map[String, JsValue] = parentJob match {
-      case None      => Map.empty
-      case Some(job) => Map("parentJob" -> JsString(job.getId))
+    val parentField: Map[String, JsValue] = parentJobId match {
+      case None        => Map.empty
+      case Some(jobId) => Map("parentJob" -> JsString(jobId))
     }
     val cursorField: Map[String, JsValue] = cursor match {
       case JsNull      => Map.empty
@@ -224,21 +236,21 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
     val responseJs: JsObject = DxUtils.jsValueOfJsonNode(response).asJsObject
     val results: Vector[ChildExecDesc] =
       responseJs.fields.get("results") match {
-        case Some(JsArray(results)) => results.flatMap(res => parseOneResult(res, excludeId))
+        case Some(JsArray(results)) => results.flatMap(res => parseOneResult(res, excludeIds))
         case Some(other)            => throw new Exception(s"malformed results field ${other.prettyPrint}")
         case None                   => throw new Exception(s"missing results field ${response}")
       }
     (results, responseJs.fields("next"))
   }
 
-  private def findChildExecutions(parentJob: Option[DxJob],
-                                  excludeId: String,
+  private def findChildExecutions(parentJobId: Option[String],
+                                  excludeIds: Set[String],
                                   limit: Option[Int] = None): Vector[ChildExecDesc] = {
 
     new UnfoldIterator[Vector[ChildExecDesc], Option[JsValue]](Some(JsNull))({
       case None => None
       case Some(cursor: JsValue) =>
-        submitRequest(parentJob, cursor, excludeId, limit) match {
+        submitRequest(parentJobId, cursor, excludeIds, limit) match {
           case (Vector(), _)     => None
           case (results, JsNull) => Some(results, None)
           case (results, next)   => Some(results, Some(next))
@@ -246,12 +258,27 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
     }).toVector.flatten.sortWith(_.seqNum < _.seqNum)
   }
 
-  def executableFromSeqNum(): Vector[ChildExecDesc] = {
-    // get the parent job
-    val dxJob = DxJob(DxUtils.dxEnv.getJob)
-    val parentJob: DxJob = dxJob.describe().parentJob.get
-    val childExecs: Vector[ChildExecDesc] =
-      findChildExecutions(Some(parentJob), dxJob.id)
+  /**
+    * Gets all the jobs launched by this job's origin job, excluding
+    * any continue and collect sub-jobs.
+    * @return
+    */
+  private def getScatterJobs: Vector[ChildExecDesc] = {
+    val childExecs = jobDesc.details match {
+      case Some(JsObject(fields)) if fields.contains(ParentsKey) =>
+        val parentJobIds = jsStringArrayToVector(fields.get(ParentsKey))
+        val excludeJobIds = parentJobIds.toSet + jobDesc.id
+        parentJobIds.flatMap { parentJobId =>
+          findChildExecutions(Some(parentJobId), excludeJobIds)
+        }
+      case _ =>
+        val parentJob = jobDesc.parentJob match {
+          case Some(job) => job
+          case None =>
+            throw new Exception(s"Can't get parent job for $jobDesc")
+        }
+        findChildExecutions(Some(parentJob.id), Set(jobDesc.id))
+    }
     Utils.trace(verbose.on, s"childExecs=${childExecs}")
     childExecs
   }
@@ -282,12 +309,11 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
   }
 
   // aggregate call results
-  def aggregateResults(call: CallNode,
-                       childJobsComplete: Vector[ChildExecDesc]): Map[String, WdlVarLinks] = {
+  def aggregateResults(call: CallNode): Map[String, WdlVarLinks] = {
     call.callable.outputs.map { cot: OutputDefinition =>
       val fullName = s"${call.identifier.workflowLocalName}.${cot.name}"
       val womType = cot.womType
-      val value: WomValue = collectCallField(cot.name, womType, childJobsComplete)
+      val value: WomValue = collectCallField(cot.name, womType, getScatterJobs)
       val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
       fullName -> wvl
     }.toMap
@@ -296,12 +322,11 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
   // collect results from a sub-workflow generated for the sole purpose of calculating
   // a sub-block.
   def aggregateResultsFromGeneratedSubWorkflow(
-      execLinkInfo: ExecLinkInfo,
-      childJobsComplete: Vector[ChildExecDesc]
+      execLinkInfo: ExecLinkInfo
   ): Map[String, WdlVarLinks] = {
     execLinkInfo.outputs.map {
       case (name, womType) =>
-        val value: WomValue = collectCallField(name, womType, childJobsComplete)
+        val value: WomValue = collectCallField(name, womType, getScatterJobs)
         val wvl = wdlVarLinksConverter.importFromWDL(value.womType, value)
         name -> wvl
     }

--- a/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
@@ -92,6 +92,7 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
   private val verbose = Verbose(runtimeDebugLevel >= 1, quiet = false, Set.empty)
   private val wdlVarLinksConverter = WdlVarLinksConverter(verbose, Map.empty, typeAliases)
   private val ParentsKey = "parents___"
+
   private def jsStringArrayToVector(jsv: Option[JsValue]): Vector[String] = {
     jsv match {
       case Some(JsArray(array)) =>

--- a/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
+++ b/src/main/scala/dxWDL/exec/ScatterSubJobs.scala
@@ -118,7 +118,7 @@ case class CollectSubJobs(jobInputOutput: JobInputOutput,
         Vector.empty
     }
     // add the current job to the list of parents
-    val allParents = parents :+ DxUtils.dxEnv.getJob
+    val allParents = parents :+ jobDesc.id
     JsObject(Map(ParentsKey -> JsArray(allParents.map(JsString(_)))))
   }
 

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -67,7 +67,7 @@ case class WfFragRunner(wf: WorkflowDefinition,
                         runtimeDebugLevel: Int,
                         scatterStart: Int = 0) {
   private val MAX_JOB_NAME = 50
-  private val MAX_JOBS_PER_SCATTER = 1000
+  private val MAX_JOBS_PER_SCATTER = 2
   private val verbose = runtimeDebugLevel >= 1
   //private val maxVerboseLevel = (runtimeDebugLevel == 2)
   private val utlVerbose = Verbose(runtimeDebugLevel >= 1, false, Set.empty)

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -667,7 +667,7 @@ case class WfFragRunner(wf: WorkflowDefinition,
       scp: ScatterGathererPort =>
         scp.identifier.localName.value -> scp.womType
     }.toMap
-    val promises = collectSubJobs.launchContinue(childJobs, next, resultTypes)
+    val promises = collectSubJobs.launchContinue(childJobs, next, resultTypes, scatterStart > 0)
     val promisesStr = promises.mkString("\n")
     Utils.appletLog(verbose, s"resultTypes=${resultTypes}")
     Utils.appletLog(verbose, s"promises=${promisesStr}")
@@ -682,7 +682,7 @@ case class WfFragRunner(wf: WorkflowDefinition,
       scp: ScatterGathererPort =>
         scp.identifier.localName.value -> scp.womType
     }.toMap
-    val promises = collectSubJobs.launchCollect(childJobs, resultTypes)
+    val promises = collectSubJobs.launchCollect(childJobs, resultTypes, scatterStart > 0)
     val promisesStr = promises.mkString("\n")
     Utils.appletLog(verbose, s"resultTypes=${resultTypes}")
     Utils.appletLog(verbose, s"promises=${promisesStr}")
@@ -706,7 +706,7 @@ case class WfFragRunner(wf: WorkflowDefinition,
 
     next match {
       case Some(index) =>
-        // there are remaning chunks - call a continue sub-job
+        // there are remaining chunks - call a continue sub-job
         continueScatter(sctNode, childJobs, index)
       case None =>
         // this is the last chunk - call collect sub-job to gather all the results

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -657,11 +657,11 @@ case class WfFragRunner(wf: WorkflowDefinition,
   //
   // translates to:
   //
-  // scatter(1-1000, previous=None)
+  // scatter(1-1000, jobId=A, parents=[])
   // |_exec job 1..1000
-  // |_exec scatter(1001..2000, previous=JBOR 1..1000) // does not run until jobs 1-1000 are complete
+  // |_exec scatter(1001..2000, jobId=B, parents=[A]) // does not run until jobs 1-1000 are complete
   //        |_exec job 1001..2000
-  //        |_exec collect(JBOR 1..2000)
+  //        |_exec collect(parents=[A,B]) // does not run until jobs 1001-2000 are complete
   private def continueScatter(sctNode: ScatterNode,
                               childJobs: Vector[DxExecution],
                               next: Int): Map[String, WdlVarLinks] = {

--- a/src/main/scala/dxWDL/exec/WfFragRunner.scala
+++ b/src/main/scala/dxWDL/exec/WfFragRunner.scala
@@ -671,7 +671,7 @@ case class WfFragRunner(wf: WorkflowDefinition,
                               env: Map[String, WomValue]): Map[String, WdlVarLinks] = {
     val (svNode, collection) = evalScatterCollection(sctNode, env)
 
-    collection.grouped(MAX_JOBS_PER_SCATTER).foldLeft
+    //collection.grouped(MAX_JOBS_PER_SCATTER).foldLeft
 
     // loop on the collection, call the applet in the inner loop
     val childJobs: Vector[DxExecution] =

--- a/test/wdl_1_0/large_scatter.wdl
+++ b/test/wdl_1_0/large_scatter.wdl
@@ -42,6 +42,7 @@ task sum_ints {
   }
 
   command <<<
+    apt update && apt install -y bc
     echo "~{sep="+" ints}" | bc
   >>>
 

--- a/test/wdl_1_0/large_scatter.wdl
+++ b/test/wdl_1_0/large_scatter.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+workflow large_scatter {
+  input {
+    Int n
+  }
+
+  scatter (i in range(n)) {
+    call echo { input: i = i }
+  }
+
+  output {
+    Array[Int] j = echo.j
+  }
+}
+
+task echo {
+  input {
+    Int i
+  }
+
+  command <<<
+  echo ~{i}
+  >>>
+
+  output {
+    Int j = read_int(stdout())
+  }
+
+  runtime {
+    docker: "ubuntu"
+  }
+}

--- a/test/wdl_1_0/large_scatter.wdl
+++ b/test/wdl_1_0/large_scatter.wdl
@@ -42,7 +42,7 @@ task sum_ints {
   }
 
   command <<<
-    apt update && apt install -y bc
+    (apt update && apt install -y bc) > /dev/null 2> /dev/null
     echo "~{sep="+" ints}" | bc
   >>>
 

--- a/test/wdl_1_0/large_scatter.wdl
+++ b/test/wdl_1_0/large_scatter.wdl
@@ -9,8 +9,12 @@ workflow large_scatter {
     call echo { input: i = i }
   }
 
+  call sum_ints {
+    input: ints = echo.j
+  }
+
   output {
-    Array[Int] j = echo.j
+    Int sum = sum_ints.sum
   }
 }
 
@@ -25,6 +29,24 @@ task echo {
 
   output {
     Int j = read_int(stdout())
+  }
+
+  runtime {
+    docker: "ubuntu"
+  }
+}
+
+task sum_ints {
+  input {
+    Array[Int] ints
+  }
+
+  command <<<
+    echo "~{sep="+" ints}" | bc
+  >>>
+
+  output {
+    Int sum = read_int(stdout())
   }
 
   runtime {


### PR DESCRIPTION
This is a change to the runtime for scatter jobs. Instead of launching all subjobs at once, only a maximum of N subjobs (where N defaults to 500 but is user configurable between 1-1000) are launched at once. When one chunk finishes, the next launches, and so on until all sub-jobs have been executed.