### PR TITLE
upgrade to wdlTools 0.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ logLevel in assembly := Level.Info
 assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
-val wdlToolsVersion = "0.5.0"
+val wdlToolsVersion = "0.6.1"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 dxWDL {
-    version = "2.0.0-rc3"
+    version = "2.0.0-rc4"
 }
 
 #

--- a/src/main/scala/dx/core/languages/wdl/Block.scala
+++ b/src/main/scala/dx/core/languages/wdl/Block.scala
@@ -290,7 +290,7 @@ object Block {
             .toVector
             .flatten
 
-        case TAT.ExprPlaceholderEqual(t: TAT.Expr, f: TAT.Expr, value: TAT.Expr, _, _) =>
+        case TAT.ExprPlaceholderCondition(t: TAT.Expr, f: TAT.Expr, value: TAT.Expr, _, _) =>
           inner(t) ++ inner(f) ++ inner(value)
         case TAT.ExprPlaceholderDefault(default: TAT.Expr, value: TAT.Expr, _, _) =>
           inner(default) ++ inner(value)

--- a/src/main/scala/dx/core/languages/wdl/ParseSource.scala
+++ b/src/main/scala/dx/core/languages/wdl/ParseSource.scala
@@ -43,6 +43,11 @@ case class ParseSource(dxApi: DxApi) {
                              |${existing}
                              |""".stripMargin)
             throw new Exception(s"callable ${name} appears twice, with two different definitions")
+          case Some(_) =>
+            logger.trace(
+                s"callable ${name} appears twice, with identical definitions"
+            )
+            accu
           case _ =>
             // The same task/workflow appears twice
             accu

--- a/src/main/scala/dx/core/languages/wdl/ParseSource.scala
+++ b/src/main/scala/dx/core/languages/wdl/ParseSource.scala
@@ -36,10 +36,10 @@ case class ParseSource(dxApi: DxApi) {
           // unequal.
           case Some(existing) if existing != callable =>
             logger.error(s"""|${name} appears with two different callable definitions
-                             |1)
+                             |1) in ${callable.asInstanceOf[TAT.Element].loc.source}
                              |${callable}
                              |
-                             |2)
+                             |2) in ${existing.asInstanceOf[TAT.Element].loc.source}
                              |${existing}
                              |""".stripMargin)
             throw new Exception(s"callable ${name} appears twice, with two different definitions")

--- a/src/test/scala/dx/core/languages/wdl/WdlVarLinksTest.scala
+++ b/src/test/scala/dx/core/languages/wdl/WdlVarLinksTest.scala
@@ -1,5 +1,7 @@
 package dx.core.languages.wdl
 
+import java.nio.file.Paths
+
 import dx.api.DxApi
 import dx.core.io.{DxFileAccessProtocol, DxFileDescCache}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -65,8 +67,10 @@ class WdlVarLinksTest extends AnyFlatSpec with Matchers {
             WdlTypes.T_Array(WdlTypes.T_Boolean, nonEmpty = false),
             WdlValues.V_Array(Vector(WdlValues.V_Boolean(true), WdlValues.V_Boolean(false)))
         ),
-        makeElement(WdlTypes.T_Optional(WdlTypes.T_File),
-                    WdlValues.V_Optional(WdlValues.V_File("ddd"))),
+        makeElement(
+            WdlTypes.T_Optional(WdlTypes.T_File),
+            WdlValues.V_Optional(WdlValues.V_File(Paths.get("ddd").toAbsolutePath.toString))
+        ),
         // maps
         makeElement(
             WdlTypes.T_Map(WdlTypes.T_String, WdlTypes.T_Boolean),


### PR DESCRIPTION
The bug APPS-186 was due to the fact that two apps are compared as strings. If the same app is imported from two different WDL files, the parent FileSources will have different `value`s, but the same `localPath`. In wdlTools 0.6.1 the `toString` method of `LocalFileSource` is changed to use `localPath` rather than `value`, so the two applications now have identical string values again.