### PR TITLE
Fix name regexp in DxFindDataObjects

### DIFF
--- a/src/main/scala/dx/api/DxFindDataObjects.scala
+++ b/src/main/scala/dx/api/DxFindDataObjects.scala
@@ -133,17 +133,9 @@ case class DxFindDataObjects(dxApi: DxApi, limit: Option[Int]) {
   private def buildScope(dxProject: DxProject,
                          folder: Option[String],
                          recurse: Boolean): JsValue = {
-    val part1 = Map("project" -> JsString(dxProject.getId))
-    val part2 = folder match {
-      case None       => Map.empty
-      case Some(path) => Map("folder" -> JsString(path))
-    }
-    val part3 =
-      if (recurse)
-        Map("recurse" -> JsBoolean(true))
-      else
-        Map("recurse" -> JsBoolean(false))
-    JsObject(part1 ++ part2 ++ part3)
+    val scopeFields = Map("project" -> JsString(dxProject.getId), "recurse" -> JsBoolean(recurse))
+    val folderFields = folder.map(path => Map("folder" -> JsString(path))).getOrElse(Map.empty)
+    JsObject(scopeFields ++ folderFields)
   }
 
   // Submit a request for a limited number of objects
@@ -158,8 +150,7 @@ case class DxFindDataObjects(dxApi: DxApi, limit: Option[Int]) {
       idConstraints: Vector[String],
       extraFields: Set[Field.Value]
   ): (Map[DxDataObject, DxObjectDescribe], Option[JsValue]) = {
-    var fields = Set(Field.Name, Field.Folder, Field.Size, Field.ArchivalState, Field.Properties)
-    fields ++= extraFields
+    var fields = Set(Field.Name, Field.Folder, Field.Size, Field.ArchivalState, Field.Properties) ++ extraFields
     if (withInputOutputSpec) {
       fields ++= Set(Field.InputSpec, Field.OutputSpec)
     }
@@ -203,13 +194,13 @@ case class DxFindDataObjects(dxApi: DxApi, limit: Option[Int]) {
       } else {
         // Make a conjunction of all the legal names. For example:
         // ["Nice", "Foo", "Bar"] ===>
-        //  [(Nice)|(Foo)|(Bar)]
+        //  ^Nice$|^Foo$|^Bar$
         val orAll = nameConstraints
           .map { x =>
-            s"(${x})"
+            s"^${x}$$"
           }
           .mkString("|")
-        Map("name" -> JsObject("regexp" -> JsString(s"[${orAll}]")))
+        Map("name" -> JsObject("regexp" -> JsString(orAll)))
       }
 
     val idField =
@@ -221,10 +212,9 @@ case class DxFindDataObjects(dxApi: DxApi, limit: Option[Int]) {
         }))
       }
 
-    val repJs = dxApi.findDataObjects(
-        reqFields ++ projField ++ scopeField ++ cursorField ++ limitField ++ classField ++ propertiesField ++
-          namePcreField ++ idField
-    )
+    val request = reqFields ++ projField ++ scopeField ++ cursorField ++ limitField ++ classField ++ propertiesField ++
+      namePcreField ++ idField
+    val repJs = dxApi.findDataObjects(request)
     val next: Option[JsValue] = repJs.fields.get("next") match {
       case None                  => None
       case Some(JsNull)          => None
@@ -255,10 +245,7 @@ case class DxFindDataObjects(dxApi: DxApi, limit: Option[Int]) {
         throw new Exception("class limitation must be one of {record, file, applet, workflow}")
     }
 
-    val scope: Option[JsValue] = dxProject match {
-      case None    => None
-      case Some(p) => Some(buildScope(p, folder, recurse))
-    }
+    val scope: Option[JsValue] = dxProject.map(p => buildScope(p, folder, recurse))
     var allResults = Map.empty[DxDataObject, DxObjectDescribe]
     var cursor: Option[JsValue] = None
     do {

--- a/src/main/scala/dx/compiler/DxObjectDirectory.scala
+++ b/src/main/scala/dx/compiler/DxObjectDirectory.scala
@@ -57,6 +57,7 @@ case class DxObjectDirectory(ns: IR.Bundle,
   // use by a regular dnanexus applet/workflow.
   private def bulkLookup(): Map[String, Vector[DxObjectInfo]] = {
     // find applets
+    dxApi.logger.trace(s"Searching for applets in ${dxProject.getId} folder=${folder}")
     val t0 = System.nanoTime()
     val dxAppletsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(dxApi, None)
@@ -80,6 +81,7 @@ case class DxObjectDirectory(ns: IR.Bundle,
     )
 
     // find workflows
+    dxApi.logger.trace(s"Searching for workflows in ${dxProject.getId} folder=${folder}")
     val t2 = System.nanoTime()
     val dxWorkflowsInFolder: Map[DxDataObject, DxObjectDescribe] =
       DxFindDataObjects(dxApi, None)

--- a/src/test/scala/dx/compiler/NativeTest.scala
+++ b/src/test/scala/dx/compiler/NativeTest.scala
@@ -57,10 +57,11 @@ class NativeTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   private lazy val cFlagsReorg = List("-compileMode",
                                       "NativeWithoutRuntimeAsset",
-                                      "--project",
+                                      "-project",
                                       dxTestProject.getId,
+                                      "-force",
                                       "-quiet",
-                                      "--folder",
+                                      "-folder",
                                       "/reorg_tests")
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
In DxFindDataObjects, if a set of object names is specified, the query includes a regular expression search. The regular expression is incorrect. For example, if there are a set of app/workflow names {"foo", "bar", "baz"}, the code in dxWDL builds a regular expression to match any of them:

```[(foo)|(bar)|(baz)]```

which will match any of the characters f, o, b, a, r, z

When searching for objects in a folder with existing objects, the query takes extremely long to run. Most of the time the user thinks the program has hung and gives up (e.g. https://jira.internal.dnanexus.com/browse/APPS-140).

The correct regexp is ```^foo$|^bar$|^baz$```

This needs to be fixed in both 1.x and master.