### PR TITLE
Fix name regexp in DxFindDataObjects

### DIFF
--- a/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
+++ b/src/main/scala/dxWDL/dx/DxFindDataObjects.scala
@@ -201,13 +201,13 @@ case class DxFindDataObjects(limit: Option[Int], verbose: Verbose) {
       } else {
         // Make a conjunction of all the legal names. For example:
         // ["Nice", "Foo", "Bar"] ===>
-        //  [(Nice)|(Foo)|(Bar)]
+        //  ^Nice$|^Foo$|^Bar$
         val orAll = nameConstraints
           .map { x =>
-            s"(${x})"
+            s"^${x}$$"
           }
           .mkString("|")
-        Map("name" -> JsObject("regexp" -> JsString(s"[${orAll}]")))
+        Map("name" -> JsObject("regexp" -> JsString(orAll)))
       }
 
     val idField =


### PR DESCRIPTION
In DxFindDataObjects, if a set of object names is specified, the query includes a regular expression search. The regular expression is incorrect. For example, if there are a set of app/workflow names {"foo", "bar", "baz"}, the code in dxWDL builds a regular expression to match any of them:

```[(foo)|(bar)|(baz)]```

which will match any of the characters f, o, b, a, r, z

When searching for objects in a folder with existing objects, the query takes extremely long to run. Most of the time the user thinks the program has hung and gives up (e.g. https://jira.internal.dnanexus.com/browse/APPS-140).

The correct regexp is ```^foo$|^bar$|^baz$```

This needs to be fixed in both 1.x and master.