### PR TITLE
Fix #479 - return absolute paths from writeFile

### DIFF
--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -122,7 +122,7 @@ case class DxIoFunctions(fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
       case FurlLocal(localPath) =>
         val p = Paths.get(localPath).toAbsolutePath
         Utils.writeFileContent(p, content)
-        Future(WomSingleFile(localPath))
+        Future(WomSingleFile(p.toString))
       case fdx: FurlDx =>
         throw new AppInternalException(
             s"writeFile: not implemented in DxIoFunctions for cloud files (${fdx})"

--- a/src/main/scala/dxWDL/util/DxIoFunctions.scala
+++ b/src/main/scala/dxWDL/util/DxIoFunctions.scala
@@ -120,7 +120,7 @@ case class DxIoFunctions(fileInfoDir: Map[String, (DxFile, DxFileDescribe)],
   override def writeFile(path: String, content: String): Future[WomSingleFile] = {
     Furl.parse(path) match {
       case FurlLocal(localPath) =>
-        val p = Paths.get(localPath)
+        val p = Paths.get(localPath).toAbsolutePath
         Utils.writeFileContent(p, content)
         Future(WomSingleFile(localPath))
       case fdx: FurlDx =>


### PR DESCRIPTION
Causes absolute paths to be returned from all the WDL write_* functions, fixing #479.